### PR TITLE
Security: Hook writes to predictable path without symlink protection (possible file clobber)

### DIFF
--- a/hooks/caveman-activate.js
+++ b/hooks/caveman-activate.js
@@ -19,7 +19,23 @@ const flagPath = path.join(os.homedir(), '.claude', '.caveman-active');
 
 try {
   fs.mkdirSync(path.dirname(flagPath), { recursive: true });
-  fs.writeFileSync(flagPath, 'full');
+  try {
+    if (fs.lstatSync(flagPath).isSymbolicLink()) {
+      throw new Error('Symlink flag path');
+    }
+  } catch (e) {
+    if (e.code !== 'ENOENT') throw e;
+  }
+
+  const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC |
+    (typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0);
+  const fd = fs.openSync(flagPath, flags, 0o600);
+  try {
+    fs.writeSync(fd, 'full');
+    fs.fchmodSync(fd, 0o600);
+  } finally {
+    fs.closeSync(fd);
+  }
 } catch (e) {
   // Silent fail -- flag is best-effort, don't block the hook
 }

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -40,7 +40,23 @@ process.stdin.on('end', () => {
 
       if (mode) {
         fs.mkdirSync(path.dirname(flagPath), { recursive: true });
-        fs.writeFileSync(flagPath, mode);
+        try {
+          if (fs.lstatSync(flagPath).isSymbolicLink()) {
+            throw new Error('Symlink flag path');
+          }
+        } catch (e) {
+          if (e.code !== 'ENOENT') throw e;
+        }
+
+        const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC |
+          (typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0);
+        const fd = fs.openSync(flagPath, flags, 0o600);
+        try {
+          fs.writeSync(fd, mode);
+          fs.fchmodSync(fd, 0o600);
+        } finally {
+          fs.closeSync(fd);
+        }
       }
     }
 


### PR DESCRIPTION
## Problem

The SessionStart hook writes to `~/.claude/.caveman-active` using `fs.writeFileSync` on a predictable path. If that path is replaced with a symlink, Node will follow it and overwrite the symlink target. A local attacker (or another process running as the same user) could abuse this to modify unintended files writable by the user.

**Severity**: `medium`
**File**: `hooks/caveman-activate.js`

## Solution

Before writing, use `lstatSync` to reject symlinks, open files with flags that avoid following links where possible, and enforce restrictive permissions (e.g., create with mode `0o600`). Consider writing to a temporary file and atomic-renaming after validation.

## Changes

- `hooks/caveman-activate.js` (modified)
- `hooks/caveman-mode-tracker.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
