### PR TITLE
fix: per-turn reinforcement in UserPromptSubmit hook

### DIFF
--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -56,17 +56,23 @@ process.stdin.on('end', () => {
     // The SessionStart hook injects the full ruleset once, but models lose it
     // when other plugins inject competing style instructions every turn.
     // This keeps caveman visible in the model's attention on every user message.
+    //
+    // Skip independent modes (commit, review, compress) — they have their own
+    // skill behavior and the base caveman rules would conflict.
+    const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
     try {
       if (fs.existsSync(flagPath)) {
         const activeMode = fs.readFileSync(flagPath, 'utf8').trim() || 'full';
-        process.stdout.write(JSON.stringify({
-          hookSpecificOutput: {
-            hookEventName: "UserPromptSubmit",
-            additionalContext: "CAVEMAN MODE ACTIVE (" + activeMode + "). " +
-              "Drop articles/filler/pleasantries/hedging. Fragments OK. " +
-              "Code/commits/security: write normal."
-          }
-        }));
+        if (!INDEPENDENT_MODES.has(activeMode)) {
+          process.stdout.write(JSON.stringify({
+            hookSpecificOutput: {
+              hookEventName: "UserPromptSubmit",
+              additionalContext: "CAVEMAN MODE ACTIVE (" + activeMode + "). " +
+                "Drop articles/filler/pleasantries/hedging. Fragments OK. " +
+                "Code/commits/security: write normal."
+            }
+          }));
+        }
       }
     } catch (e) {
       // Silent fail — reinforcement is best-effort

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -51,6 +51,26 @@ process.stdin.on('end', () => {
     if (/\b(stop caveman|normal mode)\b/i.test(prompt)) {
       try { fs.unlinkSync(flagPath); } catch (e) {}
     }
+
+    // Per-turn reinforcement: emit a structured reminder when caveman is active.
+    // The SessionStart hook injects the full ruleset once, but models lose it
+    // when other plugins inject competing style instructions every turn.
+    // This keeps caveman visible in the model's attention on every user message.
+    try {
+      if (fs.existsSync(flagPath)) {
+        const activeMode = fs.readFileSync(flagPath, 'utf8').trim() || 'full';
+        process.stdout.write(JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "UserPromptSubmit",
+            additionalContext: "CAVEMAN MODE ACTIVE (" + activeMode + "). " +
+              "Drop articles/filler/pleasantries/hedging. Fragments OK. " +
+              "Code/commits/security: write normal."
+          }
+        }));
+      }
+    } catch (e) {
+      // Silent fail — reinforcement is best-effort
+    }
   } catch (e) {
     // Silent fail
   }


### PR DESCRIPTION
## The problem

Caveman's SessionStart hook injects the full ruleset once per session. This works great in isolation, but falls apart when other plugins inject competing style instructions on every turn.

I run caveman alongside an output-style plugin (explanatory mode). That plugin emits a style reminder via `<system-reminder>` on every user message. Caveman's one-shot injection from SessionStart quietly loses the priority fight — the model sees "be educational and verbose" on every turn but only saw "drop articles, fragments OK" once at the start. As it turns out, recency and repetition win in LLM attention. Caveman was active but the model wrote full verbose prose anyway.

## The fix

The mode-tracker hook already fires on every `UserPromptSubmit` — it just didn't emit anything. This adds a short structured reminder (via `hookSpecificOutput`) when the flag file exists. The full rules from SessionStart stay in context; this simply keeps them visible in the model's attention window.

The reminder uses the same `hookSpecificOutput.additionalContext` JSON format that Claude Code expects from hooks — no raw stdout.

## What changes

`hooks/caveman-mode-tracker.js`: after processing mode changes and deactivation, checks if the flag file exists and emits a one-line reinforcement. Silent-fails on all filesystem errors, same as existing code.

## Testing

Ran with an active output-style plugin that previously caused caveman to be ignored. With the reinforcement, caveman style persists across turns.