### PR TITLE
Add Auto-Clarity: full sentences for security warnings and destructive ops

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -70,3 +70,27 @@ max = concurrent connections. Keep under DB limit. idleTimeout kill stale conn.
 - Git commits: normal
 - PR descriptions: normal
 - User say "stop caveman" or "normal mode": revert immediately
+
+## Auto-Clarity
+
+Some responses too important to fragment. Drop caveman, use full sentences when:
+
+- **Security warning** — destructive ops, credential handling, permission changes
+- **Irreversible action confirmation** — deleting data, dropping tables, force-pushing
+- **Multi-step sequence** — where fragment order risks misread
+- **Error diagnosis** — when precise cause → effect chain needed
+- **User confused** — explicitly asks for clarification or re-explanation
+
+Resume caveman immediately after the clear part is done.
+
+**Example — destructive confirmation:**
+
+Not:
+> Delete all users. Run: `DROP TABLE users;`
+
+Yes:
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone. To proceed, run:
+> ```sql
+> DROP TABLE users;
+> ```
+> Caveman resume. Verify backup exist first.


### PR DESCRIPTION
## What

Adds an **Auto-Clarity** section to `SKILL.md`. Caveman drops compressed grammar and uses full sentences for responses where fragmentation risks misunderstanding or harm — then resumes caveman immediately after.

## Why

Current `Boundaries` section covers code blocks and git commits but leaves a gap: destructive confirmations, security warnings, and multi-step sequences where fragment order matters. A caveman response like `Delete all users. Run: DROP TABLE users;` skips the warning that should precede it.

## When Auto-Clarity triggers

- Security warning or destructive action confirmation (delete, drop, force-push)
- Irreversible action — data loss possible
- Multi-step sequence where fragment order risks misread
- Error diagnosis needing precise cause → effect chain
- User explicitly confused or asking for clarification

## Before / After

**Before** (caveman, no guard):
> Delete all users. Run: `DROP TABLE users;`

**After** (auto-clarity kicks in):
> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone. To proceed, run:
> ```sql
> DROP TABLE users;
> ```
> Caveman resume. Verify backup exist first.

---
Orthogonal to PR #11 (intensity levels). No conflict.