### PR TITLE
fix(docs): use ANSI-C quoting for bash statusline badge example

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -28,10 +28,10 @@ caveman_flag="$HOME/.claude/.caveman-active"
 if [ -f "$caveman_flag" ]; then
   caveman_mode=$(cat "$caveman_flag" 2>/dev/null)
   if [ "$caveman_mode" = "full" ] || [ -z "$caveman_mode" ]; then
-    caveman_text="\033[38;5;172m[CAVEMAN]\033[0m"
+    caveman_text=$'\033[38;5;172m[CAVEMAN]\033[0m'
   else
     caveman_suffix=$(echo "$caveman_mode" | tr '[:lower:]' '[:upper:]')
-    caveman_text="\033[38;5;172m[CAVEMAN:${caveman_suffix}]\033[0m"
+    caveman_text=$'\033[38;5;172m[CAVEMAN:'"${caveman_suffix}"$']\033[0m'
   fi
 fi
 ```


### PR DESCRIPTION
Small docs fix — the bash statusline snippet in \`hooks/README.md\` has a real bug.

## Problem

The current snippet uses double-quoted escape sequences:

\`\`\`bash
caveman_text=\"\033[38;5;172m[CAVEMAN]\033[0m\"
\`\`\`

Bash does **not** interpret backslash escapes inside double quotes. Users who copy-paste this get the literal 19-character string \`\033[38;5;172m[CAVEMAN]\033[0m\` in their statusline instead of a colored badge.

You can verify with \`printf\`:

\`\`\`bash
$ caveman_text=\"\033[38;5;172m[CAVEMAN]\033[0m\"
$ printf '%s\n' \"\$caveman_text\" | cat -v
\033[38;5;172m[CAVEMAN]\033[0m
\`\`\`

No ESC character — just literal text.

## Fix

Switch to ANSI-C quoted strings (\`\$'...'\`), which bash does interpret:

\`\`\`bash
caveman_text=\$'\033[38;5;172m[CAVEMAN]\033[0m'
\`\`\`

For the mode-variant line that needs to interpolate \`\${caveman_suffix}\`, adjacent string concatenation preserves both the ANSI-C literal portions and the double-quoted expansion:

\`\`\`bash
caveman_text=\$'\033[38;5;172m[CAVEMAN:'\"\${caveman_suffix}\"\$']\033[0m'
\`\`\`

Verified with \`bash -c ... | cat -v\`:

\`\`\`
^[[38;5;172m[CAVEMAN]^[[0m
^[[38;5;172m[CAVEMAN:ULTRA]^[[0m
\`\`\`

\`^[\` is the visible representation of ESC (0x1B). Both variants now produce real escape sequences, and the badge renders with color in a terminal.

## Scope

- 2 lines changed in \`hooks/README.md\`
- No other files touched
- No behavior change — purely a docs fix so copy-paste works

This is one of a small batch of docs and install.sh quality-of-life PRs I'm sending today. Each one is independent and can be merged in any order. Close any that don't fit your vision — no pressure. 🪨