### PR TITLE
fix: handle nested fences + strip LLM output wrapper in caveman-compress

### DIFF
--- a/caveman-compress/scripts/compress.py
+++ b/caveman-compress/scripts/compress.py
@@ -7,9 +7,29 @@ Usage:
 """
 
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import List
+
+OUTER_FENCE_REGEX = re.compile(
+    r"\A\s*(`{3,}|~{3,})[^\n]*\n(.*)\n\1\s*\Z", re.DOTALL
+)
+
+
+def strip_llm_wrapper(text: str) -> str:
+    """Strip outer ```markdown ... ``` fence when it wraps the entire output.
+
+    Claude sometimes wraps its full response in a fenced block (despite
+    prompt instructions not to), which then fails validation because the
+    inner real code blocks no longer match the original. We only strip
+    when a single outer fence wraps the whole output — inner fences are
+    preserved exactly.
+    """
+    m = OUTER_FENCE_REGEX.match(text)
+    if m:
+        return m.group(2)
+    return text
 
 from .detect import should_compress
 from .validate import validate
@@ -32,7 +52,7 @@ def call_claude(prompt: str) -> str:
                 max_tokens=8096,
                 messages=[{"role": "user", "content": prompt}],
             )
-            return msg.content[0].text.strip()
+            return strip_llm_wrapper(msg.content[0].text.strip())
         except ImportError:
             pass  # anthropic not installed, fall back to CLI
     # Fallback: use claude CLI (handles desktop auth)
@@ -44,7 +64,7 @@ def call_claude(prompt: str) -> str:
             capture_output=True,
             check=True,
         )
-        return result.stdout.strip()
+        return strip_llm_wrapper(result.stdout.strip())
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Claude call failed:\n{e.stderr}")
 
@@ -59,6 +79,7 @@ STRICT RULES:
 - Preserve ALL URLs exactly
 - Preserve ALL headings exactly
 - Preserve file paths and commands
+- Return ONLY the compressed markdown body — do NOT wrap the entire output in a ```markdown fence or any other fence. Inner code blocks from the original stay as-is; do not add a new outer fence around the whole file.
 
 Only compress natural language.
 

--- a/caveman-compress/scripts/validate.py
+++ b/caveman-compress/scripts/validate.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 
 URL_REGEX = re.compile(r"https?://[^\s)]+")
-CODE_BLOCK_REGEX = re.compile(r"```.*?```", re.DOTALL)
+FENCE_OPEN_REGEX = re.compile(r"^(\s{0,3})(`{3,}|~{3,})(.*)$")
 HEADING_REGEX = re.compile(r"^(#{1,6})\s+(.*)", re.MULTILINE)
 BULLET_REGEX = re.compile(r"^\s*[-*+]\s+", re.MULTILINE)
 
@@ -38,7 +38,44 @@ def extract_headings(text):
 
 
 def extract_code_blocks(text):
-    return CODE_BLOCK_REGEX.findall(text)
+    """Line-based fenced code block extractor.
+
+    Handles ``` and ~~~ fences with variable length (CommonMark: closing
+    fence must use same char and be at least as long as opening). Supports
+    info strings and nested fences (e.g. an outer 4-backtick block wrapping
+    inner 3-backtick content — common in docs about markdown and in report
+    templates that illustrate code output).
+
+    Previous regex (```.*?```) paired fences greedily from-left and silently
+    mispaired nested fences, causing valid compressions to fail validation.
+    """
+    blocks = []
+    lines = text.split("\n")
+    i = 0
+    n = len(lines)
+    while i < n:
+        m = FENCE_OPEN_REGEX.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        fence = m.group(2)
+        fence_char = fence[0]
+        fence_len = len(fence)
+        start = i
+        i += 1
+        while i < n:
+            cm = FENCE_OPEN_REGEX.match(lines[i])
+            if (
+                cm
+                and cm.group(2)[0] == fence_char
+                and len(cm.group(2)) >= fence_len
+                and cm.group(3).strip() == ""
+            ):
+                i += 1
+                break
+            i += 1
+        blocks.append("\n".join(lines[start:i]))
+    return blocks
 
 
 def extract_urls(text):


### PR DESCRIPTION
## Summary

Two bugs caused `caveman-compress` to reliably fail on files that contain fenced code blocks showing markdown (e.g. report templates, output format examples, docs about markdown). Both are fixed here with no behavior change for the happy path.

### 1. Fence parser mispairs nested / variable-length fences

`validate.py` used:

```python
CODE_BLOCK_REGEX = re.compile(r"```.*?```", re.DOTALL)
```

This pairs fences greedily left-to-right. When a file has an outer 4-backtick fence wrapping an inner 3-backtick snippet (common in docs about markdown and in report templates that illustrate code output), the regex parses it as two separate blocks — so `extract_code_blocks(original) != extract_code_blocks(compressed)` even when nothing inside changed. Tilde fences (`~~~`) weren't supported at all.

**Fix:** replaced with a line-based fence parser following CommonMark rules. A fenced block opens on a line starting with 3+ backticks or tildes (with up to 3 leading spaces), and closes on a line with a matching fence char of at least the same length and no info string. Variable-length fences, tilde fences, and nested blocks all parse correctly.

### 2. Claude wraps full output in `` ```markdown ... ``` ``

`compress.py` passes Claude's stdout straight through without stripping any wrapper. The model frequently wraps its entire response in a fence (even when prompted not to), which:

- fails code-block validation (inner real blocks no longer match the original)
- burns the retry budget on a fix that can't succeed
- ends with the file restored and the user thinking compression "just doesn't work on this file"

**Fix:** added `strip_llm_wrapper()` that removes an outer `` ``` ``-or-`~~~` fence only when it wraps the entire output. Inner fences preserved exactly. Applied to both the `anthropic` SDK path and the `claude` CLI fallback. Also strengthened the compression prompt with an explicit "do not wrap the output in an outer fence" rule.

## Test plan

- [x] Unit-style smoke test on a file with three fenced blocks (one ` ``` `, one tilde, one 4-backtick wrapping 3-backtick) — all three extract correctly
- [x] `strip_llm_wrapper()` round-trips ` ```markdown ... ``` ` correctly, preserves inner ` ```py ... ``` ` exactly
- [x] End-to-end run on a real ~6KB command file with two fenced output-format blocks — validation passes on first attempt where the old parser would hit max retries and restore

## Notes

- No change to the extractor's public API — still returns `list[str]`
- `strip_llm_wrapper()` is conservative: it only strips when a single outer fence wraps the *entire* stripped output, so normal responses without a wrapper are untouched
- Happy to split into two commits if preferred