### PR TITLE
feat: add Thai language auto-detection and filler compression rules

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -3,7 +3,7 @@ name: caveman
 description: >
   Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
   while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
-  wenyan-lite, wenyan-full, wenyan-ultra.
+  wenyan-lite, wenyan-full, wenyan-ultra. Auto-detects Thai language and applies Thai filler rules.
   Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
   "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
 ---
@@ -43,6 +43,9 @@ Example — "Why React component re-render?"
 - wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
 - wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
 - wenyan-ultra: "新參照→重繪。useMemo Wrap。"
+- thai-lite: "Component re-render เพราะสร้าง object reference ใหม่ทุก render ต้อง wrap ด้วย `useMemo`."
+- thai-full: "Object ref ใหม่ทุก render. Inline prop = ref ใหม่ = re-render. ใช้ `useMemo`."
+- thai-ultra: "Inline prop → ref ใหม่ → re-render. `useMemo`."
 
 Example — "Explain database connection pooling."
 - lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
@@ -50,6 +53,17 @@ Example — "Explain database connection pooling."
 - ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
 - wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
 - wenyan-ultra: "池reuse conn。skip handshake → fast。"
+- thai-lite: "Pool ใช้ connection เดิมซ้ำแทนการสร้างใหม่ทุก request หลีกเลี่ยง handshake overhead."
+- thai-full: "Pool reuse DB connection. ไม่เปิดใหม่ทุก request. Skip handshake."
+- thai-ultra: "Pool = reuse conn. Skip handshake → fast."
+
+## Thai Language
+
+Auto-detect: when user writes in Thai or response is in Thai, apply Thai filler rules at current intensity level (lite/full/ultra). No mode switch needed — language detection is automatic.
+
+Drop (always safe): ก็ (padding "also/just"), อะ/อ่ะ/วะ (informal sentence particles), นะ (softener), เออ (opener filler), แบบว่า/แบบ (hedge "like"), ก็คือ (intro starter), แล้วก็ (redundant clause chaining), เลย (trailing emphasis particle), อยู่ (trailing stative particle), ถ้าเกิดว่า→ถ้า (verbose conditional), เหรอ/เหรอวะ (question particles)
+
+Keep (context-dependent): คือ (when = definition/meaning), แค่ (when meaningful limit), น่าจะ (genuine uncertainty), ใช่ไหม (seeking confirmation)
 
 ## Auto-Clarity
 


### PR DESCRIPTION
## What this adds

When the user writes in Thai, caveman now automatically detects it and applies Thai-specific filler rules at the current intensity level (lite/full/ultra). No `/caveman thai` command needed — language detection is automatic. Same principle as wenyan for Chinese, but Thai-specific.

## How the filler list was derived

The drop list wasn't guessed — it was derived from analysis of real Thai-language conversations in actual Claude Code sessions. Extracted user messages containing Thai text, counted frequency, and verified which words carry zero semantic payload vs. which are context-dependent.

**Top Thai fillers found (ranked by frequency in real usage):**

| Word/Phrase | What it is | Safe to always drop? |
|---|---|---|
| ก็ | Padding softener "also/just" | Yes |
| อะ/อ่ะ/วะ | Informal sentence particles | Yes |
| นะ | Softener particle | Yes |
| เออ | Opener filler "yeah/uh" | Yes |
| แบบว่า/แบบ | Hedge "like" | Yes |
| ก็คือ | Intro starter "well, it is..." | Yes |
| แล้วก็ | Redundant clause chaining | Yes |
| เลย | Trailing emphasis | Yes |
| อยู่ | Trailing stative particle | Yes |
| ถ้าเกิดว่า | Verbose conditional → ถ้า | Yes (shorten) |
| เหรอ/เหรอวะ | Question particles | Yes |

Context-dependent (keep when meaningful): `คือ` (definition), `แค่` (meaningful limit), `น่าจะ` (genuine uncertainty), `ใช่ไหม` (seeking confirmation).

## Before / After

**"ทำไม React component ถึง re-render?"**

Without caveman:
> "อ่ะ คือก็แบบว่า component มันก็ re-render เพราะว่ามันก็สร้าง object reference ใหม่ทุกครั้งเลยนะครับ ก็น่าจะลองใช้ useMemo ดูนะครับ"

With Thai caveman (full):
> "Object ref ใหม่ทุก render. Inline prop = ref ใหม่ = re-render. ใช้ `useMemo`."

**"อธิบาย database connection pooling"**

Without caveman:
> "ก็คือแบบว่า pool มันก็ reuse connection เดิมอยู่แล้วนะครับ ก็เลยไม่ต้องเปิดใหม่ทุก request เลยนะครับ ก็ skip handshake overhead ได้"

With Thai caveman (full):
> "Pool reuse DB connection. ไม่เปิดใหม่ทุก request. Skip handshake."

## Changes

- `skills/caveman/SKILL.md`: Added `## Thai Language` section with auto-detect rule, drop list, keep list, and two worked examples (lite/full/ultra) for both existing example prompts

Only `skills/caveman/SKILL.md` edited (source of truth per CLAUDE.md — CI syncs all derived files on merge).