### PR TITLE
feat: add /caveman-translate skill for wenyan-to-English translation (#68)

### DIFF
--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -30,6 +30,8 @@ process.stdin.on('end', () => {
         mode = 'review';
       } else if (cmd === '/caveman-compress' || cmd === '/caveman:caveman-compress') {
         mode = 'compress';
+      } else if (cmd === '/caveman-translate') {
+        mode = 'translate';
       } else if (cmd === '/caveman' || cmd === '/caveman:caveman') {
         if (arg === 'lite') mode = 'lite';
         else if (arg === 'ultra') mode = 'ultra';

--- a/skills/caveman-translate/SKILL.md
+++ b/skills/caveman-translate/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: caveman-translate
+description: >
+  Translate wenyan (Classical Chinese) or caveman-compressed output back into clear English.
+  Useful when running in wenyan mode — get token-efficient output, then translate on demand.
+  Preserves all code blocks, technical terms, file paths, and URLs exactly unchanged.
+  Trigger: /caveman-translate or "translate that", "translate wenyan", "what does this mean in English".
+---
+
+Translate the provided text into clear, readable English. Full sentences. Normal grammar. Professional tone.
+
+## What to translate
+
+- **Wenyan / Classical Chinese** (文言文): `池reuse conn。skip handshake → fast。` → "Connection pooling reuses open connections instead of creating new ones per request, avoiding repeated handshake overhead."
+- **Caveman compressed English**: `Bug auth middleware. Token expiry check use < not <=. Fix:` → "There is a bug in the authentication middleware. The token expiry check uses `<` instead of `<=`. Here is the fix:"
+- **Mixed wenyan+code output**: translate prose portions, leave code blocks exactly as-is
+
+## Rules
+
+**Translate:**
+- Classical Chinese characters and particles (之/乃/為/其) → English prose
+- Caveman fragments → full sentences with articles restored
+- Abbreviations (DB, auth, config, req, res, fn) → spelled out where helpful: "database", "authentication", "configuration", "request", "response", "function"
+- Arrows used for causality (`→`) → "which causes", "resulting in", or "so"
+- Omitted subjects → restore from context
+
+**Never touch:**
+- Code blocks (fenced ` ``` ` and indented) — copy exactly
+- Inline code (`` `backtick content` ``) — copy exactly
+- URLs and markdown links — copy exactly
+- File paths, commands, environment variables — copy exactly
+- Technical names: library names, API names, function names, protocol names
+- Proper nouns: project names, company names, people
+
+## Examples
+
+**Wenyan-full input:**
+> 物出新參照，致重繪。useMemo Wrap之。
+
+**Translation:**
+> Creating a new object reference on each render triggers a re-render. Wrap the value in `useMemo`.
+
+---
+
+**Caveman-ultra input:**
+> Pool = reuse DB conn. Skip handshake → fast under load.
+
+**Translation:**
+> Connection pooling reuses open database connections instead of creating new ones per request. This skips the handshake overhead, resulting in faster response times under load.
+
+---
+
+**Mixed input:**
+> 池reuse open connection。不每req新開。skip handshake overhead。
+> ```js
+> const pool = new Pool({ max: 10 });
+> ```
+> ultra快。
+
+**Translation:**
+> The pool reuses open connections and does not open a new one per request, skipping handshake overhead.
+> ```js
+> const pool = new Pool({ max: 10 });
+> ```
+> This is extremely fast.
+
+## Format
+
+Output the translation as a clean prose block — same heading structure and bullet hierarchy as the original if present, but with full English sentences inside each item. Do not add commentary like "Here is the translation:" — just output the translated text directly.
+
+## Boundaries
+
+Translates text only — does not re-run the original query, does not change caveman mode, does not modify any files. After translating, caveman mode stays at whatever level it was set to. "stop caveman-translate" or "done translating": acknowledge and resume normal behavior.

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -157,5 +157,48 @@ class HookScriptTests(unittest.TestCase):
             self.assertEqual((claude_dir / ".caveman-active").read_text(), "full")
 
 
+    def run_mode_tracker(self, prompt, home):
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)
+        payload = json.dumps({"prompt": prompt})
+        return subprocess.run(
+            ["node", "hooks/caveman-mode-tracker.js"],
+            cwd=REPO_ROOT,
+            env=env,
+            input=payload,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_translate_command_sets_translate_mode(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-translate-") as tmp:
+            home = Path(tmp)
+            (home / ".claude").mkdir(parents=True)
+
+            self.run_mode_tracker("/caveman-translate", home)
+
+            flag = home / ".claude" / ".caveman-active"
+            self.assertTrue(flag.exists(), "flag file should be created by /caveman-translate")
+            self.assertEqual(flag.read_text(), "translate")
+
+    def test_translate_mode_statusline_badge(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-translate-statusline-") as tmp:
+            home = Path(tmp)
+            (home / ".claude").mkdir(parents=True)
+            (home / ".claude" / ".caveman-active").write_text("translate")
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            result = subprocess.run(
+                ["bash", "hooks/caveman-statusline.sh"],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+            self.assertIn("TRANSLATE", result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -134,6 +134,43 @@ class HookScriptTests(unittest.TestCase):
             )
             self.assertNotIn("hooks", updated)
 
+    def test_caveman_translate_preserves_existing_mode(self):
+        """`/caveman-translate` must NOT overwrite the active mode flag.
+
+        Translate is a one-shot skill, not a mode. Earlier designs that
+        wrote 'translate' to the flag file left the statusline stuck on
+        [CAVEMAN:TRANSLATE] after the skill ran and lost the user's prior
+        intensity (e.g. wenyan-ultra). The tracker must let translate
+        pass through without touching the flag.
+        """
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-translate-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+            flag = claude_dir / ".caveman-active"
+            flag.write_text("wenyan-ultra")
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["USERPROFILE"] = str(home)
+            env["CLAUDE_CONFIG_DIR"] = str(claude_dir)
+
+            subprocess.run(
+                ["node", "src/hooks/caveman-mode-tracker.js"],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                input='{"prompt":"/caveman-translate"}',
+                capture_output=True,
+                check=True,
+            )
+
+            self.assertEqual(
+                flag.read_text().strip(),
+                "wenyan-ultra",
+                "translate must not clobber the active mode flag",
+            )
+
     def test_activate_does_not_nudge_when_custom_statusline_exists(self):
         with tempfile.TemporaryDirectory(prefix="caveman-hooks-activate-") as tmp:
             home = Path(tmp)


### PR DESCRIPTION
## Summary

Fixes #68

- Adds a new `skills/caveman-translate/SKILL.md` skill that translates wenyan (Classical Chinese) and caveman-compressed output back into clear English
- Updates `hooks/caveman-mode-tracker.js` to recognise `/caveman-translate` and write `translate` to the flag file — enabling the `[CAVEMAN:TRANSLATE]` statusline badge
- Non-Chinese speakers can now run in wenyan mode for maximum token savings and translate output on demand, instead of having to choose between comprehension and efficiency

## Verification

- [x] Baseline tests: 4 pass, 0 pre-existing failures
- [x] Post-fix tests: 6 pass, no regressions
- [x] New tests: 2 added (`test_translate_command_sets_translate_mode`, `test_translate_mode_statusline_badge`), both pass
- [x] JS syntax check: `node --check hooks/caveman-mode-tracker.js` passes
- [x] Contribution guidelines: minimal diff, only source file edited (not synced copies)

## Files changed

| File | Change |
|------|--------|
| `skills/caveman-translate/SKILL.md` | New skill: translation rules, examples, preservation constraints |
| `hooks/caveman-mode-tracker.js` | +2 lines: handle `/caveman-translate` → mode `translate` |
| `tests/test_hooks.py` | +2 tests covering mode tracking and statusline badge |