### PR TITLE
fix: natural language activation/deactivation in mode tracker

### DIFF
--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -22,8 +22,11 @@ process.stdin.on('end', () => {
     if (/\b(activate|enable|turn on|start|talk like)\b.*\bcaveman\b/i.test(prompt) ||
         /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt)) {
       if (!/\b(stop|disable|turn off|deactivate)\b/i.test(prompt)) {
-        fs.mkdirSync(path.dirname(flagPath), { recursive: true });
-        fs.writeFileSync(flagPath, getDefaultMode());
+        const mode = getDefaultMode();
+        if (mode !== 'off') {
+          fs.mkdirSync(path.dirname(flagPath), { recursive: true });
+          fs.writeFileSync(flagPath, mode);
+        }
       }
     }
 

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -16,6 +16,17 @@ process.stdin.on('end', () => {
     const data = JSON.parse(input);
     const prompt = (data.prompt || '').trim().toLowerCase();
 
+    // Natural language activation (e.g. "activate caveman", "turn on caveman mode",
+    // "talk like caveman"). README tells users they can say these, but the hook
+    // only matched /caveman commands — flag file and statusline stayed out of sync.
+    if (/\b(activate|enable|turn on|start|talk like)\b.*\bcaveman\b/i.test(prompt) ||
+        /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt)) {
+      if (!/\b(stop|disable|turn off|deactivate)\b/i.test(prompt)) {
+        fs.mkdirSync(path.dirname(flagPath), { recursive: true });
+        fs.writeFileSync(flagPath, getDefaultMode());
+      }
+    }
+
     // Match /caveman commands
     if (prompt.startsWith('/caveman')) {
       const parts = prompt.split(/\s+/);
@@ -47,8 +58,10 @@ process.stdin.on('end', () => {
       }
     }
 
-    // Detect deactivation
-    if (/\b(stop caveman|normal mode)\b/i.test(prompt)) {
+    // Detect deactivation — natural language and slash commands
+    if (/\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/i.test(prompt) ||
+        /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/i.test(prompt) ||
+        /\bnormal mode\b/i.test(prompt)) {
       try { fs.unlinkSync(flagPath); } catch (e) {}
     }
   } catch (e) {


### PR DESCRIPTION
## The problem

The README tells users they can say "talk like caveman" to activate. And they can — the model reads the prompt and starts speaking caveman. But the `UserPromptSubmit` hook only matched `/caveman` commands, so the flag file never got written and the statusline badge never appeared.

In other words: the model was in caveman mode, but the hook system didn't know about it. The flag file and statusline were out of sync with actual behavior.

## The fix

The mode-tracker now matches natural language activation phrases: "activate caveman", "turn on caveman mode", "talk like caveman", "enable caveman", etc. Same for deactivation: "stop caveman", "disable caveman", "turn off caveman mode".

A negative guard prevents "stop caveman" from triggering activation (it contains "caveman" after all). Deactivation runs after activation in the control flow, so even if both somehow matched, deactivation wins.

Natural language activation uses `getDefaultMode()` to respect `CAVEMAN_DEFAULT_MODE` and `config.json`, same as the `/caveman` command path.

## What changes

`hooks/caveman-mode-tracker.js`:
- New natural language activation block before the `/caveman` command block
- Expanded deactivation regex to match "disable", "deactivate", "turn off" in addition to existing "stop caveman" and "normal mode"