### PR TITLE
fix: use consistent o200k_base tiktoken encoding in benchmark.py

### DIFF
--- a/caveman-compress/scripts/benchmark.py
+++ b/caveman-compress/scripts/benchmark.py
@@ -11,7 +11,7 @@ except ImportError:
 
 try:
     import tiktoken
-    _enc = tiktoken.get_encoding("cl100k_base")
+    _enc = tiktoken.get_encoding("o200k_base")
 except ImportError:
     _enc = None
 


### PR DESCRIPTION
benchmark.py uses cl100k_base while the rest of the project (measure.py, plot.py) uses o200k_base. This causes token counts from benchmark.py to be measured on a different scale than the eval harness. Aligns with the project's documented tokenizer choice.