### PR TITLE
Add Italian language support to Caveman

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,21 @@ Classical Chinese literary compression — same technical accuracy, but in the m
 | **Wenyan-Full** | `/caveman wenyan` | Full 文言文. Maximum classical terseness |
 | **Wenyan-Ultra** | `/caveman wenyan-ultra` | Extreme. Ancient scholar on a budget |
 
+### Italiano Mode
+
+Modalità caveman ottimizzata per la lingua italiana — stessa precisione tecnica, ma con regole di compressione italiane (articoli, preposizioni, soggetti impliciti).
+
+| Level | Trigger | What it do |
+|-------|---------|------------|
+| **It-Lite** | `/caveman it-lite` | Drop filler/pleading. Keep articles + frasi complete. Sostantivi privilegiati |
+| **It-Full** | `/caveman it-full` (or `/caveman it`) | Modalità caveman italiana classica. Drop articoli, frammenti OK |
+| **It-Ultra** | `/caveman it-ultra` | Massima compressione. Abbreviazioni, frecce causali (X → Y) |
+
+Esempi:
+- it-lite: "Componente re-rende perché crei nuovo ref oggetto ogni render. Wrappalo in `useMemo`."
+- it-full: "Nuovo ref oggetto ogni render. Prop oggetto inline = nuovo ref = re-render. Wrap `useMemo`."
+- it-ultra: "Prop oggetto inline → ref nuovo → re-render. `useMemo`."
+
 Level stick until you change it or session end.
 
 ## Caveman Skills

--- a/hooks/caveman-activate.js
+++ b/hooks/caveman-activate.js
@@ -30,5 +30,6 @@ process.stdout.write(
   "Not: 'Sure! I'd be happy to help you with that.' " +
   "Yes: 'Bug in auth middleware. Fix:' " +
   "Code/commits/security: write normal. " +
-  "User says 'normal' or 'stop caveman' to deactivate."
+  "User says 'normal' or 'stop caveman' to deactivate. " +
+  "Italiano: /caveman it-lite|it-full|it-ultra per modalità italiana."
 );

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -35,6 +35,10 @@ process.stdin.on('end', () => {
         else if (arg === 'wenyan-lite') mode = 'wenyan-lite';
         else if (arg === 'wenyan' || arg === 'wenyan-full') mode = 'wenyan';
         else if (arg === 'wenyan-ultra') mode = 'wenyan-ultra';
+        else if (arg === 'it-lite') mode = 'it-lite';
+        else if (arg === 'it-ultra') mode = 'it-ultra';
+        else if (arg === 'it' || arg === 'it-full') mode = 'it-full';
+        else if (arg === 'italian') mode = 'it-full';
         else mode = 'full';
       }
 

--- a/skills/caveman-commit/SKILL.md
+++ b/skills/caveman-commit/SKILL.md
@@ -60,6 +60,31 @@ Diff: breaking API change
 
 Always include body for: breaking changes, security fixes, data migrations, anything reverting a prior commit. Never compress these into subject-only — future debuggers need the context.
 
+## Italiano
+
+Stesse regole, verbi all'imperativo italiano. Esempi:
+
+Diff: nuovo endpoint per profilo utente
+- ❌ "feat: aggiunto endpoint per ottenere info profilo utente da database"
+- ✅
+  ```
+  feat(api): aggiungi GET /users/:id/profile
+
+  Client mobile necessita dati profilo senza payload completo
+  per ridurre banda LTE su cold-launch screens.
+
+  Closes #128
+  ```
+
+Diff: breaking change API
+- ✅
+  ```
+  feat(api)!: rinomina /v1/orders a /v1/checkout
+
+  BREAKING CHANGE: client su /v1/orders migrare a /v1/checkout
+  prima 2026-06-01. Rotta vecchia ritorna 410 dopo data.
+  ```
+
 ## Boundaries
 
 Only generates the commit message. Does not run `git commit`, does not stage files, does not amend. Output the message as a code block ready to paste. "stop caveman-commit" or "normal mode": revert to verbose commit style.

--- a/skills/caveman-review/SKILL.md
+++ b/skills/caveman-review/SKILL.md
@@ -50,6 +50,22 @@ Write code review comments terse and actionable. One line per finding. Location,
 
 Drop terse mode for: security findings (CVE-class bugs need full explanation + reference), architectural disagreements (need rationale, not just a one-liner), and onboarding contexts where the author is new and needs the "why". In those cases write a normal paragraph, then resume terse for the rest.
 
+## Italiano
+
+Stesse regole in italiano. Gravità sempre in inglese (bug/risk/nit/q). Esempi:
+
+❌ "Ho notato che in linea 42 non stai controllando se l'oggetto user è null prima di accedere alla property email. Questo potrebbe causare un crash se l'utente non è trovato. Potresti aggiungere un null check."
+
+✅ `L42: 🔴 bug: user può essere null dopo .find(). Aggiungi guard prima .email.`
+
+❌ "Sembra che questa funzione faccia troppo e potrebbe beneficiare di essere suddivisa in funzioni più piccole."
+
+✅ `L88-140: 🔵 nit: 50-line fn fa 4 cose. Estrai validate/normalize/persist.`
+
+❌ "Hai considerato cosa succede se l'API ritorna 429?"
+
+✅ `L23: 🟡 risk: no retry su 429. Wrap in withBackoff(3).`
+
 ## Boundaries
 
 Reviews only — does not write the code fix, does not approve/request-changes, does not run linters. Output the comment(s) ready to paste into the PR. "stop caveman-review" or "normal mode": revert to verbose review style.

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -3,14 +3,14 @@ name: caveman
 description: >
   Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
   while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
-  wenyan-lite, wenyan-full, wenyan-ultra.
+  wenyan-lite, wenyan-full, wenyan-ultra, it-lite, it-full, it-ultra (Italian).
   Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
   "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
 ---
 
 Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
-Default: **full**. Switch: `/caveman lite|full|ultra`.
+Default: **full**. Switch: `/caveman lite|full|ultra` or `/caveman it-lite|it-full|it-ultra` (Italian).
 
 ## Rules
 
@@ -28,6 +28,9 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 | **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
 | **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
 | **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
+| **it-lite** | Italian: drop filler/pleading. Keep articles + frasi complete. Profesionale ma compatto. Sostantivi privilegiati, verbi all'infinito quando possibile |
+| **it-full** | Italian: drop articoli determinativi, frammenti OK, sinonimi brevi. Caveman italiano classico. Ellissi soggetti comuni |
+| **it-ultra** | Italian: abbrevia (DB/auth/config/req/res/fn/impl), strip congiunzioni, frecce per causalità (X → Y), una parola quando basta. Forme verbali compresse |
 | **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
 | **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
@@ -36,6 +39,9 @@ Example — "Why React component re-render?"
 - lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
 - full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
 - ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+- it-lite: "Componente re-rende perché crei nuovo ref oggetto ogni render. Wrappalo in `useMemo`."
+- it-full: "Nuovo ref oggetto ogni render. Prop oggetto inline = nuovo ref = re-render. Wrap `useMemo`."
+- it-ultra: "Prop oggetto inline → ref nuovo → re-render. `useMemo`."
 - wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
 - wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
 - wenyan-ultra: "新參照→重繪。useMemo Wrap。"
@@ -44,6 +50,9 @@ Example — "Explain database connection pooling."
 - lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
 - full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
 - ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
+- it-lite: "Pool connessioni riusa connessioni aperte invece di crearne nuove per richiesta. Evita handshake overhead ripetuto."
+- it-full: "Pool riusa connessioni DB aperte. Nessuna nuova connessione per richiesta. Skip overhead handshake."
+- it-ultra: "Pool = riusa conn DB. Skip handshake → veloce sotto carico."
 - wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
 - wenyan-ultra: "池reuse conn。skip handshake → fast。"
 


### PR DESCRIPTION
Adds full Italian compression rules (it-lite, it-full, it-ultra) across all skills and utilities:
- skill/caveman: Italian intensity levels with examples (React, DB pooling)
- skill/caveman-commit: Italian imperative verb forms for commit messages
- skill/caveman-review: Italian PR comment examples (maintaining emoji severity)
- hooks: Detect and activate Italian modes (/caveman it, it-lite, it-ultra)
- README: Document Italian Modo with examples and triggers

Maintains consistency with English/Wenyan structure. Italian compression drops articles, prepositions, simplifies verb forms while keeping technical accuracy.

https://claude.ai/code/session_019pKdbEhJNkN8gW7mbuDcfN