### PR TITLE
Add GitHub Action to auto-sync SKILL.md copies on push to main

### DIFF
--- a/.github/workflows/sync-skill.yml
+++ b/.github/workflows/sync-skill.yml
@@ -1,0 +1,36 @@
+name: Sync SKILL.md
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - skills/caveman/SKILL.md
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Copy to duplicate locations
+        run: |
+          cp skills/caveman/SKILL.md caveman/SKILL.md
+          cp skills/caveman/SKILL.md plugins/caveman/skills/caveman/SKILL.md
+
+      - name: Rebuild caveman.skill ZIP
+        run: |
+          mkdir -p _zip_tmp/caveman
+          cp skills/caveman/SKILL.md _zip_tmp/caveman/SKILL.md
+          cd _zip_tmp && zip -r ../caveman.skill caveman/
+          cd .. && rm -rf _zip_tmp
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet && exit 0
+          git add caveman/SKILL.md plugins/caveman/skills/caveman/SKILL.md caveman.skill
+          git commit -m "chore: sync SKILL.md copies and caveman.skill"
+          git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,13 @@ Improvements to the SKILL.md prompt are welcome — open a PR with before/after 
 ## How
 
 1. Fork repo
-2. Edit `skills/caveman/SKILL.md`
+2. Edit `skills/caveman/SKILL.md` — this is the only copy you need to touch
 3. Open PR with:
    - **Before:** what caveman say now
    - **After:** what caveman say with change
    - One sentence why change better
+
+> **Note:** `caveman/SKILL.md`, `plugins/caveman/skills/caveman/SKILL.md`, and `caveman.skill` are auto-synced by CI after merge. Do not edit them directly.
 
 Small focused change > big rewrite. Caveman like simple.
 


### PR DESCRIPTION
## What

Adds a GitHub Action (`.github/workflows/sync-skill.yml`) that automatically syncs the canonical `skills/caveman/SKILL.md` to all duplicate locations after any push to `main` that touches it.

## Why

`SKILL.md` exists in 4 places:
- `skills/caveman/SKILL.md` ← canonical (per CONTRIBUTING.md)
- `caveman/SKILL.md`
- `plugins/caveman/skills/caveman/SKILL.md`
- `caveman.skill` (ZIP)

Currently contributors must sync manually, which is error-prone and undocumented. This action makes it automatic and invisible.

## How it works

1. Triggers on push to `main` when `skills/caveman/SKILL.md` changes
2. Copies canonical file to both directory duplicates
3. Rebuilds `caveman.skill` ZIP (`caveman/SKILL.md` inside)
4. Auto-commits if any file changed

`CONTRIBUTING.md` updated to say: only edit `skills/caveman/SKILL.md`, CI handles the rest.

## No action needed from contributors

After this merges, contributors edit one file, open a PR, and the sync happens automatically post-merge.