### PR TITLE
feat(install): check for node availability and back up settings.json

### DIFF
--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -5,6 +5,14 @@
 #   or:  bash <(curl -s https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks/install.sh)
 set -e
 
+# Require node — we use it to merge the hook config into settings.json
+if ! command -v node >/dev/null 2>&1; then
+  echo "ERROR: 'node' is required to install the caveman hooks (used to merge"
+  echo "       the hook config into ~/.claude/settings.json safely)."
+  echo "       Install Node.js from https://nodejs.org and re-run this script."
+  exit 1
+fi
+
 CLAUDE_DIR="$HOME/.claude"
 HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS="$CLAUDE_DIR/settings.json"
@@ -34,6 +42,11 @@ done
 if [ ! -f "$SETTINGS" ]; then
   echo '{}' > "$SETTINGS"
 fi
+
+# Back up existing settings.json before touching it. If the node merge below
+# fails mid-write (disk full, interrupted, etc.), the user can recover from
+# "$SETTINGS.bak" instead of losing their config.
+cp "$SETTINGS" "$SETTINGS.bak"
 
 node -e "
   const fs = require('fs');


### PR DESCRIPTION
Two small safety improvements to `hooks/install.sh`. Both purely additive — no behavior change on the happy path, only on failure modes.

## 1. Fail fast if node is missing

The script uses `node -e` to merge the hook config into `~/.claude/settings.json`, but doesn't check that node is on PATH first. Claude Code itself ships node, but users running `install.sh` via curl pipe on a fresh machine (before installing Claude Code) hit a cryptic error from inside the heredoc.

Adds a `command -v node` check at the top with a helpful message:

```bash
if ! command -v node >/dev/null 2>&1; then
  echo "ERROR: 'node' is required to install the caveman hooks (used to merge"
  echo "       the hook config into ~/.claude/settings.json safely)."
  echo "       Install Node.js from https://nodejs.org and re-run this script."
  exit 1
fi
```

## 2. Back up `settings.json` before the node merge

The script now copies `$SETTINGS` to `$SETTINGS.bak` before running the node rewrite. If the merge fails mid-write (disk full, interrupted script, node crash, power loss), the user can recover their config from the backup instead of losing it.

```bash
cp "$SETTINGS" "$SETTINGS.bak"
```

This matters more now that the script wires up **two** hook entries (SessionStart + UserPromptSubmit) in a single `node -e` write. More state at risk per transaction.

## Scope

- 1 file changed: `hooks/install.sh`
- +13 lines, -0 lines
- Syntax-checked with `bash -n`
- No new dependencies, no new flags, no new behavior on the happy path

Second PR in a small batch today. Independent of the others — can be merged in any order. Close if it doesn't fit your vision. 🪨