### PR TITLE
Security: Mode tracker flag file write also vulnerable to symlink-based overwrite

### DIFF
--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -8,6 +8,26 @@ const os = require('os');
 
 const flagPath = path.join(os.homedir(), '.claude', '.caveman-active');
 
+function assertNoSymlink(targetPath) {
+  const resolved = path.resolve(targetPath);
+  const parsed = path.parse(resolved);
+  let current = parsed.root;
+  const parts = resolved.slice(parsed.root.length).split(path.sep).filter(Boolean);
+
+  for (const part of parts) {
+    current = path.join(current, part);
+    try {
+      const stat = fs.lstatSync(current);
+      if (stat.isSymbolicLink()) {
+        throw new Error('symlink');
+      }
+    } catch (e) {
+      if (e.code === 'ENOENT') continue;
+      throw e;
+    }
+  }
+}
+
 let input = '';
 process.stdin.on('data', chunk => { input += chunk; });
 process.stdin.on('end', () => {
@@ -39,8 +59,14 @@ process.stdin.on('end', () => {
       }
 
       if (mode) {
-        fs.mkdirSync(path.dirname(flagPath), { recursive: true });
-        fs.writeFileSync(flagPath, mode);
+        const flagDir = path.dirname(flagPath);
+        assertNoSymlink(flagDir);
+        fs.mkdirSync(flagDir, { recursive: true, mode: 0o700 });
+        assertNoSymlink(flagDir);
+        assertNoSymlink(flagPath);
+        const tempPath = path.join(flagDir, `.caveman-active.${process.pid}.${Date.now()}`);
+        fs.writeFileSync(tempPath, mode, { mode: 0o600 });
+        fs.renameSync(tempPath, flagPath);
       }
     }
 


### PR DESCRIPTION
## Problem

The UserPromptSubmit hook similarly writes to `~/.claude/.caveman-active` without checking whether the path is a symlink. This duplicates the same local file-clobber risk in another execution path.

**Severity**: `medium`
**File**: `hooks/caveman-mode-tracker.js`

## Solution

Apply the same hardening as in the activation hook: validate path components with `lstat`, refuse symlinks, and write with restrictive permissions and atomic replace semantics.

## Changes

- `hooks/caveman-mode-tracker.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
