### PR TITLE
feat(hooks): add uninstall.sh companion to install.sh

### DIFF
--- a/hooks/uninstall.sh
+++ b/hooks/uninstall.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# caveman — uninstaller for the SessionStart + UserPromptSubmit hooks
+# Removes: hook files in ~/.claude/hooks, settings.json entries, and the flag file
+# Usage: bash hooks/uninstall.sh
+#   or:  bash <(curl -s https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks/uninstall.sh)
+set -e
+
+CLAUDE_DIR="$HOME/.claude"
+HOOKS_DIR="$CLAUDE_DIR/hooks"
+SETTINGS="$CLAUDE_DIR/settings.json"
+FLAG_FILE="$CLAUDE_DIR/.caveman-active"
+
+HOOK_FILES=("caveman-activate.js" "caveman-mode-tracker.js")
+
+echo "Uninstalling caveman hooks..."
+
+# 1. Remove hook files
+for hook in "${HOOK_FILES[@]}"; do
+  if [ -f "$HOOKS_DIR/$hook" ]; then
+    rm "$HOOKS_DIR/$hook"
+    echo "  Removed: $HOOKS_DIR/$hook"
+  fi
+done
+
+# 2. Remove caveman entries from settings.json (idempotent)
+if [ -f "$SETTINGS" ]; then
+  # Require node for the same reason install.sh does — safe JSON editing
+  if ! command -v node >/dev/null 2>&1; then
+    echo "WARNING: 'node' not found — cannot safely edit settings.json."
+    echo "         Remove the caveman SessionStart and UserPromptSubmit"
+    echo "         entries from $SETTINGS manually."
+  else
+    # Back up before editing, same policy as install.sh
+    cp "$SETTINGS" "$SETTINGS.bak"
+
+    node -e "
+      const fs = require('fs');
+      const settings = JSON.parse(fs.readFileSync('$SETTINGS', 'utf8'));
+
+      const isCavemanEntry = (entry) =>
+        entry && entry.hooks && entry.hooks.some(h =>
+          h.command && h.command.includes('caveman')
+        );
+
+      let removed = 0;
+      if (settings.hooks) {
+        for (const event of ['SessionStart', 'UserPromptSubmit']) {
+          if (Array.isArray(settings.hooks[event])) {
+            const before = settings.hooks[event].length;
+            settings.hooks[event] = settings.hooks[event].filter(e => !isCavemanEntry(e));
+            removed += before - settings.hooks[event].length;
+            // Drop the event key if it's now empty (keeps settings.json tidy)
+            if (settings.hooks[event].length === 0) {
+              delete settings.hooks[event];
+            }
+          }
+        }
+        // Drop settings.hooks if it's now empty
+        if (Object.keys(settings.hooks).length === 0) {
+          delete settings.hooks;
+        }
+      }
+
+      fs.writeFileSync('$SETTINGS', JSON.stringify(settings, null, 2) + '\n');
+      console.log('  Removed ' + removed + ' caveman hook entries from settings.json');
+    "
+  fi
+fi
+
+# 3. Remove flag file
+if [ -f "$FLAG_FILE" ]; then
+  rm "$FLAG_FILE"
+  echo "  Removed: $FLAG_FILE"
+fi
+
+echo ""
+echo "Done! Restart Claude Code to complete the uninstall."
+echo ""
+echo "Note: If you installed caveman as a plugin, disabling the plugin is"
+echo "      the recommended way to deactivate hooks — this script is only"
+echo "      needed if you installed manually via install.sh."


### PR DESCRIPTION
Symmetric uninstaller for users who installed the hooks via `hooks/install.sh` (not via the plugin system). Currently `hooks/README.md` documents uninstall as three manual steps — this script automates them.

## What it does

1. Removes `caveman-activate.js` and `caveman-mode-tracker.js` from `~/.claude/hooks` if present (idempotent — skips missing files)
2. Uses node to filter out the caveman `SessionStart` and `UserPromptSubmit` entries from `~/.claude/settings.json`. Preserves all non-caveman hook entries. Drops event keys that become empty (e.g. if `UserPromptSubmit` only had the caveman tracker, the `UserPromptSubmit` key is removed entirely to keep settings.json tidy)
3. Removes the `~/.claude/.caveman-active` flag file
4. Backs up settings.json to `settings.json.bak` before editing, same policy as the install.sh safety PR
5. Gracefully degrades if node is missing — prints a warning with the settings.json path and tells the user to edit manually
6. Prints a reminder that plugin users should disable the plugin instead of running this script

## Verified

Node JSON-filter logic tested in isolation against a settings.json containing:

```json
{
  "hooks": {
    "SessionStart": [
      { "hooks": [ {"command": "node /path/caveman-activate.js"} ] },
      { "hooks": [ {"command": "node /path/unrelated-hook.js"} ] }
    ],
    "UserPromptSubmit": [
      { "hooks": [ {"command": "node /path/caveman-mode-tracker.js"} ] }
    ],
    "PostToolUse": [
      { "hooks": [ {"command": "node /path/some-other-hook.js"} ] }
    ]
  },
  "someOtherField": "preserve me"
}
```

Result after running the filter:
- 2 caveman entries removed (as expected)
- `unrelated-hook` preserved in `SessionStart`
- `UserPromptSubmit` key dropped (was only caveman-mode-tracker)
- `PostToolUse` entirely preserved
- `someOtherField` preserved

## Scope

- 1 new file: `hooks/uninstall.sh` (81 lines, +x)
- No existing files touched
- Syntax-checked with `bash -n`
- Depends only on `bash`, `node`, `cp`, `rm` — same set as `install.sh`

Third PR in the batch. Independent of the others — merge in any order. 🪨