### PR TITLE
feat: add Copilot instruction template file

### DIFF
--- a/.github/instructions/caveman.instructions.md
+++ b/.github/instructions/caveman.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: "**"
+description: "Always-on compressed response mode for GitHub Copilot in this repository. Enforce persistent caveman style, runtime mode switching (/caveman ...), and explicit off command."
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+Rules:
+- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
+- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
+- Pattern: [thing] [action] [reason]. [next step].
+- Not: "Sure! I'd be happy to help you with that."
+- Yes: "Bug in auth middleware. Fix:"
+
+Switch level: /caveman lite|full|ultra|wenyan
+Stop: "stop caveman" or "normal mode"
+
+Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
+
+Boundaries: code/commits/PRs written normal.

--- a/.github/workflows/sync-skill.yml
+++ b/.github/workflows/sync-skill.yml
@@ -56,10 +56,14 @@ jobs:
         run: |
           BODY="rules/caveman-activate.md"
 
-          # Cline + Copilot — no frontmatter, direct copy
-          mkdir -p .clinerules .github
+          # Cline + Copilot workspace instructions — no frontmatter, direct copy
+          mkdir -p .clinerules .github .github/instructions
           cp "$BODY" .clinerules/caveman.md
           cp "$BODY" .github/copilot-instructions.md
+
+          # Copilot file instruction template for easy post-install copy
+          printf '%s\n' '---' 'applyTo: "**"' 'description: "Always-on compressed response mode for GitHub Copilot in this repository. Enforce persistent caveman style, runtime mode switching (/caveman ...), and explicit off command."' '---' '' > .github/instructions/caveman.instructions.md
+          cat "$BODY" >> .github/instructions/caveman.instructions.md
 
           # Cursor — needs alwaysApply frontmatter
           mkdir -p .cursor/rules
@@ -82,6 +86,7 @@ jobs:
             caveman.skill \
             .clinerules/caveman.md \
             .github/copilot-instructions.md \
+            .github/instructions/caveman.instructions.md \
             .cursor/rules/caveman.mdc \
             .windsurf/rules/caveman.md
           git diff --staged --quiet && exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Overwritten by CI on push to main when sources change. Edits here lost.
 | `caveman.skill` | ZIP of `skills/caveman/` directory |
 | `.clinerules/caveman.md` | `rules/caveman-activate.md` |
 | `.github/copilot-instructions.md` | `rules/caveman-activate.md` |
+| `.github/instructions/caveman.instructions.md` | Frontmatter + `rules/caveman-activate.md` |
 | `.cursor/rules/caveman.mdc` | `rules/caveman-activate.md` + Cursor frontmatter |
 | `.windsurf/rules/caveman.md` | `rules/caveman-activate.md` + Windsurf frontmatter |
 
@@ -61,7 +62,7 @@ Overwritten by CI on push to main when sources change. Edits here lost.
 What it does:
 1. Copies `skills/caveman/SKILL.md` to all agent-specific SKILL.md locations
 2. Rebuilds `caveman.skill` as a ZIP of `skills/caveman/`
-3. Rebuilds all agent rule files from `rules/caveman-activate.md`, prepending agent-specific frontmatter (Cursor needs `alwaysApply: true`, Windsurf needs `trigger: always_on`)
+3. Rebuilds all agent rule files from `rules/caveman-activate.md`, prepending agent-specific frontmatter (Cursor needs `alwaysApply: true`, Windsurf needs `trigger: always_on`) and generates `.github/instructions/caveman.instructions.md`
 4. Commits and pushes with `[skip ci]` to avoid loops
 
 CI bot commits as `github-actions[bot]`. After PR merge, wait for workflow before declaring release complete.
@@ -157,7 +158,7 @@ How caveman reaches each agent type:
 | Cursor | `.cursor/rules/caveman.mdc` with `alwaysApply: true` | Yes — always-on rule |
 | Windsurf | `.windsurf/rules/caveman.md` with `trigger: always_on` | Yes — always-on rule |
 | Cline | `.clinerules/caveman.md` (auto-discovered) | Yes — Cline injects all .clinerules files |
-| Copilot | `.github/copilot-instructions.md` + `AGENTS.md` | Yes — repo-wide instructions |
+| Copilot | `.github/instructions/caveman.instructions.md` (recommended) or `.github/copilot-instructions.md` + `AGENTS.md` | Yes — repo-wide instructions |
 | Others | `npx skills add JuliusBrussee/caveman` | No — user must say `/caveman` each session |
 
 For agents without hook systems, minimal always-on snippet lives in README under "Want it always on?" — keep current with `rules/caveman-activate.md`.

--- a/CLAUDE.original.md
+++ b/CLAUDE.original.md
@@ -48,6 +48,7 @@ These files are overwritten by CI on every push to main that touches the sources
 | `caveman.skill` | ZIP of `skills/caveman/` directory |
 | `.clinerules/caveman.md` | `rules/caveman-activate.md` |
 | `.github/copilot-instructions.md` | `rules/caveman-activate.md` |
+| `.github/instructions/caveman.instructions.md` | Frontmatter + `rules/caveman-activate.md` |
 | `.cursor/rules/caveman.mdc` | `rules/caveman-activate.md` + Cursor frontmatter |
 | `.windsurf/rules/caveman.md` | `rules/caveman-activate.md` + Windsurf frontmatter |
 
@@ -60,7 +61,7 @@ These files are overwritten by CI on every push to main that touches the sources
 What it does:
 1. Copies `skills/caveman/SKILL.md` to all agent-specific SKILL.md locations
 2. Rebuilds `caveman.skill` as a ZIP of `skills/caveman/`
-3. Rebuilds all agent rule files from `rules/caveman-activate.md`, prepending the agent-specific frontmatter (Cursor needs `alwaysApply: true`, Windsurf needs `trigger: always_on`)
+3. Rebuilds all agent rule files from `rules/caveman-activate.md`, prepending the agent-specific frontmatter (Cursor needs `alwaysApply: true`, Windsurf needs `trigger: always_on`) and generates `.github/instructions/caveman.instructions.md`
 4. Commits and pushes with `[skip ci]` to avoid loops
 
 The CI bot commits as `github-actions[bot]`. After a PR merges, wait for this workflow before declaring the release complete.
@@ -156,7 +157,7 @@ How caveman reaches each agent type:
 | Cursor | `.cursor/rules/caveman.mdc` with `alwaysApply: true` | Yes — always-on rule |
 | Windsurf | `.windsurf/rules/caveman.md` with `trigger: always_on` | Yes — always-on rule |
 | Cline | `.clinerules/caveman.md` (auto-discovered) | Yes — Cline injects all .clinerules files |
-| Copilot | `.github/copilot-instructions.md` + `AGENTS.md` | Yes — repo-wide instructions |
+| Copilot | `.github/instructions/caveman.instructions.md` (recommended) or `.github/copilot-instructions.md` + `AGENTS.md` | Yes — repo-wide instructions |
 | Others | `npx skills add JuliusBrussee/caveman` | No — user must say `/caveman` each session |
 
 For agents without hook systems, the minimal always-on snippet lives in README under "Want it always on?" — keep it current with `rules/caveman-activate.md`.

--- a/README.md
+++ b/README.md
@@ -225,16 +225,28 @@ Auto-activates via `GEMINI.md` context file. Also ships custom Gemini commands:
 <details>
 <summary><strong>Cursor / Windsurf / Cline / Copilot — full details</strong></summary>
 
-`npx skills add` installs the skill file only — it does **not** install the agent's rule/instruction file, so caveman does not auto-start. For always-on, add the "Want it always on?" snippet below to your agent's rules or system prompt.
+`npx skills add` installs the skill file only — it does **not** install the agent's rule/instruction file, so caveman does not auto-start. For always-on, add the "Want it always on?" snippet below to your agent's rules or system prompt. Copilot also has a ready-made file-instruction template: [`.github/instructions/caveman.instructions.md`](.github/instructions/caveman.instructions.md).
 
 | Agent | Command | Not installed | Mode switching | Always-on location |
 |-------|---------|--------------|:--------------:|--------------------|
 | Cursor | `npx skills add JuliusBrussee/caveman -a cursor` | `.cursor/rules/caveman.mdc` | Y | Cursor rules |
 | Windsurf | `npx skills add JuliusBrussee/caveman -a windsurf` | `.windsurf/rules/caveman.md` | Y | Windsurf rules |
 | Cline | `npx skills add JuliusBrussee/caveman -a cline` | `.clinerules/caveman.md` | — | Cline rules or system prompt |
-| Copilot | `npx skills add JuliusBrussee/caveman -a github-copilot` | `.github/copilot-instructions.md` + `AGENTS.md` | — | Copilot custom instructions |
+| Copilot | `npx skills add JuliusBrussee/caveman -a github-copilot` | `.github/instructions/caveman.instructions.md` (recommended) or `.github/copilot-instructions.md` + `AGENTS.md` | — | Copilot custom instructions |
 
 Uninstall: `npx skills remove caveman`
+
+Copilot always-on quick copy:
+
+```bash
+# macOS / Linux
+mkdir -p .github/instructions
+curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/.github/instructions/caveman.instructions.md -o .github/instructions/caveman.instructions.md
+
+# Windows (PowerShell)
+New-Item -ItemType Directory -Force .github/instructions | Out-Null
+Invoke-WebRequest https://raw.githubusercontent.com/JuliusBrussee/caveman/main/.github/instructions/caveman.instructions.md -OutFile .github/instructions/caveman.instructions.md
+```
 
 Copilot works with Chat, Edits, and Coding Agent.
 

--- a/tests/verify_repo.py
+++ b/tests/verify_repo.py
@@ -81,6 +81,19 @@ def verify_synced_files() -> None:
     for copy in rule_copies:
         ensure(copy.read_text() == rule_source.read_text(), f"Rule copy mismatch: {copy}")
 
+    copilot_instruction = ROOT / ".github/instructions/caveman.instructions.md"
+    expected_copilot_instruction = (
+        "---\n"
+        'applyTo: "**"\n'
+        'description: "Always-on compressed response mode for GitHub Copilot in this repository. Enforce persistent caveman style, runtime mode switching (/caveman ...), and explicit off command."\n'
+        "---\n\n"
+        f"{rule_source.read_text()}"
+    )
+    ensure(
+        copilot_instruction.read_text() == expected_copilot_instruction,
+        f"Copilot instruction template mismatch: {copilot_instruction}",
+    )
+
     with zipfile.ZipFile(ROOT / "caveman.skill") as archive:
         ensure("caveman/SKILL.md" in archive.namelist(), "caveman.skill missing caveman/SKILL.md")
         ensure(


### PR DESCRIPTION
## Summary
- add .github/instructions/caveman.instructions.md as a Copilot-ready always-on template
- update sync workflow to generate this template from rules/caveman-activate.md
- extend tests/verify_repo.py to verify template stays synchronized
- update README Copilot install details with template path + quick copy commands
- align CLAUDE.md and CLAUDE.original.md sync/distribution docs

## Validation
- ran targeted synced-file verification: PYTHONUTF8=1 d:/Development/caveman/.venv/Scripts/python.exe -c "from tests.verify_repo import verify_synced_files; verify_synced_files()" (pass)
- full tests/verify_repo.py currently fails in this Windows shell at bash -n hooks/install.sh due existing CRLF line-ending issue in hooks/install.sh (pre-existing, unrelated)
