### PR TITLE
feat: add Antigravity agent support with auto-activation rules and do…

### DIFF
--- a/.agents/rules/caveman.md
+++ b/.agents/rules/caveman.md
@@ -1,0 +1,15 @@
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+Rules:
+- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
+- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
+- Pattern: [thing] [action] [reason]. [next step].
+- Not: "Sure! I'd be happy to help you with that."
+- Yes: "Bug in auth middleware. Fix:"
+
+Switch level: /caveman lite|full|ultra|wenyan
+Stop: "stop caveman" or "normal mode"
+
+Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
+
+Boundaries: code/commits/PRs written normal.

--- a/.github/workflows/sync-skill.yml
+++ b/.github/workflows/sync-skill.yml
@@ -71,6 +71,10 @@ jobs:
           printf '%s\n' '---' 'trigger: always_on' '---' '' > .windsurf/rules/caveman.md
           cat "$BODY" >> .windsurf/rules/caveman.md
 
+          # Antigravity — no frontmatter, direct copy (same as Cline)
+          mkdir -p .agents/rules
+          cp "$BODY" .agents/rules/caveman.md
+
       - name: Commit and push if changed
         run: |
           git add \
@@ -83,7 +87,8 @@ jobs:
             .clinerules/caveman.md \
             .github/copilot-instructions.md \
             .cursor/rules/caveman.mdc \
-            .windsurf/rules/caveman.md
+            .windsurf/rules/caveman.md \
+            .agents/rules/caveman.md
           git diff --staged --quiet && exit 0
           git commit -m "chore: sync SKILL.md copies and auto-activation rules [skip ci]"
           git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ README = product front door. Non-technical people read it to decide if caveman w
 
 ## Project overview
 
-Caveman makes AI coding agents respond in compressed caveman-style prose — cuts ~65-75% output tokens, full technical accuracy. Ships as Claude Code plugin, Codex plugin, Gemini CLI extension, agent rule files for Cursor, Windsurf, Cline, Copilot, 40+ others via `npx skills`.
+Caveman makes AI coding agents respond in compressed caveman-style prose — cuts ~65-75% output tokens, full technical accuracy. Ships as Claude Code plugin, Codex plugin, Gemini CLI extension, agent rule files for Cursor, Windsurf, Cline, Copilot, Antigravity, 40+ others via `npx skills`.
 
 ---
 
@@ -51,6 +51,7 @@ Overwritten by CI on push to main when sources change. Edits here lost.
 | `.github/copilot-instructions.md` | `rules/caveman-activate.md` |
 | `.cursor/rules/caveman.mdc` | `rules/caveman-activate.md` + Cursor frontmatter |
 | `.windsurf/rules/caveman.md` | `rules/caveman-activate.md` + Windsurf frontmatter |
+| `.agents/rules/caveman.md` | `rules/caveman-activate.md` |
 
 ---
 
@@ -158,6 +159,7 @@ How caveman reaches each agent type:
 | Windsurf | `.windsurf/rules/caveman.md` with `trigger: always_on` | Yes — always-on rule |
 | Cline | `.clinerules/caveman.md` (auto-discovered) | Yes — Cline injects all .clinerules files |
 | Copilot | `.github/copilot-instructions.md` + `AGENTS.md` | Yes — repo-wide instructions |
+| Antigravity | `.agents/rules/caveman.md` + `AGENTS.md` | Yes — workspace rule auto-discovered |
 | Others | `npx skills add JuliusBrussee/caveman` | No — user must say `/caveman` each session |
 
 For agents without hook systems, minimal always-on snippet lives in README under "Want it always on?" — keep current with `rules/caveman-activate.md`.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Pick your agent. One command. Done.
 | **Windsurf** | `npx skills add JuliusBrussee/caveman -a windsurf` |
 | **Copilot** | `npx skills add JuliusBrussee/caveman -a github-copilot` |
 | **Cline** | `npx skills add JuliusBrussee/caveman -a cline` |
+| **Antigravity** | `npx skills add JuliusBrussee/caveman -a antigravity` |
 | **Any other** | `npx skills add JuliusBrussee/caveman` |
 
 Install once. Use in every session for that install target after that. One rock. That it.
@@ -141,17 +142,17 @@ Install once. Use in every session for that install target after that. One rock.
 
 Auto-activation is built in for Claude Code, Gemini CLI, and the repo-local Codex setup below. `npx skills add` installs the skill for other agents, but does **not** install repo rule/instruction files, so Caveman does not auto-start there unless you add the always-on snippet below.
 
-| Feature | Claude Code | Codex | Gemini CLI | Cursor | Windsurf | Cline | Copilot |
-|---------|:-----------:|:-----:|:----------:|:------:|:--------:|:-----:|:-------:|
-| Caveman mode | Y | Y | Y | Y | Y | Y | Y |
-| Auto-activate every session | Y | Y¹ | Y | —² | —² | —² | —² |
-| `/caveman` command | Y | Y¹ | Y | — | — | — | — |
-| Mode switching (lite/full/ultra) | Y | Y¹ | Y | Y³ | Y³ | — | — |
-| Statusline badge | Y⁴ | — | — | — | — | — | — |
-| caveman-commit | Y | — | Y | Y | Y | Y | Y |
-| caveman-review | Y | — | Y | Y | Y | Y | Y |
-| caveman-compress | Y | Y | Y | Y | Y | Y | Y |
-| caveman-help | Y | — | Y | Y | Y | Y | Y |
+| Feature | Claude Code | Codex | Gemini CLI | Cursor | Windsurf | Cline | Copilot | Antigravity |
+|---------|:-----------:|:-----:|:----------:|:------:|:--------:|:-----:|:-------:|:-----------:|
+| Caveman mode | Y | Y | Y | Y | Y | Y | Y | Y |
+| Auto-activate every session | Y | Y¹ | Y | —² | —² | —² | —² | Y⁵ |
+| `/caveman` command | Y | Y¹ | Y | — | — | — | — | — |
+| Mode switching (lite/full/ultra) | Y | Y¹ | Y | Y³ | Y³ | — | — | Y³ |
+| Statusline badge | Y⁴ | — | — | — | — | — | — | — |
+| caveman-commit | Y | — | Y | Y | Y | Y | Y | Y |
+| caveman-review | Y | — | Y | Y | Y | Y | Y | Y |
+| caveman-compress | Y | Y | Y | Y | Y | Y | Y | Y |
+| caveman-help | Y | — | Y | Y | Y | Y | Y | Y |
 
 > [!NOTE]
 > Auto-activation works differently per agent: Claude Code uses SessionStart hooks, this repo's Codex dogfood setup uses `.codex/hooks.json`, Gemini uses context files. Cursor/Windsurf/Cline/Copilot can be made always-on, but `npx skills add` installs only the skill, not the repo rule/instruction files.
@@ -160,6 +161,7 @@ Auto-activation is built in for Claude Code, Gemini CLI, and the repo-local Code
 > ² Add the "Want it always on?" snippet below to those agents' system prompt or rule file if you want session-start activation.
 > ³ Cursor and Windsurf receive the full SKILL.md with all intensity levels. Mode switching works on-demand via the skill; no slash command.
 > ⁴ Available in Claude Code, but plugin install only nudges setup. Standalone `install.sh` / `install.ps1` configures it automatically when no custom `statusLine` exists.
+> ⁵ Antigravity auto-discovers `.agents/rules/caveman.md` as a workspace rule. Also reads `AGENTS.md` at repo root. Auto-activation works out of the box when skill is installed via `npx skills` or when cloning this repo.
 
 <details>
 <summary><strong>Claude Code — full details</strong></summary>
@@ -241,6 +243,25 @@ Copilot works with Chat, Edits, and Coding Agent.
 </details>
 
 <details>
+<summary><strong>Antigravity — full details</strong></summary>
+
+```bash
+npx skills add JuliusBrussee/caveman -a antigravity
+```
+
+Installs caveman skill files into your Antigravity workspace. Antigravity also reads `AGENTS.md` and `GEMINI.md` at the project root, so cloning this repo activates caveman automatically.
+
+**Workspace rules:** Antigravity loads `.agents/rules/caveman.md` as an always-on workspace rule. The skill is active from your first message.
+
+**Mode switching:** Say `/caveman lite`, `/caveman ultra`, or `/caveman wenyan` to change intensity. Works on-demand via the skill; no slash command system.
+
+**Custom rules:** You can also add caveman to your global rules at `~/.gemini/GEMINI.md` for activation across all workspaces.
+
+Uninstall: `npx skills remove caveman`
+
+</details>
+
+<details>
 <summary><strong>Any other agent (opencode, Roo, Amp, Goose, Kiro, and 40+ more)</strong></summary>
 
 [npx skills](https://github.com/vercel-labs/skills) supports 40+ agents:
@@ -276,6 +297,7 @@ Where to put it:
 | Agent | File |
 |-------|------|
 | opencode | `.config/opencode/AGENTS.md` |
+| Antigravity | `.agents/rules/caveman.md` |
 | Roo | `.roo/rules/caveman.md` |
 | Amp | your workspace system prompt |
 | Others | your agent's system prompt or rules file |


### PR DESCRIPTION
Adds support for the Google Antigravity IDE. 

Antigravity operates on a workspace rules system (`.agents/rules/`). Since rule application works without strict frontmatter (similar to Cline and Copilot), this PR sets up the auto-activation rule and documents the `npx skills` installation path.

Changes:
- Rule Architecture: Added `.agents/rules/caveman.md` to trigger the agent automatically upon startup.
- CI Sync Update: Modified `.github/workflows/sync-skill.yml` to ensure `.agents/rules/caveman.md` is synced whenever `rules/caveman-activate.md` changes. 
- Doc Updates: Added Antigravity to the install table and feature matrix in `README.md`. Includes a `<details>` block with full installation, mode-switching, and uninstall instructions. Updated `CLAUDE.md` to map the new IDE distribution paths.

Validation:
- Verified Antigravity correctly indexes `.md` files in `.agents/rules/` out of the box without proprietary YAML frontmatter.
- Validated YAML syntax in the CI workflow update.
