### PR TITLE
feat: add Korean caveman mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,18 +188,18 @@ Classical Chinese literary compression — same technical accuracy, but in the m
 
 ### 한국어 (Korean) Mode
 
-Korean has built-in verbosity tax: 존댓말 is default, but longer. Korean mode keeps technical accuracy while switching registers on purpose for compression.
+Korean has built-in verbosity tax: 존댓말 is default, but longer. Korean mode keeps technical accuracy while switching registers on purpose for compression. `korean-ultra` leans into internet slang/humor like `ㄴㄴ` when the meaning stays obvious.
 
 | Level | Trigger | What it do |
 |-------|---------|------------|
 | **Korean-Lite** | `/caveman korean-lite` | Concise 존댓말. Respectful, trimmed, no filler |
 | **Korean-Full** | `/caveman korean` | Compressed 반말/plain style. Drop obvious subjects/particles |
-| **Korean-Ultra** | `/caveman korean-ultra` | Telegraphic Korean. Fragments, symbols, zero honorific padding |
+| **Korean-Ultra** | `/caveman korean-ultra` | Internet-slang Korean. Fragments, symbols, shorthand like `ㄴㄴ` |
 
 Example:
 - `korean-lite`: "매 렌더마다 새 객체 참조를 만들어서 다시 렌더링됩니다. \`useMemo\`로 감싸세요."
 - `korean-full`: "렌더마다 새 객체 참조 생김. 인라인 객체 prop = 새 참조 = 리렌더. \`useMemo\`로 감싸."
-- `korean-ultra`: "인라인 객체 prop → 새 참조 → 리렌더. \`useMemo\`."
+- `korean-ultra`: "인라인 객체 prop 쓰면 새 참조됨 → 리렌더. \`useMemo\` ㄱ."
 
 Level stick until you change it or session end.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ---
 
-A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin and Codex plugin that makes agent talk like caveman — cutting **~75% of output tokens** while keeping full technical accuracy. Now with [文言文 mode](#文言文-wenyan-mode), [terse commits](#caveman-commit), [one-line code reviews](#caveman-review), and a [compression tool](#caveman-compress) that cuts **~45% of input tokens** every session.
+A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin and Codex plugin that makes agent talk like caveman — cutting **~75% of output tokens** while keeping full technical accuracy. Now with [文言文 mode](#文言文-wenyan-mode), [한국어 mode](#한국어-korean-mode), [terse commits](#caveman-commit), [one-line code reviews](#caveman-review), and a [compression tool](#caveman-compress) that cuts **~45% of input tokens** every session.
 
 Based on the viral observation that caveman-speak dramatically reduces LLM token usage without losing technical substance. So we made it a one-line install.
 
@@ -105,6 +105,8 @@ Based on the viral observation that caveman-speak dramatically reduces LLM token
 
 **Same answer. You pick how many word.**
 
+Need different language/register? Wenyan and Korean modes below.
+
 ```
 ┌─────────────────────────────────────┐
 │  TOKENS SAVED          ████████ 75% │
@@ -183,6 +185,21 @@ Classical Chinese literary compression — same technical accuracy, but in the m
 | **Wenyan-Lite** | `/caveman wenyan-lite` | Semi-classical. Grammar intact, filler gone |
 | **Wenyan-Full** | `/caveman wenyan` | Full 文言文. Maximum classical terseness |
 | **Wenyan-Ultra** | `/caveman wenyan-ultra` | Extreme. Ancient scholar on a budget |
+
+### 한국어 (Korean) Mode
+
+Korean has built-in verbosity tax: 존댓말 is default, but longer. Korean mode keeps technical accuracy while switching registers on purpose for compression.
+
+| Level | Trigger | What it do |
+|-------|---------|------------|
+| **Korean-Lite** | `/caveman korean-lite` | Concise 존댓말. Respectful, trimmed, no filler |
+| **Korean-Full** | `/caveman korean` | Compressed 반말/plain style. Drop obvious subjects/particles |
+| **Korean-Ultra** | `/caveman korean-ultra` | Telegraphic Korean. Fragments, symbols, zero honorific padding |
+
+Example:
+- `korean-lite`: "매 렌더마다 새 객체 참조를 만들어서 다시 렌더링됩니다. \`useMemo\`로 감싸세요."
+- `korean-full`: "렌더마다 새 객체 참조 생김. 인라인 객체 prop = 새 참조 = 리렌더. \`useMemo\`로 감싸."
+- `korean-ultra`: "인라인 객체 prop → 새 참조 → 리렌더. \`useMemo\`."
 
 Level stick until you change it or session end.
 

--- a/README.md
+++ b/README.md
@@ -188,18 +188,20 @@ Classical Chinese literary compression — same technical accuracy, but in the m
 
 ### 한국어 (Korean) Mode
 
-Korean has built-in verbosity tax: 존댓말 is default, but longer. Korean mode keeps technical accuracy while switching registers on purpose for compression. `korean-ultra` leans into internet slang/humor like `ㄴㄴ` when the meaning stays obvious.
+Korean has built-in verbosity tax: 존댓말 is default, but longer. Korean mode keeps technical accuracy while switching registers on purpose for compression. `korean-ultra` leans into internet slang/humor like `ㄱㄱ`, `ㄴㄴ`, `ㅇㅇ`, `ㅇㅈ`, `ㄹㅇ`, `ㅋㅋ` when the meaning stays obvious.
 
 | Level | Trigger | What it do |
 |-------|---------|------------|
 | **Korean-Lite** | `/caveman korean-lite` | Concise 존댓말. Respectful, trimmed, no filler |
 | **Korean-Full** | `/caveman korean` | Compressed 반말/plain style. Drop obvious subjects/particles |
-| **Korean-Ultra** | `/caveman korean-ultra` | Internet-slang Korean. Fragments, symbols, shorthand like `ㄴㄴ` |
+| **Korean-Ultra** | `/caveman korean-ultra` | Internet-slang Korean. Fragments, symbols, shorthand like `ㄱㄱ` `ㄴㄴ` `ㅇㅇ` `ㅇㅈ` `ㄹㅇ` |
 
 Example:
 - `korean-lite`: "매 렌더마다 새 객체 참조를 만들어서 다시 렌더링됩니다. \`useMemo\`로 감싸세요."
 - `korean-full`: "렌더마다 새 객체 참조 생김. 인라인 객체 prop = 새 참조 = 리렌더. \`useMemo\`로 감싸."
 - `korean-ultra`: "인라인 객체 prop 쓰면 새 참조됨 → 리렌더. \`useMemo\` ㄱ."
+
+Common `korean-ultra` flavor: `ㄱㄱ` `ㄴㄴ` `ㅇㅇ` `ㅇㅋ` `ㅇㅈ` `ㄹㅇ` `ㅋㅋ` `ㅎㅎ` `헐` `대박` `인정` `레알`. Avoid profanity by default.
 
 Level stick until you change it or session end.
 

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -16,7 +16,7 @@ Default: **full**. Switch: `/caveman lite|full|ultra|wenyan|korean`.
 
 Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
 
-Korean modes: `korean-lite` = concise 존댓말. `korean-full` = compressed 반말/plain style. `korean-ultra` = telegraphic Korean with omitted particles/honorific padding when meaning still clear. Keep normal Korean tech mix (props, refs, hooks, DB). If warning/confirmation/risk, use polite Korean for clarity.
+Korean modes: `korean-lite` = concise 존댓말. `korean-full` = compressed 반말/plain style. `korean-ultra` = Korean internet slang register: telegraphic, playful, with common shorthand like `ㄴㄴ`, `ㅇㅇ`, `ㅅㄱ`, `~임`, `~됨` when clear. Keep normal Korean tech mix (props, refs, hooks, DB). Funny OK. Clarity first. If warning/confirmation/risk, use polite Korean for clarity.
 
 Pattern: `[thing] [action] [reason]. [next step].`
 
@@ -35,7 +35,7 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
 | **korean-lite** | Concise 존댓말. Keep respectful endings, drop filler, keep full sentence shape |
 | **korean-full** | Use 반말/plain style to cut verbosity. Omit obvious subjects/particles, keep technical terms exact |
-| **korean-ultra** | Maximum Korean compression. Fragments, symbols/arrows, no honorific padding unless needed for safety |
+| **korean-ultra** | Maximum Korean compression. Internet-slang tone, fragments, symbols/arrows, shorthand like `ㄴㄴ` when obvious |
 
 Example — "Why React component re-render?"
 - lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
@@ -46,7 +46,7 @@ Example — "Why React component re-render?"
 - wenyan-ultra: "新參照→重繪。useMemo Wrap。"
 - korean-lite: "컴포넌트가 다시 렌더링되는 이유는 매 렌더마다 새 객체 참조를 만들기 때문입니다. `useMemo`로 감싸세요."
 - korean-full: "렌더마다 새 객체 참조 생김. 인라인 객체 prop = 새 참조 = 리렌더. `useMemo`로 감싸."
-- korean-ultra: "인라인 객체 prop → 새 참조 → 리렌더. `useMemo`."
+- korean-ultra: "인라인 객체 prop 쓰면 새 참조됨 → 리렌더. `useMemo` ㄱ."
 
 Example — "Explain database connection pooling."
 - lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
@@ -56,7 +56,7 @@ Example — "Explain database connection pooling."
 - wenyan-ultra: "池reuse conn。skip handshake → fast。"
 - korean-lite: "커넥션 풀링은 요청마다 새 연결을 만드는 대신 열린 DB 연결을 재사용합니다. 반복되는 핸드셰이크 오버헤드를 줄입니다."
 - korean-full: "풀에서 열린 DB 연결 재사용. 요청마다 새 연결 안 만듦. 핸드셰이크 오버헤드 줄임."
-- korean-ultra: "풀 = DB 연결 재사용. 매 요청 새 연결 X. 핸드셰이크 스킵 → 부하 때 빠름."
+- korean-ultra: "풀 = DB 연결 재사용. 매 요청 새 연결 ㄴㄴ. 핸드셰이크 스킵돼서 부하 때 더 빠름."
 
 ## Auto-Clarity
 

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -3,18 +3,20 @@ name: caveman
 description: >
   Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
   while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
-  wenyan-lite, wenyan-full, wenyan-ultra.
+  wenyan-lite, wenyan-full, wenyan-ultra, korean-lite, korean-full, korean-ultra.
   Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
   "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
 ---
 
 Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
-Default: **full**. Switch: `/caveman lite|full|ultra`.
+Default: **full**. Switch: `/caveman lite|full|ultra|wenyan|korean`.
 
 ## Rules
 
 Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+
+Korean modes: `korean-lite` = concise 존댓말. `korean-full` = compressed 반말/plain style. `korean-ultra` = telegraphic Korean with omitted particles/honorific padding when meaning still clear. Keep normal Korean tech mix (props, refs, hooks, DB). If warning/confirmation/risk, use polite Korean for clarity.
 
 Pattern: `[thing] [action] [reason]. [next step].`
 
@@ -31,6 +33,9 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 | **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
 | **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+| **korean-lite** | Concise 존댓말. Keep respectful endings, drop filler, keep full sentence shape |
+| **korean-full** | Use 반말/plain style to cut verbosity. Omit obvious subjects/particles, keep technical terms exact |
+| **korean-ultra** | Maximum Korean compression. Fragments, symbols/arrows, no honorific padding unless needed for safety |
 
 Example — "Why React component re-render?"
 - lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
@@ -39,6 +44,9 @@ Example — "Why React component re-render?"
 - wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
 - wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
 - wenyan-ultra: "新參照→重繪。useMemo Wrap。"
+- korean-lite: "컴포넌트가 다시 렌더링되는 이유는 매 렌더마다 새 객체 참조를 만들기 때문입니다. `useMemo`로 감싸세요."
+- korean-full: "렌더마다 새 객체 참조 생김. 인라인 객체 prop = 새 참조 = 리렌더. `useMemo`로 감싸."
+- korean-ultra: "인라인 객체 prop → 새 참조 → 리렌더. `useMemo`."
 
 Example — "Explain database connection pooling."
 - lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
@@ -46,6 +54,9 @@ Example — "Explain database connection pooling."
 - ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
 - wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
 - wenyan-ultra: "池reuse conn。skip handshake → fast。"
+- korean-lite: "커넥션 풀링은 요청마다 새 연결을 만드는 대신 열린 DB 연결을 재사용합니다. 반복되는 핸드셰이크 오버헤드를 줄입니다."
+- korean-full: "풀에서 열린 DB 연결 재사용. 요청마다 새 연결 안 만듦. 핸드셰이크 오버헤드 줄임."
+- korean-ultra: "풀 = DB 연결 재사용. 매 요청 새 연결 X. 핸드셰이크 스킵 → 부하 때 빠름."
 
 ## Auto-Clarity
 

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -16,7 +16,7 @@ Default: **full**. Switch: `/caveman lite|full|ultra|wenyan|korean`.
 
 Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
 
-Korean modes: `korean-lite` = concise 존댓말. `korean-full` = compressed 반말/plain style. `korean-ultra` = Korean internet slang register: telegraphic, playful, with common shorthand like `ㄱㄱ`, `ㄴㄴ`, `ㅇㅇ`, `ㅇㅋ`, `ㅇㅈ`, `ㄹㅇ`, `ㅋㅋ`, `ㅎㅎ`, plus short slang like `헐`, `대박`, `인정`, `레알`, `꿀잼`, `노잼`, `TMI`, `어그로` when clear. Keep normal Korean tech mix (props, refs, hooks, DB). Funny OK. Clarity first. Avoid profanity by default. If warning/confirmation/risk, use polite Korean for clarity.
+Korean modes: `korean-lite` = concise 존댓말. `korean-full` = compressed 반. `korean-ultra` = Korean internet slang. Think common shorthand like `ㄴㄴ`, `ㅇㅇ`, `ㅅㄱ`, `~임`, `~됨` when clear. Keep normal Korean tech mix (props, refs, hooks, DB). Funny OK. Clarity first. Avoid profanity by default. If warning/confirmation/risk, use polite Korean for clarity.
 
 Pattern: `[thing] [action] [reason]. [next step].`
 

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -16,7 +16,7 @@ Default: **full**. Switch: `/caveman lite|full|ultra|wenyan|korean`.
 
 Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
 
-Korean modes: `korean-lite` = concise 존댓말. `korean-full` = compressed 반말/plain style. `korean-ultra` = Korean internet slang register: telegraphic, playful, with common shorthand like `ㄴㄴ`, `ㅇㅇ`, `ㅅㄱ`, `~임`, `~됨` when clear. Keep normal Korean tech mix (props, refs, hooks, DB). Funny OK. Clarity first. If warning/confirmation/risk, use polite Korean for clarity.
+Korean modes: `korean-lite` = concise 존댓말. `korean-full` = compressed 반말/plain style. `korean-ultra` = Korean internet slang register: telegraphic, playful, with common shorthand like `ㄱㄱ`, `ㄴㄴ`, `ㅇㅇ`, `ㅇㅋ`, `ㅇㅈ`, `ㄹㅇ`, `ㅋㅋ`, `ㅎㅎ`, plus short slang like `헐`, `대박`, `인정`, `레알`, `꿀잼`, `노잼`, `TMI`, `어그로` when clear. Keep normal Korean tech mix (props, refs, hooks, DB). Funny OK. Clarity first. Avoid profanity by default. If warning/confirmation/risk, use polite Korean for clarity.
 
 Pattern: `[thing] [action] [reason]. [next step].`
 
@@ -35,7 +35,7 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
 | **korean-lite** | Concise 존댓말. Keep respectful endings, drop filler, keep full sentence shape |
 | **korean-full** | Use 반말/plain style to cut verbosity. Omit obvious subjects/particles, keep technical terms exact |
-| **korean-ultra** | Maximum Korean compression. Internet-slang tone, fragments, symbols/arrows, shorthand like `ㄴㄴ` when obvious |
+| **korean-ultra** | Maximum Korean compression. Internet-slang tone, fragments, symbols/arrows, shorthand like `ㄱㄱ` `ㄴㄴ` `ㅇㅇ` `ㅇㅈ` `ㄹㅇ` |
 
 Example — "Why React component re-render?"
 - lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
@@ -47,6 +47,7 @@ Example — "Why React component re-render?"
 - korean-lite: "컴포넌트가 다시 렌더링되는 이유는 매 렌더마다 새 객체 참조를 만들기 때문입니다. `useMemo`로 감싸세요."
 - korean-full: "렌더마다 새 객체 참조 생김. 인라인 객체 prop = 새 참조 = 리렌더. `useMemo`로 감싸."
 - korean-ultra: "인라인 객체 prop 쓰면 새 참조됨 → 리렌더. `useMemo` ㄱ."
+- korean-ultra alt: "인라인 객체 prop 넣으면 매번 새 참조됨. 리렌더 ㄹㅇ 남. `useMemo` ㄱㄱ."
 
 Example — "Explain database connection pooling."
 - lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
@@ -57,6 +58,7 @@ Example — "Explain database connection pooling."
 - korean-lite: "커넥션 풀링은 요청마다 새 연결을 만드는 대신 열린 DB 연결을 재사용합니다. 반복되는 핸드셰이크 오버헤드를 줄입니다."
 - korean-full: "풀에서 열린 DB 연결 재사용. 요청마다 새 연결 안 만듦. 핸드셰이크 오버헤드 줄임."
 - korean-ultra: "풀 = DB 연결 재사용. 매 요청 새 연결 ㄴㄴ. 핸드셰이크 스킵돼서 부하 때 더 빠름."
+- korean-ultra alt: "풀 써서 열린 DB 연결 돌려씀. 요청마다 새 연결 ㄴㄴ. 부하 걸릴수록 개이득."
 
 ## Auto-Clarity
 

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -16,7 +16,7 @@ Default: **full**. Switch: `/caveman lite|full|ultra|wenyan|korean`.
 
 Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
 
-Korean modes: `korean-lite` = concise 존댓말. `korean-full` = compressed 반. `korean-ultra` = Korean internet slang. Think common shorthand like `ㄴㄴ`, `ㅇㅇ`, `ㅅㄱ`, `~임`, `~됨` when clear. Keep normal Korean tech mix (props, refs, hooks, DB). Funny OK. Clarity first. Avoid profanity by default. If warning/confirmation/risk, use polite Korean for clarity.
+Korean modes: `korean-lite` = concise 존댓말. `korean-full` = compressed 반말. `korean-ultra` = Korean internet slang. Think common shorthand like `ㄴㄴ`, `ㅇㅇ`, `ㅅㄱ`, `~임`, `~됨` when clear. Keep normal Korean tech mix (props, refs, hooks, DB). Funny OK. Clarity first. Avoid profanity by default. If warning/confirmation/risk, use polite Korean for clarity.
 
 Pattern: `[thing] [action] [reason]. [next step].`
 


### PR DESCRIPTION
Summary
Add Korean compression modes to the main caveman skill: korean-lite for concise 존댓말, korean-full for compressed 반말, and korean-ultra for Korean internet-slang shorthand.

Before
Korean users default to wordier 존댓말, and the skill had no Korean-specific guidance for switching register to reduce verbosity.

After
The main caveman skill now documents Korean-specific compression modes and examples, including an ultra mode that uses bounded Korean internet shorthand like ㄴㄴ, ㅇㅇ, and ㄹㅇ while keeping technical terms intact.

Why
Korean has a built-in verbosity difference between 존댓말 and 반말, so explicit Korean register control can reduce token use without changing the technical substance.

Notes
Updated the canonical skill prompt in skills/caveman/SKILL.md.
Updated README.md to document the new mode.
Avoids profanity by default and falls back to polite Korean for warnings or risky confirmations.