### PR TITLE
Fix broken compress skill packaging in Codex plugin

### DIFF
--- a/plugins/caveman/skills/compress/SKILL.md
+++ b/plugins/caveman/skills/compress/SKILL.md
@@ -1,1 +1,110 @@
-../../../../caveman-compress/SKILL.md
+---
+name: compress
+description: >
+  Compress natural language memory files (CLAUDE.md, todos, preferences) into caveman format
+  to save input tokens. Preserves all technical substance, code, URLs, and structure.
+  Compressed version overwrites the original file. Human-readable backup saved as FILE.original.md.
+  Trigger: /caveman:compress <filepath> or "compress memory file"
+---
+
+# Caveman Compress
+
+## Purpose
+
+Compress natural language files (CLAUDE.md, todos, preferences) into caveman-speak to reduce input tokens. Compressed version overwrites original. Human-readable backup saved as `<filename>.original.md`.
+
+## Trigger
+
+`/caveman:compress <filepath>` or when user asks to compress a memory file.
+
+## Process
+
+1. This SKILL.md lives alongside `scripts/` in the same directory. Find that directory.
+
+2. Run:
+
+cd <directory_containing_this_SKILL.md> && python3 -m scripts <absolute_filepath>
+
+3. The CLI will:
+- detect file type (no tokens)
+- call Claude to compress
+- validate output (no tokens)
+- if errors: cherry-pick fix with Claude (targeted fixes only, no recompression)
+- retry up to 2 times
+
+4. Return result to user
+
+## Compression Rules
+
+### Remove
+- Articles: a, an, the
+- Filler: just, really, basically, actually, simply, essentially, generally
+- Pleasantries: "sure", "certainly", "of course", "happy to", "I'd recommend"
+- Hedging: "it might be worth", "you could consider", "it would be good to"
+- Redundant phrasing: "in order to" -> "to", "make sure to" -> "ensure", "the reason is because" -> "because"
+- Connective fluff: "however", "furthermore", "additionally", "in addition"
+
+### Preserve EXACTLY (never modify)
+- Code blocks (fenced ``` and indented)
+- Inline code (`backtick content`)
+- URLs and links (full URLs, markdown links)
+- File paths (`/src/components/...`, `./config.yaml`)
+- Commands (`npm install`, `git commit`, `docker build`)
+- Technical terms (library names, API names, protocols, algorithms)
+- Proper nouns (project names, people, companies)
+- Dates, version numbers, numeric values
+- Environment variables (`$HOME`, `NODE_ENV`)
+
+### Preserve Structure
+- All markdown headings (keep exact heading text, compress body below)
+- Bullet point hierarchy (keep nesting level)
+- Numbered lists (keep numbering)
+- Tables (compress cell text, keep structure)
+- Frontmatter/YAML headers in markdown files
+
+### Compress
+- Use short synonyms: "big" not "extensive", "fix" not "implement a solution for", "use" not "utilize"
+- Fragments OK: "Run tests before commit" not "You should always run tests before committing"
+- Drop "you should", "make sure to", "remember to" - just state the action
+- Merge redundant bullets that say the same thing differently
+- Keep one example where multiple examples show the same pattern
+
+CRITICAL RULE:
+Anything inside ``` ... ``` must be copied EXACTLY.
+Do not:
+- remove comments
+- remove spacing
+- reorder lines
+- shorten commands
+- simplify anything
+
+Inline code (`...`) must be preserved EXACTLY.
+Do not modify anything inside backticks.
+
+If file contains code blocks:
+- Treat code blocks as read-only regions
+- Only compress text outside them
+- Do not merge sections around code
+
+## Pattern
+
+Original:
+> You should always make sure to run the test suite before pushing any changes to the main branch. This is important because it helps catch bugs early and prevents broken builds from being deployed to production.
+
+Compressed:
+> Run tests before push to main. Catch bugs early, prevent broken prod deploys.
+
+Original:
+> The application uses a microservices architecture with the following components. The API gateway handles all incoming requests and routes them to the appropriate service. The authentication service is responsible for managing user sessions and JWT tokens.
+
+Compressed:
+> Microservices architecture. API gateway route all requests to services. Auth service manage user sessions + JWT tokens.
+
+## Boundaries
+
+- ONLY compress natural language files (.md, .txt, extensionless)
+- NEVER modify: .py, .js, .ts, .json, .yaml, .yml, .toml, .env, .lock, .css, .html, .xml, .sql, .sh
+- If file has mixed content (prose + code), compress ONLY the prose sections
+- If unsure whether something is code or prose, leave it unchanged
+- Original file is backed up as FILE.original.md before overwriting
+- Never compress FILE.original.md (skip it)

--- a/plugins/caveman/skills/compress/scripts
+++ b/plugins/caveman/skills/compress/scripts
@@ -1,1 +1,0 @@
-../../../../caveman-compress/scripts

--- a/plugins/caveman/skills/compress/scripts/__init__.py
+++ b/plugins/caveman/skills/compress/scripts/__init__.py
@@ -1,0 +1,7 @@
+"""Caveman compress scripts.
+
+This package provides tools to compress natural language markdown files
+into caveman format while preserving code blocks and technical content.
+"""
+
+__all__ = ["cli", "compress", "detect", "validate"]

--- a/plugins/caveman/skills/compress/scripts/__main__.py
+++ b/plugins/caveman/skills/compress/scripts/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+main()

--- a/plugins/caveman/skills/compress/scripts/benchmark.py
+++ b/plugins/caveman/skills/compress/scripts/benchmark.py
@@ -1,0 +1,72 @@
+"""Benchmark token savings from markdown compression.
+
+Usage:
+    python benchmark.py original.md compressed.md
+"""
+
+import sys
+from pathlib import Path
+
+import tiktoken
+
+
+def count_tokens(text: str, model: str = "gpt-4") -> int:
+    """Count tokens using OpenAI tokenizer."""
+    try:
+        encoding = tiktoken.encoding_for_model(model)
+    except KeyError:
+        encoding = tiktoken.get_encoding("cl100k_base")
+    return len(encoding.encode(text))
+
+
+def benchmark_pair(original_path: Path, compressed_path: Path):
+    """Compare original vs compressed token counts."""
+    original = original_path.read_text()
+    compressed = compressed_path.read_text()
+
+    orig_tokens = count_tokens(original)
+    comp_tokens = count_tokens(compressed)
+    saved = orig_tokens - comp_tokens
+    reduction = (saved / orig_tokens * 100) if orig_tokens > 0 else 0
+
+    print(f"Original:   {orig_tokens:6d} tokens")
+    print(f"Compressed: {comp_tokens:6d} tokens")
+    print(f"Saved:      {saved:6d} tokens")
+    print(f"Reduction:  {reduction:6.1f}%")
+
+
+def main():
+    if len(sys.argv) == 3:
+        # Direct file pair: python3 benchmark.py original.md compressed.md
+        original = Path(sys.argv[1])
+        compressed = Path(sys.argv[2])
+        benchmark_pair(original, compressed)
+        return
+
+    if len(sys.argv) != 1:
+        print("Usage: python benchmark.py [original.md compressed.md]")
+        print("   or: python benchmark.py  # benchmark all test pairs")
+        sys.exit(1)
+
+    # Glob mode: repo_root/tests/caveman-compress/
+    tests_dir = Path(__file__).parent.parent.parent / "tests" / "caveman-compress"
+    pairs = []
+
+    for original in tests_dir.glob("*.original.md"):
+        compressed = original.parent / original.name.replace(".original.md", ".compressed.md")
+        if compressed.exists():
+            pairs.append((original, compressed))
+
+    if not pairs:
+        print("No compressed file pairs found.")
+        return
+
+    print(f"Found {len(pairs)} file pairs\n")
+    for original, compressed in pairs:
+        print(f"=== {original.stem.replace('.original', '')} ===")
+        benchmark_pair(original, compressed)
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/caveman/skills/compress/scripts/cli.py
+++ b/plugins/caveman/skills/compress/scripts/cli.py
@@ -1,0 +1,45 @@
+"""CLI wrapper for caveman file compression."""
+
+import sys
+from pathlib import Path
+
+from .compress import compress_file
+from .detect import detect_file_type, should_compress
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python3 -m scripts <filepath>")
+        sys.exit(1)
+
+    filepath = Path(sys.argv[1]).resolve()
+
+    if not filepath.exists():
+        print(f"Error: file not found: {filepath}")
+        sys.exit(1)
+
+    file_type = detect_file_type(filepath)
+    print(f"File: {filepath}")
+    print(f"Type: {file_type}")
+
+    if filepath.name.endswith(".original.md"):
+        print("Skip: .original.md backup files should not be compressed")
+        sys.exit(0)
+
+    # Check if compressible
+    if not should_compress(filepath):
+        print(f"Skip: {filepath.name} is not a natural language file")
+        sys.exit(0)
+
+    print("Starting caveman compression...\n")
+
+    try:
+        success = compress_file(filepath)
+        sys.exit(0 if success else 1)
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/caveman/skills/compress/scripts/compress.py
+++ b/plugins/caveman/skills/compress/scripts/compress.py
@@ -1,0 +1,122 @@
+"""Core compression logic for caveman file compression.
+
+Usage:
+    python scripts/compress.py <filepath>
+"""
+
+from pathlib import Path
+from typing import List
+
+from .detect import should_compress
+from .validate import validate
+
+
+def call_claude(prompt: str) -> str:
+    """Call Claude CLI with prompt, return stdout."""
+    import subprocess
+
+    result = subprocess.run(
+        ["claude", "-p", prompt],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(f"Claude failed: {result.stderr}")
+
+    return result.stdout.strip()
+
+
+def build_compress_prompt(original: str) -> str:
+    return f"""Compress this markdown file into caveman-speak.
+
+Preserve EXACTLY:
+- code blocks
+- inline code
+- URLs
+- file paths
+- commands
+- proper nouns
+- dates/numbers/versions
+- heading text
+- list structure
+
+Only compress natural language.
+Return ONLY compressed markdown. No explanation.
+
+FILE:
+
+{original}
+"""
+
+
+def build_fix_prompt(original: str, compressed: str, errors: List[str]) -> str:
+    errors_text = "\n".join(f"- {e}" for e in errors)
+    return f"""You are fixing a caveman-compressed markdown file. Specific validation errors were found.
+
+Rules:
+- Fix ONLY the listed errors
+- DO NOT recompress or rephrase the file
+- Preserve current wording everywhere else
+- Code blocks, URLs, paths, commands, headings must match original exactly where validator says broken
+- Return ONLY the fixed markdown
+
+VALIDATION ERRORS:
+{errors_text}
+
+ORIGINAL FILE:
+{original}
+
+CURRENT COMPRESSED FILE:
+{compressed}
+
+Return ONLY the fixed compressed file. No explanation.
+"""
+
+
+def compress_file(filepath: Path) -> bool:
+    """Compress a file in place, saving backup as .original.md.
+
+    Returns True if successful.
+    """
+    if filepath.stat().st_size > 500_000:
+        raise ValueError(f"File too large to compress safely (max 500KB): {filepath}")
+
+    if not should_compress(filepath):
+        print(f"Skip: file type not compressible: {filepath}")
+        return False
+
+    original_text = filepath.read_text()
+    compressed = call_claude(build_compress_prompt(original_text))
+
+    # Save original as backup, write compressed to original path
+    backup = filepath.with_name(f"{filepath.stem}.original.md")
+    backup.write_text(original_text)
+    filepath.write_text(compressed)
+
+    print(f"Saved backup: {backup}")
+    print(f"Wrote compressed file: {filepath}")
+
+    # Validate, retry with targeted fixes if needed
+    for attempt in range(3):
+        result = validate(backup, filepath)
+        if result.ok:
+            print("Validation passed.")
+            return True
+
+        print(f"Validation failed (attempt {attempt + 1}/3):")
+        for error in result.errors:
+            print(f"  - {error}")
+
+        if attempt == 2:
+            print("Validation failed after 3 attempts.")
+            return False
+
+        compressed = call_claude(
+            build_fix_prompt(original_text, compressed, result.errors)
+        )
+        filepath.write_text(compressed)
+        print("Applied targeted fix, retrying validation...")
+
+    return False

--- a/plugins/caveman/skills/compress/scripts/detect.py
+++ b/plugins/caveman/skills/compress/scripts/detect.py
@@ -1,0 +1,91 @@
+"""Detect whether a file is natural language (compressible) or code/config (skip)."""
+
+from pathlib import Path
+
+
+# Extensions that are natural language and compressible
+COMPRESSIBLE_EXTENSIONS = {
+    ".md",
+    ".txt",
+}
+
+# Extensions that should never be compressed
+NON_COMPRESSIBLE_EXTENSIONS = {
+    ".py",
+    ".js",
+    ".ts",
+    ".tsx",
+    ".jsx",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".env",
+    ".lock",
+    ".css",
+    ".scss",
+    ".html",
+    ".xml",
+    ".sql",
+    ".sh",
+    ".bash",
+    ".zsh",
+    ".fish",
+    ".ps1",
+    ".bat",
+    ".cmd",
+    ".ini",
+    ".cfg",
+    ".conf",
+    ".dockerfile",
+}
+
+
+def detect_file_type(filepath: Path) -> str:
+    """Return 'natural-language', 'code-config', or 'unknown'."""
+    suffix = filepath.suffix.lower()
+
+    if suffix in COMPRESSIBLE_EXTENSIONS:
+        return "natural-language"
+
+    if suffix in NON_COMPRESSIBLE_EXTENSIONS:
+        return "code-config"
+
+    if suffix == "":
+        # Extensionless files: heuristic based on filename
+        name = filepath.name.lower()
+        natural_names = {
+            "claude.md",
+            "readme",
+            "todo",
+            "todos",
+            "notes",
+            "preferences",
+            "memory",
+            "context",
+        }
+        if name in natural_names:
+            return "natural-language"
+
+    return "unknown"
+
+
+def should_compress(filepath: Path) -> bool:
+    """Return True if the file is natural language and should be compressed."""
+    if filepath.name.endswith(".original.md"):
+        return False
+    return detect_file_type(filepath) == "natural-language"
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: python detect.py <filepath> [filepath2 ...]")
+        raise SystemExit(1)
+
+    for arg in sys.argv[1:]:
+        p = Path(arg)
+        file_type = detect_file_type(p)
+        compress = should_compress(p)
+        print(f"{p}: type={file_type} compress={compress}")

--- a/plugins/caveman/skills/compress/scripts/validate.py
+++ b/plugins/caveman/skills/compress/scripts/validate.py
@@ -1,0 +1,76 @@
+"""Validate compressed markdown preserves critical content."""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+
+@dataclass
+class ValidationResult:
+    ok: bool
+    errors: List[str]
+
+
+def read_file(path: Path) -> str:
+    return path.read_text()
+
+
+def extract_code_blocks(text: str) -> List[str]:
+    return re.findall(r"```.*?```", text, flags=re.DOTALL)
+
+
+def extract_inline_code(text: str) -> List[str]:
+    return re.findall(r"`[^`\n]+`", text)
+
+
+def extract_urls(text: str) -> List[str]:
+    return re.findall(r"https?://[^\s)]+", text)
+
+
+def extract_headings(text: str) -> List[str]:
+    return re.findall(r"^#+ .+$", text, flags=re.MULTILINE)
+
+
+def validate(original_path: Path, compressed_path: Path) -> ValidationResult:
+    orig = read_file(original_path)
+    comp = read_file(compressed_path)
+    errors: List[str] = []
+
+    orig_blocks = extract_code_blocks(orig)
+    comp_blocks = extract_code_blocks(comp)
+    if orig_blocks != comp_blocks:
+        errors.append("Code blocks changed")
+
+    orig_inline = extract_inline_code(orig)
+    comp_inline = extract_inline_code(comp)
+    if orig_inline != comp_inline:
+        errors.append("Inline code changed")
+
+    orig_urls = extract_urls(orig)
+    comp_urls = extract_urls(comp)
+    if orig_urls != comp_urls:
+        errors.append("URLs changed")
+
+    orig_headings = extract_headings(orig)
+    comp_headings = extract_headings(comp)
+    if orig_headings != comp_headings:
+        errors.append("Headings changed")
+
+    return ValidationResult(ok=not errors, errors=errors)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 3:
+        print("Usage: python validate.py <original> <compressed>")
+        raise SystemExit(1)
+
+    result = validate(Path(sys.argv[1]), Path(sys.argv[2]))
+    if result.ok:
+        print("OK")
+    else:
+        for error in result.errors:
+            print(error)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
Fix the Codex plugin packaging for the `compress` skill.

## Problem
The packaged plugin currently ships:

```text
plugins/caveman/skills/compress/SKILL.md
plugins/caveman/skills/compress/scripts
```

as pointer-style stub files instead of actual packaged content. Codex does not resolve those stubs, so install/load fails with missing YAML frontmatter on `SKILL.md`.

Closes #92.

## Changes
- replace the stub `plugins/caveman/skills/compress/SKILL.md` with the real skill file containing YAML frontmatter
- replace the stub `plugins/caveman/skills/compress/scripts` entry with the actual Python script package
- preserve the existing compress-skill behavior while making the packaged plugin self-contained for Codex installs

## Verification
- confirmed the installed cached plugin loads a real `SKILL.md` that starts with `---`
- confirmed `scripts/` is a real directory in the packaged plugin rather than a one-line path stub