### PR TITLE
fix(caveman): replace "user confused" with observable triggers

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -49,7 +49,7 @@ Example — "Explain database connection pooling."
 
 ## Auto-Clarity
 
-Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user confused. Resume caveman after clear part done.
+Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.
 
 Example — destructive op:
 > **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.


### PR DESCRIPTION
## Summary

Auto-Clarity section: "user confused" → "user asks to clarify or repeats question"

## Why

"Confused" is an internal mental state the model can't observe directly. Observable triggers — clarification requests, repeated questions — produce more consistent behavior across sessions.

## Test plan

- [ ] Activate caveman mode, ask an ambiguous question, then say "wait, what?" — verify caveman drops to clear mode
- [ ] Verify caveman stays active when user does not signal confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)