### PR TITLE
feat: make default caveman mode configurable

### DIFF
--- a/hooks/caveman-activate.js
+++ b/hooks/caveman-activate.js
@@ -14,12 +14,13 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { getDefaultMode } = require('./caveman-config');
 
 const flagPath = path.join(os.homedir(), '.claude', '.caveman-active');
 
 try {
   fs.mkdirSync(path.dirname(flagPath), { recursive: true });
-  fs.writeFileSync(flagPath, 'full');
+  fs.writeFileSync(flagPath, getDefaultMode());
 } catch (e) {
   // Silent fail -- flag is best-effort, don't block the hook
 }

--- a/hooks/caveman-config.js
+++ b/hooks/caveman-config.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// caveman — shared configuration resolver
+//
+// Resolution order for default mode:
+//   1. CAVEMAN_DEFAULT_MODE environment variable
+//   2. Config file defaultMode field:
+//      - $XDG_CONFIG_HOME/caveman/config.json (any platform, if set)
+//      - ~/.config/caveman/config.json (macOS / Linux fallback)
+//      - %APPDATA%\caveman\config.json (Windows fallback)
+//   3. 'full'
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const VALID_MODES = [
+  'lite', 'full', 'ultra',
+  'wenyan-lite', 'wenyan', 'wenyan-full', 'wenyan-ultra',
+  'commit', 'review', 'compress'
+];
+
+function getConfigDir() {
+  if (process.env.XDG_CONFIG_HOME) {
+    return path.join(process.env.XDG_CONFIG_HOME, 'caveman');
+  }
+  if (process.platform === 'win32') {
+    return path.join(
+      process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'),
+      'caveman'
+    );
+  }
+  return path.join(os.homedir(), '.config', 'caveman');
+}
+
+function getConfigPath() {
+  return path.join(getConfigDir(), 'config.json');
+}
+
+function getDefaultMode() {
+  // 1. Environment variable (highest priority)
+  const envMode = process.env.CAVEMAN_DEFAULT_MODE;
+  if (envMode && VALID_MODES.includes(envMode.toLowerCase())) {
+    return envMode.toLowerCase();
+  }
+
+  // 2. Config file
+  try {
+    const configPath = getConfigPath();
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    if (config.defaultMode && VALID_MODES.includes(config.defaultMode.toLowerCase())) {
+      return config.defaultMode.toLowerCase();
+    }
+  } catch (e) {
+    // Config file doesn't exist or is invalid — fall through
+  }
+
+  // 3. Default
+  return 'full';
+}
+
+module.exports = { getDefaultMode, getConfigDir, getConfigPath, VALID_MODES };

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -5,6 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { getDefaultMode } = require('./caveman-config');
 
 const flagPath = path.join(os.homedir(), '.claude', '.caveman-active');
 
@@ -35,7 +36,7 @@ process.stdin.on('end', () => {
         else if (arg === 'wenyan-lite') mode = 'wenyan-lite';
         else if (arg === 'wenyan' || arg === 'wenyan-full') mode = 'wenyan';
         else if (arg === 'wenyan-ultra') mode = 'wenyan-ultra';
-        else mode = 'full';
+        else mode = getDefaultMode();
       }
 
       if (mode) {

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -10,7 +10,7 @@ HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS="$CLAUDE_DIR/settings.json"
 REPO_URL="https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks"
 
-HOOK_FILES=("caveman-activate.js" "caveman-mode-tracker.js")
+HOOK_FILES=("caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js")
 
 # Resolve source — works from repo clone or curl pipe
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" 2>/dev/null)" 2>/dev/null && pwd)"


### PR DESCRIPTION
## Summary

- Add `hooks/caveman-config.js` — shared config resolver with XDG-compliant path resolution across all platforms
- Remove hard-coded `'full'` default from `caveman-activate.js` and `caveman-mode-tracker.js`, replaced with `getDefaultMode()` call
- Update `install.sh` to include the new config module

### Config resolution order

1. `CAVEMAN_DEFAULT_MODE` environment variable (highest priority)
2. Config file `defaultMode` field at:
   - `$XDG_CONFIG_HOME/caveman/config.json` (any platform, if `XDG_CONFIG_HOME` is set)
   - `~/.config/caveman/config.json` (macOS / Linux fallback)
   - `%APPDATA%\caveman\config.json` (Windows fallback)
3. `'full'` (unchanged default)

### Example config

```json
{ "defaultMode": "ultra" }
```

Or per-harness via environment variable:

```bash
CAVEMAN_DEFAULT_MODE=lite
```

## Test plan

Manual smoke tests — all passing:

### Test 1: No config (default behavior)
```
$ node -e "const c = require('./hooks/caveman-config'); console.log('default:', c.getDefaultMode()); console.log('configPath:', c.getConfigPath()); console.log('configDir:', c.getConfigDir());"
default: full
configPath: /Users/matt/.config/caveman/config.json
configDir: /Users/matt/.config/caveman
```

### Test 2: Environment variable override
```
$ CAVEMAN_DEFAULT_MODE=ultra node -e "const c = require('./hooks/caveman-config'); console.log('default:', c.getDefaultMode());"
default: ultra
```

### Test 3: XDG config file override
```
$ mkdir -p /tmp/caveman-xdg-test/caveman
$ echo '{"defaultMode":"lite"}' > /tmp/caveman-xdg-test/caveman/config.json
$ XDG_CONFIG_HOME=/tmp/caveman-xdg-test node -e "const c = require('./hooks/caveman-config'); console.log('default:', c.getDefaultMode());"
default: lite
```

### Validation
- [x] No config → defaults to `full` (backward compatible)
- [x] `CAVEMAN_DEFAULT_MODE` env var respected
- [x] XDG config file with `defaultMode` respected
- [x] Invalid modes in config/env are ignored (falls through to default)