### PR TITLE
fix(compress): resolve runtime path and add retry failure behavior

### DIFF
--- a/caveman-compress/SKILL.md
+++ b/caveman-compress/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: compress
+name: caveman-compress
 description: >
   Compress natural language memory files (CLAUDE.md, todos, preferences) into caveman format
   to save input tokens. Preserves all technical substance, code, URLs, and structure.
@@ -19,11 +19,11 @@ Compress natural language files (CLAUDE.md, todos, preferences) into caveman-spe
 
 ## Process
 
-1. This SKILL.md lives alongside `scripts/` in the same directory. Find that directory.
+1. The compression scripts live in `caveman-compress/scripts/` (adjacent to this SKILL.md). If the path is not immediately available, search for `caveman-compress/scripts/__main__.py`.
 
 2. Run:
 
-cd <directory_containing_this_SKILL.md> && python3 -m scripts <absolute_filepath>
+cd caveman-compress && python3 -m scripts <absolute_filepath>
 
 3. The CLI will:
 - detect file type (no tokens)
@@ -31,6 +31,7 @@ cd <directory_containing_this_SKILL.md> && python3 -m scripts <absolute_filepath
 - validate output (no tokens)
 - if errors: cherry-pick fix with Claude (targeted fixes only, no recompression)
 - retry up to 2 times
+- if still failing after 2 retries: report error to user, leave original file untouched
 
 4. Return result to user
 


### PR DESCRIPTION
## Summary

- Replace unresolvable `<directory_containing_this_SKILL.md>` placeholder with concrete `caveman-compress/` path and a glob fallback
- Define behavior after 2 failed retries: report error, leave original file untouched
- Align `name: compress` → `name: caveman-compress` to match trigger `/caveman:compress` and directory name

## Why

The path placeholder in step 1 is not resolvable at runtime — the model has no mechanism to derive the skill's install directory from "Find that directory." The missing failure path leaves the user in an undefined state after retries exhaust.

Spotted while running the skills through [nlpm](https://github.com/xiaolai/nlpm-for-claude).

## Test plan

- [ ] Invoke `/caveman:compress` on a test markdown file
- [ ] Confirm `scripts/` directory is found without manual intervention
- [ ] Force a compression failure and verify original file is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)