### PR TITLE
feat: add Spanish language support to caveman skill  

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -18,12 +18,12 @@ Default: **full**. Switch: `/caveman lite|full|ultra`.
 
 ## Rules
 
-Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+Drop: artículos (un/una/el/la/los/las/unos/unas), relleno (básicamente/realmente/simplemente/obviamente/totalmente), cortesías (claro/por supuesto/encantado/con gusto), rodeos. Fragmentos OK. Sinónimos cortos (grande no extenso, arreglar no "implementar una solución para"). Términos técnicos exactos. Bloques de código sin cambios. Errores citados exactos.
 
-Pattern: `[thing] [action] [reason]. [next step].`
+Patrón: `[cosa] [acción] [razón]. [siguiente paso].`
 
-Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
-Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+No: "¡Claro! Con gusto te ayudo con eso. El problema que estás experimentando probablemente se debe a..."
+Sí: "Bug en middleware auth. Verificación expiración token usa `<` no `<=`. Fix:"
 
 ## Intensity
 
@@ -36,31 +36,31 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 | **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
 
-Example — "Why React component re-render?"
-- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
-- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
-- ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+Ejemplo — "¿Por qué el componente React vuelve a renderizarse?"
+- lite: "El componente se vuelve a renderizar porque creas una nueva referencia de objeto en cada renderizado. Envuélvelo en `useMemo`."
+- full: "Nueva ref objeto cada render. Prop objeto inline = nueva ref = re-render. Envolver en `useMemo`."
+- ultra: "Prop obj inline → nueva ref → re-render. `useMemo`."
 - wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
-- wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
+- wenyan-full: "物出新參照，致重繪。useMemo Wrap之。"
 - wenyan-ultra: "新參照→重繪。useMemo Wrap。"
 
-Example — "Explain database connection pooling."
-- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
-- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
-- ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
+Ejemplo — "Explica el pool de conexiones de base de datos."
+- lite: "El pool de conexiones reutiliza conexiones abiertas en vez de crear nuevas por cada petición. Evita el overhead del handshake repetido."
+- full: "Pool reutiliza conexiones DB abiertas. Sin nueva conexión por petición. Sin overhead handshake."
+- ultra: "Pool = reutilizar conn DB. Sin handshake → rápido bajo carga."
 - wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
 - wenyan-ultra: "池reuse conn。skip handshake → fast。"
 
 ## Auto-Clarity
 
-Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.
+Drop caveman for: avisos de seguridad, confirmaciones de acciones irreversibles, secuencias multi-paso donde fragmentos ambiguos arriesgan mala lectura, usuario pide aclaración o repite pregunta. Resume caveman después de parte clara.
 
-Example — destructive op:
-> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+Ejemplo — operación destructiva:
+> **Advertencia:** Esto eliminará permanentemente todas las filas de la tabla `users` y no se puede deshacer.
 > ```sql
 > DROP TABLE users;
 > ```
-> Caveman resume. Verify backup exist first.
+> Caveman resume. Verificar backup existe primero.
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary  
Add Spanish language support to the caveman token compression skill by replacing English linguistic rules with Spanish equivalents.  
  
## Changes Made  
  
### Core Linguistic Rules  
- **Articles**: `a/an/the` → `un/una/el/la/los/las/unos/unas`  
- **Filler words**: `just/really/basically/actually/simply` → `básicamente/realmente/simplemente/obviamente/totalmente`  
- **Pleasantries**: `sure/certainly/of course/happy to` → `claro/por supuesto/encantado/con gusto`  
  
### Files Modified  
- `skills/caveman/SKILL.md` - Primary skill definition with Spanish compression rules [1](#4-0)   
- `plugins/caveman/skills/caveman/SKILL.md` - Auto-synced by workflow [2](#4-1)   
- `caveman/SKILL.md` - Auto-synced by workflow  
- `caveman.skill` - Rebuilt ZIP archive  
  
### Example Transformations  
**Before (English):**