### PR TITLE
fix: correct max_tokens typo from 8096 to 8192

### DIFF
--- a/caveman-compress/scripts/compress.py
+++ b/caveman-compress/scripts/compress.py
@@ -29,7 +29,7 @@ def call_claude(prompt: str) -> str:
             client = anthropic.Anthropic(api_key=api_key)
             msg = client.messages.create(
                 model=os.environ.get("CAVEMAN_MODEL", "claude-sonnet-4-5"),
-                max_tokens=8096,
+                max_tokens=8192,
                 messages=[{"role": "user", "content": prompt}],
             )
             return msg.content[0].text.strip()


### PR DESCRIPTION
`max_tokens=8096` is likely a typo for `8192` (2^13). Other scripts in the repo use `4096` (2^12). While the API accepts any integer, this aligns the value with the intended power-of-two convention.