### PR TITLE
wenyan: add -simp suffix for 简体 output

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -29,7 +29,7 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 | **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
 | **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
 | **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
-| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
+| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其). Default 繁體; append `-simp` suffix → 简体 (works on all 3 wenyan levels) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
 
 Example — "Why React component re-render?"
@@ -39,6 +39,9 @@ Example — "Why React component re-render?"
 - wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
 - wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
 - wenyan-ultra: "新參照→重繪。useMemo Wrap。"
+- wenyan-lite-simp: "组件频重绘，以每绘新生对象参照故。以 useMemo 包之。"
+- wenyan-full-simp: "物出新参照，致重绘。useMemo .Wrap之。"
+- wenyan-ultra-simp: "新参照→重绘。useMemo Wrap。"
 
 Example — "Explain database connection pooling."
 - lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."


### PR DESCRIPTION
## Before

User: `/caveman wenyan`
Caveman: 物出新參照，致重繪。useMemo .Wrap之。   ← only 繁體 available

User: asks in 简体 / wants simplified
Caveman: 物出新參照，致重繪。useMemo .Wrap之。   ← still 繁體, no way to switch

## After

User: `/caveman wenyan` (or `wenyan-lite` / `wenyan-ultra`)
Caveman: 物出新參照，致重繪。useMemo .Wrap之。   ← default 繁體, unchanged

User: `/caveman wenyan-lite-simp`
Caveman: 组件频重绘，以每绘新生对象参照故。以 useMemo 包之。

User: `/caveman wenyan-full-simp`
Caveman: 物出新参照，致重绘。useMemo .Wrap之。

User: `/caveman wenyan-ultra-simp`
Caveman: 新参照→重绘。useMemo Wrap。

## Why

Wenyan currently only emits 繁體 because every few-shot example in `SKILL.md` is 繁體, even though 文言文 itself has no inherent script. This adds a composable `-simp` suffix to each wenyan intensity (`wenyan-lite-simp`, `wenyan-full-simp`, `wenyan-ultra-simp`) as a first-class switch, grounded by parallel 简体 examples in the React demonstration block. Default remains 繁體 — zero breaking change.

## Design notes

- **Suffix, not a new mode family** — composes with existing `wenyan-lite/full/ultra` instead of doubling the mode count, keeps the `/caveman <mode>` single-arg grammar, and leaves the 3-row intensity table intact.
- **Flag declared where wenyan is defined** — inline addition to the `wenyan-full` table row (the canonical wenyan entry) rather than a bolted-on section.
- **Few-shot over rules** — script bias was created by examples, so the fix is examples. Adding one 简体 row per intensity gives the model symmetric grounding; no magic-word rule needed.
- **Diff stat: `+4 −1`, one file.** Per CONTRIBUTING.md, only `skills/caveman/SKILL.md` is touched; the other 3 SKILL.md copies and `caveman.skill` are left for CI auto-sync.

## Known follow-up (not in this PR)

`hooks/caveman-mode-tracker.js` will fall the new `-simp` args through to `'full'` on the statusline badge. Functional behavior (model output) is unaffected because the model reads the user's `/caveman` command from the prompt directly, not from the flag file. Happy to add a tracker patch in this PR or a follow-up — let me know the preference.
