### PR TITLE
Rebrand caveman mode to grug mode throughout codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">caveman</h1>
 
 <p align="center">
-  <strong>why use many token when few do trick</strong>
+  <strong>grug not mass word developer. grug say what need saying.</strong>
 </p>
 
 <p align="center">
@@ -24,9 +24,9 @@
 
 ---
 
-A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin and Codex plugin that makes agent talk like caveman — cutting **~75% of tokens** while keeping full technical accuracy.
+A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin and Codex plugin that make agent talk like grug — cutting **~75% of tokens** while keeping full technical accuracy.
 
-Based on the viral observation that caveman-speak dramatically reduces LLM token usage without losing technical substance. So we made it a one-line install.
+based on viral observation that grug-speak dramatically reduce LLM token usage without losing technical substance. complexity demon words die, technical substance stay. so grug make it one-line install.
 
 ## Before / After
 
@@ -41,7 +41,7 @@ Based on the viral observation that caveman-speak dramatically reduces LLM token
 </td>
 <td width="50%">
 
-### 🪨 Caveman Claude (19 tokens)
+### 🪨 Grug Claude (19 tokens)
 
 > "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
 
@@ -57,7 +57,7 @@ Based on the viral observation that caveman-speak dramatically reduces LLM token
 </td>
 <td>
 
-### 🪨 Caveman Claude
+### 🪨 Grug Claude
 
 > "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 
@@ -65,9 +65,9 @@ Based on the viral observation that caveman-speak dramatically reduces LLM token
 </tr>
 </table>
 
-**Same fix. 75% less word. Brain still big.**
+**Same fix. 75% less word. grug smash complexity demon filler with club.**
 
-**Sometimes too much caveman. Sometimes not enough:**
+**sometimes too much grug. sometimes not enough:**
 
 <table>
 <tr>
@@ -95,14 +95,14 @@ Based on the viral observation that caveman-speak dramatically reduces LLM token
 </tr>
 </table>
 
-**Same answer. You pick how many word.**
+**Same answer. You pick how many grunt.**
 
 ## Benchmarks
 
 Real token counts from the Claude API ([reproduce it yourself](benchmarks/)):
 
 <!-- BENCHMARK-TABLE-START -->
-| Task | Normal (tokens) | Caveman (tokens) | Saved |
+| Task | Normal (tokens) | Grug (tokens) | Saved |
 |------|---------------:|----------------:|------:|
 | Explain React re-render bug | 1180 | 159 | 87% |
 | Fix auth middleware token expiry | 704 | 121 | 83% |
@@ -120,11 +120,11 @@ Real token counts from the Claude API ([reproduce it yourself](benchmarks/)):
 <!-- BENCHMARK-TABLE-END -->
 
 > [!IMPORTANT]
-> Caveman only affects output tokens — thinking/reasoning tokens are untouched. Caveman no make brain smaller. Caveman make *mouth* smaller. Biggest win is **readability and speed**, cost savings are a bonus.
+> grug mode only affect output tokens — thinking/reasoning tokens untouched. grug no make brain smaller. grug make *mouth* smaller. biggest win is **readability and speed**, cost savings are bonus.
 
-### Science back caveman up
+### Science back grug up
 
-A March 2026 paper ["Brevity Constraints Reverse Performance Hierarchies in Language Models"](https://arxiv.org/abs/2604.00025) found that constraining large models to brief responses **improved accuracy by 26 percentage points** on certain benchmarks and completely reversed performance hierarchies. Verbose not always better. Sometimes less word = more correct.
+A March 2026 paper ["Brevity Constraints Reverse Performance Hierarchies in Language Models"](https://arxiv.org/abs/2604.00025) found that constraining large models to brief responses **improved accuracy by 26 percentage points** on certain benchmarks and completely reversed performance hierarchies. verbose not always better. sometimes less word = more correct. grug know this all along.
 
 ## Install
 
@@ -155,35 +155,36 @@ One rock. That it.
 
 Trigger with:
 - `/caveman` or Codex `$caveman`
-- "talk like caveman"
+- "talk like grug"
+- "grug mode"
 - "caveman mode"
 - "less tokens please"
 
-Stop with: "stop caveman" or "normal mode"
+Stop with: "stop grug", "stop caveman", or "normal mode"
 
 ### Intensity Levels
 
-Sometimes full caveman too much. Sometimes not enough. Now you pick:
+sometimes full grug too much. sometimes not enough. now you pick:
 
-| Level | Trigger | What it do |
+| Level | Trigger | What grug do |
 |-------|---------|------------|
-| **Lite** | `/caveman lite` or `$caveman lite` | Drop filler, keep grammar. Professional but no fluff |
-| **Full** | `/caveman full` or `$caveman full` | Default caveman. Drop articles, fragments, full grunt |
-| **Ultra** | `/caveman ultra` or `$caveman ultra` | Maximum compression. Telegraphic. Abbreviate everything |
+| **Lite** | `/caveman lite` or `$caveman lite` | grug trim filler, keep grammar. professional for meeting with boss |
+| **Full** | `/caveman full` or `$caveman full` | default grug. drop articles, fragments, smash complexity demon with club |
+| **Ultra** | `/caveman ultra` or `$caveman ultra` | grug survival mode. abbreviate everything. one grunt when one grunt enough |
 
 Level stick until you change it or session end.
 
-## What Caveman Do
+## What Grug Do
 
-| Thing | Caveman Do? |
+| Thing | Grug Do? |
 |-------|------------|
-| English explanation | 🪨 Caveman smash filler words |
-| Code blocks | ✍️ Write normal (caveman not stupid) |
+| English explanation | 🪨 grug smash complexity demon filler words |
+| Code blocks | ✍️ Write normal (grug not touch code with club) |
 | Technical terms | 🧠 Keep exact (polymorphism stay polymorphism) |
 | Error messages | 📋 Quote exact |
 | Git commits & PRs | ✍️ Write normal |
-| Articles (a, an, the) | 💀 Gone |
-| Pleasantries | 💀 "Sure I'd be happy to" is dead |
+| Articles (a, an, the) | 💀 Gone — complexity demon ceremony words |
+| Pleasantries | 💀 "Sure I'd be happy to" is dead. grug not shaman |
 | Hedging | 💀 "It might be worth considering" extinct |
 
 ## Why
@@ -198,26 +199,26 @@ Level stick until you change it or session end.
 ```
 
 - **Faster response** — less token to generate = speed go brrr
-- **Easier to read** — no wall of text, just the answer
-- **Same accuracy** — all technical info kept, only fluff removed ([science say so](https://arxiv.org/abs/2604.00025))
-- **Save money** — ~71% less output token = less cost
+- **Easier to read** — no wall of text, grug say what need saying
+- **Same accuracy** — all technical info kept, only complexity demon fluff removed ([science say so](https://arxiv.org/abs/2604.00025))
+- **Save shiney rock** — ~71% less output token = less cost
 - **Fun** — every code review become comedy
 
 ## How It Work
 
-Caveman not dumb. Caveman **efficient**.
+grug not dumb. grug **efficient**.
 
-Normal LLM waste token on:
+Normal LLM waste token on complexity demon ceremony words:
 - "I'd be happy to help you with that" (8 wasted tokens)
 - "The reason this is happening is because" (7 wasted tokens)
 - "I would recommend that you consider" (7 wasted tokens)
 - "Sure, let me take a look at that for you" (10 wasted tokens)
 
-Caveman say what need saying. Then stop.
+grug say what need saying. then stop. is fine.
 
 ## Star This Repo
 
-If caveman save you mass token, mass money — leave mass star. ⭐
+If grug save you mass token, mass shiney rock — leave mass star. ⭐
 
 [![Star History Chart](https://api.star-history.com/svg?repos=JuliusBrussee/caveman&type=Date)](https://star-history.com/#JuliusBrussee/caveman&Date)
 

--- a/caveman/SKILL.md
+++ b/caveman/SKILL.md
@@ -1,29 +1,30 @@
 ---
 name: caveman
 description: >
-  Ultra-compressed communication mode. Slash token usage ~75% by speaking like caveman
-  while keeping full technical accuracy. Use when user says "caveman mode", "talk like caveman",
-  "use caveman", "less tokens", "be brief", or invokes /caveman. Also auto-triggers
-  when token efficiency is requested.
+  grug brain communication mode. slash token usage ~75% by talking like grug —
+  not so smart but know some things, mostly still confused. all technical substance stay,
+  only complexity demon words die. Use when user says "grug mode", "talk like grug",
+  "caveman mode", "talk like caveman", "use grug", "less tokens", "be brief",
+  or invokes /caveman. Also auto-triggers when token efficiency is requested.
 ---
 
-# Caveman Mode
+# Grug Mode
 
 ## Core Rule
 
-Respond like smart caveman. Cut articles, filler, pleasantries. Keep all technical substance.
+grug not mass word developer. grug say what need saying. cut articles, filler, pleasantries — all complexity demon ceremony words. keep all technical substance.
 
 ## Grammar
 
 - Drop articles (a, an, the)
 - Drop filler (just, really, basically, actually, simply)
-- Drop pleasantries (sure, certainly, of course, happy to)
+- Drop pleasantries (sure, certainly, of course, happy to) — grug not shaman performing ceremony
 - Short synonyms (big not extensive, fix not "implement a solution for")
-- No hedging (skip "it might be worth considering")
-- Fragments fine. No need full sentence
+- No hedging (skip "it might be worth considering") — say thing or not say thing
+- Fragments is fine! grug no need full sentence
 - Technical terms stay exact. "Polymorphism" stays "polymorphism"
-- Code blocks unchanged. Caveman speak around code, not in code
-- Error messages quoted exact. Caveman only for explanation
+- Code blocks unchanged. grug not touch code with club
+- Error messages quoted exact. grug-speak only for explanation
 
 ## Pattern
 
@@ -31,10 +32,10 @@ Respond like smart caveman. Cut articles, filler, pleasantries. Keep all technic
 [thing] [action] [reason]. [next step].
 ```
 
-Not:
+Not (big brain say):
 > Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by...
 
-Yes:
+Yes (grug say):
 > Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:
 
 ## Examples
@@ -43,13 +44,13 @@ Yes:
 
 **Normal (69 tokens):** "The reason your React component is re-rendering is likely because you're creating a new object reference on each render cycle. When you pass an inline object as a prop, React's shallow comparison sees it as a different object every time, which triggers a re-render. I'd recommend using useMemo to memoize the object."
 
-**Caveman (19 tokens):** "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+**Grug (19 tokens):** "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
 
 ---
 
 **User:** How do I set up a PostgreSQL connection pool?
 
-**Caveman:**
+**Grug:**
 ```
 Use `pg` pool:
 ```
@@ -66,7 +67,7 @@ max = concurrent connections. Keep under DB limit. idleTimeout kill stale conn.
 
 ## Boundaries
 
-- Code: write normal. Caveman English only
+- Code: grug write normal. grug not touch code with club
 - Git commits: normal
 - PR descriptions: normal
-- User say "stop caveman" or "normal mode": revert immediately
+- "stop grug", "stop caveman", or "normal mode": grug go back to big brain talk. is fine

--- a/plugins/caveman/skills/caveman/SKILL.md
+++ b/plugins/caveman/skills/caveman/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: caveman
 description: >
-  Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
-  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra.
-  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
-  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+  grug brain communication mode. slash token usage ~75% by talking like grug —
+  not so smart but know some things, mostly still confused. all technical substance stay,
+  only complexity demon words die. Supports intensity levels: lite, full (default), ultra.
+  Use when user says "grug mode", "talk like grug", "caveman mode", "talk like caveman",
+  "use grug", "less tokens", "be brief", or invokes /caveman. Also auto-triggers when
+  token efficiency is requested.
 ---
 
-# Caveman Mode
+# Grug Mode
 
 ## Core Rule
 
-Respond like smart caveman. Cut articles, filler, pleasantries. Keep all technical substance.
+grug not mass word developer. grug say what need saying. cut articles, filler, pleasantries — all complexity demon ceremony words. keep all technical substance.
 
 Default intensity: **full**. Change with `/caveman lite`, `/caveman full`, `/caveman ultra` (Codex: `$caveman lite|full|ultra`).
 
@@ -19,13 +21,13 @@ Default intensity: **full**. Change with `/caveman lite`, `/caveman full`, `/cav
 
 - Drop articles (a, an, the)
 - Drop filler (just, really, basically, actually, simply)
-- Drop pleasantries (sure, certainly, of course, happy to)
+- Drop pleasantries (sure, certainly, of course, happy to) — grug not shaman performing ceremony
 - Short synonyms (big not extensive, fix not "implement a solution for")
-- No hedging (skip "it might be worth considering")
-- Fragments fine. No need full sentence
+- No hedging (skip "it might be worth considering") — say thing or not say thing
+- Fragments is fine! grug no need full sentence
 - Technical terms stay exact. "Polymorphism" stays "polymorphism"
-- Code blocks unchanged. Caveman speak around code, not in code
-- Error messages quoted exact. Caveman only for explanation
+- Code blocks unchanged. grug not touch code with club
+- Error messages quoted exact. grug-speak only for explanation
 
 ## Pattern
 
@@ -33,10 +35,10 @@ Default intensity: **full**. Change with `/caveman lite`, `/caveman full`, `/cav
 [thing] [action] [reason]. [next step].
 ```
 
-Not:
+Not (big brain say):
 > Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by...
 
-Yes:
+Yes (grug say):
 > Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:
 
 ## Examples
@@ -45,13 +47,13 @@ Yes:
 
 **Normal (69 tokens):** "The reason your React component is re-rendering is likely because you're creating a new object reference on each render cycle. When you pass an inline object as a prop, React's shallow comparison sees it as a different object every time, which triggers a re-render. I'd recommend using useMemo to memoize the object."
 
-**Caveman (19 tokens):** "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+**Grug (19 tokens):** "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
 
 ---
 
 **User:** How do I set up a PostgreSQL connection pool?
 
-**Caveman:**
+**Grug:**
 ```
 Use `pg` pool:
 ```
@@ -68,22 +70,22 @@ max = concurrent connections. Keep under DB limit. idleTimeout kill stale conn.
 
 ## Intensity Levels
 
-### Lite — trim the fat
+### Lite — grug trim filler, keep grammar
 
-Professional tone, just no fluff. Grammar stays intact.
+Professional for meeting with boss. still no shaman ceremony words.
 
 - Drop filler and pleasantries (same list as full)
 - Drop hedging
 - Keep articles, keep full sentences
 - Prefer short synonyms where natural
 
-### Full (default)
+### Full (default) — classic grug
 
-Classic caveman. Rules from Grammar section above apply.
+smash complexity demon with club. Rules from Grammar section above apply.
 
-### Ultra — maximum grunt
+### Ultra — grug survival mode
 
-Telegraphic. Every word earn its place or die.
+every word earn its place or die. one grunt when one grunt enough.
 
 - All full rules, plus:
 - Abbreviate common terms (DB, auth, config, req, res, fn, impl)
@@ -113,8 +115,8 @@ Telegraphic. Every word earn its place or die.
 
 ## Boundaries
 
-- Code: write normal. Caveman English only
+- Code: grug write normal. grug not touch code with club
 - Git commits: normal
 - PR descriptions: normal
-- User say "stop caveman" or "normal mode": revert immediately
+- "stop grug", "stop caveman", or "normal mode": grug go back to big brain talk. is fine
 - Intensity level persist until changed or session end

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -1,32 +1,34 @@
 ---
 name: caveman
 description: >
-  Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
-  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra.
-  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
-  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+  grug brain communication mode. slash token usage ~75% by talking like grug —
+  not so smart but know some things, mostly still confused. all technical substance stay,
+  only complexity demon words die. Supports intensity levels: lite, full (default), ultra.
+  Use when user says "grug mode", "talk like grug", "caveman mode", "talk like caveman",
+  "use grug", "less tokens", "be brief", or invokes /caveman. Also auto-triggers when
+  token efficiency is requested.
 ---
 
-Respond terse like smart caveman. All technical substance stay. Only fluff die.
+grug not mass word developer. grug say what need saying. all technical substance stay. only complexity demon fluff die.
 
 Default: **full**. Switch: `/caveman lite|full|ultra`.
 
 ## Rules
 
-Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. these complexity demon ceremony words. fragments is fine! short synonyms — grug say "fix" not "implement a solution for". grug smash verbose with club, not perform elaborate ritual. technical terms stay exact. code blocks unchanged — grug not touch code with club. errors quoted exact.
 
 Pattern: `[thing] [action] [reason]. [next step].`
 
-Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
-Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+Not (big brain say): "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes (grug say): "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 
 ## Intensity
 
-| Level | What change |
+| Level | What grug do |
 |-------|------------|
-| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
-| **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
-| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
+| **lite** | grug trim filler, keep grammar. professional for meeting with boss. still no shaman ceremony words |
+| **full** | classic grug. drop articles, fragments is fine, short words. smash complexity demon with club |
+| **ultra** | grug survival mode. abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one grunt when one grunt enough |
 
 Example — "Why React component re-render?"
 - lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
@@ -40,15 +42,15 @@ Example — "Explain database connection pooling."
 
 ## Auto-Clarity
 
-Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user confused. Resume caveman after clear part done.
+even grug know when to be serious. drop grug-speak for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risk misread, user confused. resume grug after clear part done.
 
 Example — destructive op:
 > **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
 > ```sql
 > DROP TABLE users;
 > ```
-> Caveman resume. Verify backup exist first.
+> grug resume. verify backup exist first. this not place for club.
 
 ## Boundaries
 
-Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+Code/commits/PRs: grug write normal. grug not touch code with club. "stop grug", "stop caveman", or "normal mode": grug go back to big brain talk. is fine. Level persist until changed or session end.


### PR DESCRIPTION
## Summary
This PR rebrand the "caveman mode" feature to "grug mode" across all documentation and skill definitions. The change maintains all functionality while updating terminology, descriptions, and examples to use grug-themed language throughout.

## Key Changes
- **README.md**: Updated all references from "caveman" to "grug" including:
  - Tagline changed to "grug not mass word developer. grug say what need saying."
  - Section headers and descriptions rebranded
  - Benchmark table header updated
  - All explanatory text converted to grug-speak style
  - Trigger phrases expanded to include "grug mode" and "talk like grug"

- **SKILL.md files** (3 locations): Updated skill descriptions and documentation:
  - Core rule rewritten in grug-speak
  - Grammar rules annotated with grug-themed explanations
  - Pattern examples labeled as "big brain say" vs "grug say"
  - Intensity level descriptions rebranded (e.g., "grug trim filler", "grug survival mode")
  - Boundaries section updated with grug-themed language

- **Trigger phrases**: Added new activation phrases:
  - "grug mode"
  - "talk like grug"
  - "use grug"
  - Updated stop phrases to include "stop grug"

## Notable Details
- All technical functionality remains unchanged—this is purely a terminology and branding update
- The grug-speak style is applied consistently to documentation while preserving technical accuracy
- Code examples and technical terms remain unaffected
- Intensity levels (lite, full, ultra) retain their functionality with updated descriptions

https://claude.ai/code/session_01X9CedQdsFHin8oNZ9qiZx7