### PR TITLE
refactor: use FileType enum instead of raw strings in detect_file_type

### DIFF
--- a/caveman-compress/scripts/cli.py
+++ b/caveman-compress/scripts/cli.py
@@ -38,7 +38,7 @@ def main():
     # Detect file type
     file_type = detect_file_type(filepath)
 
-    print(f"Detected: {file_type}")
+    print(f"Detected: {file_type.name}")
 
     # Check if compressible
     if not should_compress(filepath):

--- a/caveman-compress/scripts/detect.py
+++ b/caveman-compress/scripts/detect.py
@@ -4,6 +4,14 @@
 import json
 import re
 from pathlib import Path
+from enum import Enum
+
+class FileType(Enum):
+    NaturalLanguage = 1
+    Code = 2
+    Config = 3
+    Unknown = 4
+
 
 # Extensions that are natural language and compressible
 COMPRESSIBLE_EXTENSIONS = {".md", ".txt", ".markdown", ".rst"}
@@ -59,42 +67,42 @@ def _is_yaml_content(lines: list[str]) -> bool:
     return non_empty > 0 and yaml_indicators / non_empty > 0.6
 
 
-def detect_file_type(filepath: Path) -> str:
-    """Classify a file as 'natural_language', 'code', 'config', or 'unknown'.
+def detect_file_type(filepath: Path) -> FileType:
+    """Classify a file as a FileType enum value.
 
     Returns:
-        One of: 'natural_language', 'code', 'config', 'unknown'
+        FileType.NaturalLanguage, FileType.Code, FileType.Config, or FileType.Unknown
     """
     ext = filepath.suffix.lower()
 
     # Extension-based classification
     if ext in COMPRESSIBLE_EXTENSIONS:
-        return "natural_language"
+        return FileType.NaturalLanguage
     if ext in SKIP_EXTENSIONS:
-        return "code" if ext not in {".json", ".yaml", ".yml", ".toml", ".ini", ".cfg", ".env"} else "config"
+        return FileType.Code if ext not in {".json", ".yaml", ".yml", ".toml", ".ini", ".cfg", ".env"} else FileType.Config
 
     # Extensionless files (like CLAUDE.md, TODO) — check content
     if not ext:
         try:
             text = filepath.read_text(errors="ignore")
         except (OSError, PermissionError):
-            return "unknown"
+            return FileType.Unknown
 
         lines = text.splitlines()[:50]
 
         if _is_json_content(text[:10000]):
-            return "config"
+            return FileType.Config
         if _is_yaml_content(lines):
-            return "config"
+            return FileType.Config
 
         code_lines = sum(1 for l in lines if l.strip() and _is_code_line(l))
         non_empty = sum(1 for l in lines if l.strip())
         if non_empty > 0 and code_lines / non_empty > 0.4:
-            return "code"
+            return FileType.Code
 
-        return "natural_language"
+        return FileType.NaturalLanguage
 
-    return "unknown"
+    return FileType.Unknown
 
 
 def should_compress(filepath: Path) -> bool:
@@ -104,7 +112,7 @@ def should_compress(filepath: Path) -> bool:
     # Skip backup files
     if filepath.name.endswith(".original.md"):
         return False
-    return detect_file_type(filepath) == "natural_language"
+    return detect_file_type(filepath) == FileType.NaturalLanguage
 
 
 if __name__ == "__main__":
@@ -118,4 +126,4 @@ if __name__ == "__main__":
         p = Path(path_str).resolve()
         file_type = detect_file_type(p)
         compress = should_compress(p)
-        print(f"  {p.name:30s} type={file_type:20s} compress={compress}")
+        print(f"  {p.name:30s} type={file_type.name:20s} compress={compress}")


### PR DESCRIPTION
Replace raw string returns in detect_file_type with a FileType enum. Instead of returning "natural_language", "code", "config", "unknown" as plain strings, the function now returns a FileType enum value. Updated all return sites in detect.py, the should_compress comparison, the display in cli.py, and the function docstring. No breaking changes.