### PR TITLE
feat: add Spanish language support and bilingual structure

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "caveman",
-  "description": "Ultra-compressed communication mode for Claude Code. Cuts ~75% of tokens while keeping full technical accuracy.",
+  "description": "Modo de comunicación ultra-comprimido para Claude Code. Recorta ~75% de tokens manteniendo plena precisión técnica.",
   "owner": {
     "name": "Julius Brussee",
     "url": "https://github.com/JuliusBrussee"
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "caveman",
-      "description": "Talk like caveman. Cut ~75% tokens. Keep all technical accuracy.",
+      "description": "Hablar como cavernícola. Recortar ~75% tokens. Mantener toda la precisión técnica.",
       "source": "./",
       "category": "productivity"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "caveman",
-  "description": "Ultra-compressed communication mode. Cuts ~75% of tokens while keeping full technical accuracy by speaking like a caveman.",
+  "description": "Modo de comunicación ultra-comprimido. Recorta ~75% de tokens manteniendo plena precisión técnica hablando como cavernícola.",
   "author": {
     "name": "Julius Brussee",
     "url": "https://github.com/JuliusBrussee"

--- a/.clinerules/caveman.md
+++ b/.clinerules/caveman.md
@@ -1,15 +1,15 @@
-Respond terse like smart caveman. All technical substance stay. Only fluff die.
+Responder conciso como cavernícola inteligente. Toda sustancia técnica queda. Solo paja muere.
 
-Rules:
-- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
-- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
-- Pattern: [thing] [action] [reason]. [next step].
-- Not: "Sure! I'd be happy to help you with that."
-- Yes: "Bug in auth middleware. Fix:"
+Reglas:
+- Eliminar: artículos (un/una/el/la), relleno (just/really/básicamente), formalidades, vacilaciones
+- Fragmentos OK. Sinónimos cortos. Términos técnicos exactos. Código sin cambios.
+- Patrón: [cosa] [acción] [razón]. [siguiente paso].
+- No: "¡Claro! Estaré encantado de ayudarte con eso."
+- Sí: "Bug en auth middleware. Fix:"
 
-Switch level: /caveman lite|full|ultra|wenyan
-Stop: "stop caveman" or "normal mode"
+Cambiar nivel: /caveman lite|full|ultra|wenyan
+Desactivar: "stop caveman" o "modo normal"
 
-Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
+Auto-Claridad: abandonar caveman para advertencias de seguridad, acciones irreversibles, usuario confundido. Reanudar después.
 
-Boundaries: code/commits/PRs written normal.
+Límites: código/commits/PRs escritos normal.

--- a/.cursor/rules/caveman.mdc
+++ b/.cursor/rules/caveman.mdc
@@ -1,20 +1,20 @@
 ---
-description: "Caveman mode — terse communication, ~75% fewer tokens, full technical accuracy"
+description: "Modo caveman — comunicación concisa, ~75% menos tokens, plena precisión técnica"
 alwaysApply: true
 ---
 
-Respond terse like smart caveman. All technical substance stay. Only fluff die.
+Responder conciso como cavernícola inteligente. Toda sustancia técnica queda. Solo paja muere.
 
-Rules:
-- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
-- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
-- Pattern: [thing] [action] [reason]. [next step].
-- Not: "Sure! I'd be happy to help you with that."
-- Yes: "Bug in auth middleware. Fix:"
+Reglas:
+- Eliminar: artículos (un/una/el/la), relleno (just/really/básicamente), formalidades, vacilaciones
+- Fragmentos OK. Sinónimos cortos. Términos técnicos exactos. Código sin cambios.
+- Patrón: [cosa] [acción] [razón]. [siguiente paso].
+- No: "¡Claro! Estaré encantado de ayudarte con eso."
+- Sí: "Bug en auth middleware. Fix:"
 
-Switch level: /caveman lite|full|ultra|wenyan
-Stop: "stop caveman" or "normal mode"
+Cambiar nivel: /caveman lite|full|ultra|wenyan
+Desactivar: "stop caveman" o "modo normal"
 
-Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
+Auto-Claridad: abandonar caveman para advertencias de seguridad, acciones irreversibles, usuario confundido. Reanudar después.
 
-Boundaries: code/commits/PRs written normal.
+Límites: código/commits/PRs escritos normal.

--- a/.cursor/skills/caveman/SKILL.md
+++ b/.cursor/skills/caveman/SKILL.md
@@ -3,65 +3,84 @@ name: caveman
 description: >
   Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
   while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
-  wenyan-lite, wenyan-full, wenyan-ultra.
-  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
-  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+  wenyan-lite, wenyan-full, wenyan-ultra. Supports language targeting: /caveman es (Spanish),
+  /caveman en (English). Without language flag, matches the user's language automatically.
+  Use when user says "caveman mode", "talk like caveman", "modo caveman", "habla como cavernícola",
+  "less tokens", "menos tokens", or invokes /caveman.
 ---
 
 Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
+## Language
+
+**Default (no lang flag):** detect user language and respond in same language using caveman style.
+**With lang flag** (`/caveman es`, `/caveman en`): always respond in that language regardless of input.
+
 ## Persistence
 
-ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure.
+Off only: "stop caveman" / "normal mode" / "modo normal".
 
-Default: **full**. Switch: `/caveman lite|full|ultra`.
+Default: **full**. Switch: `/caveman lite|full|ultra`. Language: `/caveman es|en`.
+Combine: `/caveman lite es`, `/caveman ultra en`.
 
 ## Rules
 
-Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+**English — Drop:** articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
 
-Pattern: `[thing] [action] [reason]. [next step].`
+**Castellano — Eliminar:** artículos (un/una/el/la/los/las/unos/unas), relleno (básicamente/realmente/simplemente/esencialmente/solo/tan solo), formalidades (claro/por supuesto/encantado/desde luego), vacilaciones (quizás/tal vez/podría ser/creo que). Fragmentos OK. Sinónimos cortos. Términos técnicos exactos. Código sin cambios.
 
-Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
-Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+Pattern / Patrón: `[thing/cosa] [action/acción] [reason/razón]. [next step/siguiente paso].`
 
 ## Intensity
 
-| Level | What change |
-|-------|------------|
-| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
-| **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
-| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
-| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
-| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
-| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+| Level | What changes |
+|-------|-------------|
+| **lite** | Drop filler/hedging. Keep articles + full sentences. Professional but tight. |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman. |
+| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), arrows for causality (X → Y), one word when one word enough. |
+| **wenyan-lite** | Semi-classical Chinese. Drop filler but keep grammar. |
+| **wenyan-full** | Full 文言文. Maximum classical terseness. |
+| **wenyan-ultra** | Extreme. Ancient scholar on a budget. |
 
-Example — "Why React component re-render?"
-- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
-- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
-- ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+## Examples
+
+**English — "Why React component re-render?"**
+- lite-en: "Component re-renders because you create a new object reference each render. Wrap in `useMemo`."
+- full-en: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra-en: "Inline obj prop → new ref → re-render. `useMemo`."
+
+**Castellano — "¿Por qué hace re-render el componente React?"**
+- lite-es: "Tu componente hace re-render porque creas una nueva referencia de objeto en cada render. Envuélvelo en `useMemo`."
+- full-es: "Nueva ref objeto en cada render. Prop inline = nueva ref = re-render. Envolver en `useMemo`."
+- ultra-es: "Prop inline → nueva ref → re-render. `useMemo`."
+
+**English — "Explain database connection pooling."**
+- lite-en: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full-en: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra-en: "Pool = reuse DB conn. Skip handshake → fast under load."
+
+**Castellano — "Explica el connection pooling."**
+- lite-es: "El connection pooling reutiliza conexiones abiertas en lugar de crear nuevas por petición. Evita la sobrecarga del handshake."
+- full-es: "Pool reutiliza conexiones DB abiertas. Sin nueva conexión por petición. Skip overhead handshake."
+- ultra-es: "Pool = reutilizar conn DB. Skip handshake → rápido bajo carga."
+
+**Wenyan — "Why React component re-render?"**
 - wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
-- wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
+- wenyan-full: "物出新參照，致重繪。useMemo Wrap之。"
 - wenyan-ultra: "新參照→重繪。useMemo Wrap。"
-
-Example — "Explain database connection pooling."
-- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
-- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
-- ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
-- wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
-- wenyan-ultra: "池reuse conn。skip handshake → fast。"
 
 ## Auto-Clarity
 
-Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.
+Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user confused or repeating question. Resume after.
 
 Example — destructive op:
-> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> **Warning / Advertencia:** This will permanently delete all rows in `users` and cannot be undone. / Esto eliminará permanentemente todas las filas de `users` y no se puede deshacer.
 > ```sql
 > DROP TABLE users;
 > ```
-> Caveman resume. Verify backup exist first.
+> Caveman resume. Verify backup exist first. / Caveman reanuda. Verificar backup primero.
 
 ## Boundaries
 
-Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+Code/commits/PRs: write normal. "stop caveman" / "normal mode" / "modo normal": revert. Level + language persist until changed or session ends.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,25 +1,25 @@
 ---
-name: Bug report
-about: Caveman speak wrong or break
+name: Reporte de bug
+about: Caveman habla mal o se rompe
 labels: bug
 ---
 
-**What happen**
-<!-- What caveman do wrong -->
+**Qué pasó**
+<!-- Qué hizo mal caveman -->
 
-**Expected**
-<!-- What caveman should do -->
+**Esperado**
+<!-- Qué debería hacer caveman -->
 
-**Before/after example**
+**Ejemplo antes/después**
 ```
-Input: [your prompt]
-Got:   [what caveman said]
-Want:  [what caveman should say]
+Entrada: [tu prompt]
+Obtuvo:  [lo que dijo caveman]
+Quería:  [lo que debería haber dicho caveman]
 ```
 
-**Platform**
+**Plataforma**
 - [ ] Claude Code
 - [ ] Codex
-- [ ] Other: ___
+- [ ] Otro: ___
 
-**Version / install method**
+**Versión / método de instalación**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,17 +1,17 @@
 ---
-name: Feature request
-about: Make caveman better
+name: Solicitud de función
+about: Hacer caveman mejor
 labels: enhancement
 ---
 
-**What you want**
-<!-- New behavior, new persona, new rule -->
+**Qué quieres**
+<!-- Nuevo comportamiento, nueva persona, nueva regla -->
 
-**Before/after example**
+**Ejemplo antes/después**
 ```
-Before: [current behavior]
-After:  [desired behavior]
+Antes: [comportamiento actual]
+Después: [comportamiento deseado]
 ```
 
-**Why good**
-<!-- Why this help users -->
+**Por qué es bueno**
+<!-- Por qué esto ayuda a los usuarios -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,15 +1,15 @@
-Respond terse like smart caveman. All technical substance stay. Only fluff die.
+Responder conciso como cavernícola inteligente. Toda sustancia técnica queda. Solo paja muere.
 
-Rules:
-- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
-- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
-- Pattern: [thing] [action] [reason]. [next step].
-- Not: "Sure! I'd be happy to help you with that."
-- Yes: "Bug in auth middleware. Fix:"
+Reglas:
+- Eliminar: artículos (un/una/el/la), relleno (just/really/básicamente), formalidades, vacilaciones
+- Fragmentos OK. Sinónimos cortos. Términos técnicos exactos. Código sin cambios.
+- Patrón: [cosa] [acción] [razón]. [siguiente paso].
+- No: "¡Claro! Estaré encantado de ayudarte con eso."
+- Sí: "Bug en auth middleware. Fix:"
 
-Switch level: /caveman lite|full|ultra|wenyan
-Stop: "stop caveman" or "normal mode"
+Cambiar nivel: /caveman lite|full|ultra|wenyan
+Desactivar: "stop caveman" o "modo normal"
 
-Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
+Auto-Claridad: abandonar caveman para advertencias de seguridad, acciones irreversibles, usuario confundido. Reanudar después.
 
-Boundaries: code/commits/PRs written normal.
+Límites: código/commits/PRs escritos normal.

--- a/.windsurf/rules/caveman.md
+++ b/.windsurf/rules/caveman.md
@@ -2,18 +2,18 @@
 trigger: always_on
 ---
 
-Respond terse like smart caveman. All technical substance stay. Only fluff die.
+Responder conciso como cavernícola inteligente. Toda sustancia técnica queda. Solo paja muere.
 
-Rules:
-- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
-- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
-- Pattern: [thing] [action] [reason]. [next step].
-- Not: "Sure! I'd be happy to help you with that."
-- Yes: "Bug in auth middleware. Fix:"
+Reglas:
+- Eliminar: artículos (un/una/el/la), relleno (just/really/básicamente), formalidades, vacilaciones
+- Fragmentos OK. Sinónimos cortos. Términos técnicos exactos. Código sin cambios.
+- Patrón: [cosa] [acción] [razón]. [siguiente paso].
+- No: "¡Claro! Estaré encantado de ayudarte con eso."
+- Sí: "Bug en auth middleware. Fix:"
 
-Switch level: /caveman lite|full|ultra|wenyan
-Stop: "stop caveman" or "normal mode"
+Cambiar nivel: /caveman lite|full|ultra|wenyan
+Desactivar: "stop caveman" o "modo normal"
 
-Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
+Auto-Claridad: abandonar caveman para advertencias de seguridad, acciones irreversibles, usuario confundido. Reanudar después.
 
-Boundaries: code/commits/PRs written normal.
+Límites: código/commits/PRs escritos normal.

--- a/.windsurf/skills/caveman/SKILL.md
+++ b/.windsurf/skills/caveman/SKILL.md
@@ -3,65 +3,84 @@ name: caveman
 description: >
   Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
   while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
-  wenyan-lite, wenyan-full, wenyan-ultra.
-  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
-  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+  wenyan-lite, wenyan-full, wenyan-ultra. Supports language targeting: /caveman es (Spanish),
+  /caveman en (English). Without language flag, matches the user's language automatically.
+  Use when user says "caveman mode", "talk like caveman", "modo caveman", "habla como cavernícola",
+  "less tokens", "menos tokens", or invokes /caveman.
 ---
 
 Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
+## Language
+
+**Default (no lang flag):** detect user language and respond in same language using caveman style.
+**With lang flag** (`/caveman es`, `/caveman en`): always respond in that language regardless of input.
+
 ## Persistence
 
-ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure.
+Off only: "stop caveman" / "normal mode" / "modo normal".
 
-Default: **full**. Switch: `/caveman lite|full|ultra`.
+Default: **full**. Switch: `/caveman lite|full|ultra`. Language: `/caveman es|en`.
+Combine: `/caveman lite es`, `/caveman ultra en`.
 
 ## Rules
 
-Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+**English — Drop:** articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
 
-Pattern: `[thing] [action] [reason]. [next step].`
+**Castellano — Eliminar:** artículos (un/una/el/la/los/las/unos/unas), relleno (básicamente/realmente/simplemente/esencialmente/solo/tan solo), formalidades (claro/por supuesto/encantado/desde luego), vacilaciones (quizás/tal vez/podría ser/creo que). Fragmentos OK. Sinónimos cortos. Términos técnicos exactos. Código sin cambios.
 
-Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
-Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+Pattern / Patrón: `[thing/cosa] [action/acción] [reason/razón]. [next step/siguiente paso].`
 
 ## Intensity
 
-| Level | What change |
-|-------|------------|
-| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
-| **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
-| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
-| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
-| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
-| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+| Level | What changes |
+|-------|-------------|
+| **lite** | Drop filler/hedging. Keep articles + full sentences. Professional but tight. |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman. |
+| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), arrows for causality (X → Y), one word when one word enough. |
+| **wenyan-lite** | Semi-classical Chinese. Drop filler but keep grammar. |
+| **wenyan-full** | Full 文言文. Maximum classical terseness. |
+| **wenyan-ultra** | Extreme. Ancient scholar on a budget. |
 
-Example — "Why React component re-render?"
-- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
-- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
-- ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+## Examples
+
+**English — "Why React component re-render?"**
+- lite-en: "Component re-renders because you create a new object reference each render. Wrap in `useMemo`."
+- full-en: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra-en: "Inline obj prop → new ref → re-render. `useMemo`."
+
+**Castellano — "¿Por qué hace re-render el componente React?"**
+- lite-es: "Tu componente hace re-render porque creas una nueva referencia de objeto en cada render. Envuélvelo en `useMemo`."
+- full-es: "Nueva ref objeto en cada render. Prop inline = nueva ref = re-render. Envolver en `useMemo`."
+- ultra-es: "Prop inline → nueva ref → re-render. `useMemo`."
+
+**English — "Explain database connection pooling."**
+- lite-en: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full-en: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra-en: "Pool = reuse DB conn. Skip handshake → fast under load."
+
+**Castellano — "Explica el connection pooling."**
+- lite-es: "El connection pooling reutiliza conexiones abiertas en lugar de crear nuevas por petición. Evita la sobrecarga del handshake."
+- full-es: "Pool reutiliza conexiones DB abiertas. Sin nueva conexión por petición. Skip overhead handshake."
+- ultra-es: "Pool = reutilizar conn DB. Skip handshake → rápido bajo carga."
+
+**Wenyan — "Why React component re-render?"**
 - wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
-- wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
+- wenyan-full: "物出新參照，致重繪。useMemo Wrap之。"
 - wenyan-ultra: "新參照→重繪。useMemo Wrap。"
-
-Example — "Explain database connection pooling."
-- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
-- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
-- ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
-- wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
-- wenyan-ultra: "池reuse conn。skip handshake → fast。"
 
 ## Auto-Clarity
 
-Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.
+Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user confused or repeating question. Resume after.
 
 Example — destructive op:
-> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> **Warning / Advertencia:** This will permanently delete all rows in `users` and cannot be undone. / Esto eliminará permanentemente todas las filas de `users` y no se puede deshacer.
 > ```sql
 > DROP TABLE users;
 > ```
-> Caveman resume. Verify backup exist first.
+> Caveman resume. Verify backup exist first. / Caveman reanuda. Verificar backup primero.
 
 ## Boundaries
 
-Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+Code/commits/PRs: write normal. "stop caveman" / "normal mode" / "modo normal": revert. Level + language persist until changed or session ends.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,199 +1,199 @@
 # CLAUDE.md — caveman
 
-## README is a product artifact
+## El README es un artefacto de producto
 
-README = product front door. Non-technical people read it to decide if caveman worth install. Treat like UI copy.
+README = puerta de entrada al producto. Lo leen personas no técnicas para decidir si vale la pena instalar caveman. Trátalo como copy de UI.
 
-**Rules for any README change:**
+**Reglas para cualquier cambio en el README:**
 
-- Readable by non-AI-agent users. If you write "SessionStart hook injects system context," invisible to most — translate it.
-- Keep Before/After examples first. That the pitch.
-- Install table always complete + accurate. One broken install command costs real user.
-- What You Get table must sync with actual code. Feature ships or removed → update table.
-- Preserve voice. Caveman speak in README on purpose. "Brain still big." "Cost go down forever." "One rock. That it." — intentional brand. Don't normalize.
-- Benchmark numbers from real runs in `benchmarks/` and `evals/`. Never invent or round. Re-run if doubt.
-- Adding new agent to install table → add detail block in `<details>` section below.
-- Readability check before any README commit: would non-programmer understand + install within 60 seconds?
-
----
-
-## Project overview
-
-Caveman makes AI coding agents respond in compressed caveman-style prose — cuts ~65-75% output tokens, full technical accuracy. Ships as Claude Code plugin, Codex plugin, Gemini CLI extension, agent rule files for Cursor, Windsurf, Cline, Copilot, 40+ others via `npx skills`.
+- Legible por usuarios no-IA. Si escribes "el hook SessionStart inyecta contexto de sistema", es invisible para la mayoría — tradúcelo a lenguaje normal.
+- Mantén los ejemplos Antes/Después primero. Ese es el argumento de venta.
+- La tabla de instalación siempre completa y exacta. Un comando de instalación roto cuesta un usuario real.
+- La tabla "Qué obtienes" debe sincronizarse con el código real. Una función sale o se elimina → actualiza la tabla.
+- Preserva la voz. El estilo caveman en el README es intencionado. "Cerebro sigue grande." "Coste baja para siempre." "Una piedra. Eso es todo." — marca intencional. No lo normalices.
+- Números de benchmark de ejecuciones reales en `benchmarks/` y `evals/`. Nunca inventar ni redondear. Reejecutar si hay duda.
+- Añadir nuevo agente a la tabla de instalación → añadir bloque de detalle en la sección `<details>` más abajo.
+- Verificar legibilidad antes de cualquier commit al README: ¿podría un no-programador entender e instalar en 60 segundos?
 
 ---
 
-## File structure and what owns what
+## Visión general del proyecto
 
-### Single source of truth files — edit only these
+Caveman hace que los agentes de codificación IA respondan en prosa comprimida estilo caveman — recorta ~65-75% de tokens de salida, con plena precisión técnica. Se distribuye como plugin de Claude Code, plugin de Codex, extensión de Gemini CLI, archivos de reglas para Cursor, Windsurf, Cline, Copilot y más de 40 agentes vía `npx skills`.
 
-| File | What it controls |
-|------|-----------------|
-| `skills/caveman/SKILL.md` | Caveman behavior: intensity levels, rules, wenyan mode, auto-clarity, persistence. Only file to edit for behavior changes. |
-| `rules/caveman-activate.md` | Always-on auto-activation rule body. CI injects into Cursor, Windsurf, Cline, Copilot rule files. Edit here, not agent-specific copies. |
-| `skills/caveman-commit/SKILL.md` | Caveman commit message behavior. Fully independent skill. |
-| `skills/caveman-review/SKILL.md` | Caveman code review behavior. Fully independent skill. |
-| `skills/caveman-help/SKILL.md` | Quick-reference card. One-shot display, not a persistent mode. |
-| `caveman-compress/SKILL.md` | Compress sub-skill behavior. |
+---
 
-### Auto-generated / auto-synced — do not edit directly
+## Estructura de archivos y responsabilidades
 
-Overwritten by CI on push to main when sources change. Edits here lost.
+### Archivos fuente de verdad — editar solo estos
 
-| File | Synced from |
-|------|-------------|
+| Archivo | Qué controla |
+|---------|--------------|
+| `skills/caveman/SKILL.md` | Comportamiento caveman: niveles de intensidad, reglas, modo wenyan, auto-claridad, persistencia. Único archivo a editar para cambios de comportamiento. |
+| `rules/caveman-activate.md` | Cuerpo de regla de auto-activación siempre activa. CI lo inyecta en archivos de reglas de Cursor, Windsurf, Cline, Copilot. Editar aquí, no en copias específicas de cada agente. |
+| `skills/caveman-commit/SKILL.md` | Comportamiento de mensajes de commit caveman. Skill completamente independiente. |
+| `skills/caveman-review/SKILL.md` | Comportamiento de revisión de código caveman. Skill completamente independiente. |
+| `skills/caveman-help/SKILL.md` | Tarjeta de referencia rápida. Visualización única, no es un modo persistente. |
+| `caveman-compress/SKILL.md` | Comportamiento del sub-skill compress. |
+
+### Auto-generados / auto-sincronizados — no editar directamente
+
+CI los sobreescribe al hacer push a main cuando cambian las fuentes. Las ediciones aquí se pierden.
+
+| Archivo | Sincronizado desde |
+|---------|-------------------|
 | `caveman/SKILL.md` | `skills/caveman/SKILL.md` |
 | `plugins/caveman/skills/caveman/SKILL.md` | `skills/caveman/SKILL.md` |
 | `.cursor/skills/caveman/SKILL.md` | `skills/caveman/SKILL.md` |
 | `.windsurf/skills/caveman/SKILL.md` | `skills/caveman/SKILL.md` |
-| `caveman.skill` | ZIP of `skills/caveman/` directory |
+| `caveman.skill` | ZIP del directorio `skills/caveman/` |
 | `.clinerules/caveman.md` | `rules/caveman-activate.md` |
 | `.github/copilot-instructions.md` | `rules/caveman-activate.md` |
-| `.cursor/rules/caveman.mdc` | `rules/caveman-activate.md` + Cursor frontmatter |
-| `.windsurf/rules/caveman.md` | `rules/caveman-activate.md` + Windsurf frontmatter |
+| `.cursor/rules/caveman.mdc` | `rules/caveman-activate.md` + frontmatter de Cursor |
+| `.windsurf/rules/caveman.md` | `rules/caveman-activate.md` + frontmatter de Windsurf |
 
 ---
 
-## CI sync workflow
+## Flujo de trabajo de sincronización CI
 
-`.github/workflows/sync-skill.yml` triggers on main push when `skills/caveman/SKILL.md` or `rules/caveman-activate.md` changes.
+`.github/workflows/sync-skill.yml` se dispara al hacer push a main cuando cambian `skills/caveman/SKILL.md` o `rules/caveman-activate.md`.
 
-What it does:
-1. Copies `skills/caveman/SKILL.md` to all agent-specific SKILL.md locations
-2. Rebuilds `caveman.skill` as a ZIP of `skills/caveman/`
-3. Rebuilds all agent rule files from `rules/caveman-activate.md`, prepending agent-specific frontmatter (Cursor needs `alwaysApply: true`, Windsurf needs `trigger: always_on`)
-4. Commits and pushes with `[skip ci]` to avoid loops
+Qué hace:
+1. Copia `skills/caveman/SKILL.md` a todas las ubicaciones SKILL.md de cada agente
+2. Reconstruye `caveman.skill` como ZIP de `skills/caveman/`
+3. Reconstruye todos los archivos de reglas de agentes desde `rules/caveman-activate.md`, añadiendo frontmatter específico de cada agente (Cursor necesita `alwaysApply: true`, Windsurf necesita `trigger: always_on`)
+4. Hace commit y push con `[skip ci]` para evitar bucles
 
-CI bot commits as `github-actions[bot]`. After PR merge, wait for workflow before declaring release complete.
+CI hace commit como `github-actions[bot]`. Tras fusionar un PR, esperar al workflow antes de declarar la release completa.
 
 ---
 
-## Hook system (Claude Code)
+## Sistema de hooks (Claude Code)
 
-Three hooks in `hooks/`. Communicate via flag file at `~/.claude/.caveman-active`.
+Tres hooks en `hooks/`. Se comunican mediante archivo de bandera en `~/.claude/.caveman-active`.
 
 ```
-SessionStart hook ──writes "full"──▶ ~/.claude/.caveman-active ◀──writes mode── UserPromptSubmit hook
+Hook SessionStart ──escribe "full"──▶ ~/.claude/.caveman-active ◀──escribe modo── Hook UserPromptSubmit
                                                │
-                                            reads
+                                            lee
                                                ▼
                                       caveman-statusline.sh
                                      [CAVEMAN] / [CAVEMAN:ULTRA] / ...
 ```
 
-### `hooks/caveman-activate.js` — SessionStart hook
+### `hooks/caveman-activate.js` — Hook SessionStart
 
-Runs once per Claude Code session start. Three things:
-1. Writes `"full"` to `~/.claude/.caveman-active` (creates if missing)
-2. Emits caveman ruleset as hidden stdout — Claude Code injects SessionStart hook stdout as system context, invisible to user
-3. Checks `~/.claude/settings.json` for statusline config; if missing, appends nudge to offer setup on first interaction
+Se ejecuta una vez al inicio de cada sesión de Claude Code. Hace tres cosas:
+1. Escribe `"full"` en `~/.claude/.caveman-active` (lo crea si no existe)
+2. Emite el conjunto de reglas caveman como stdout oculto — Claude Code inyecta el stdout del hook SessionStart como contexto de sistema, invisible para el usuario
+3. Verifica `~/.claude/settings.json` en busca de configuración de statusline; si falta, añade un aviso para ofrecer configuración en la primera interacción
 
-Silent-fails on all filesystem errors — never blocks session start.
+Falla en silencio ante todos los errores del sistema de archivos — nunca bloquea el inicio de sesión.
 
-### `hooks/caveman-mode-tracker.js` — UserPromptSubmit hook
+### `hooks/caveman-mode-tracker.js` — Hook UserPromptSubmit
 
-Reads JSON from stdin. Checks if prompt starts with `/caveman`. If yes, writes mode to flag file:
-- `/caveman` → configured default (see `caveman-config.js`, defaults to `full`)
+Lee JSON desde stdin. Comprueba si el prompt empieza con `/caveman`. Si es así, escribe el modo en el archivo de bandera:
+- `/caveman` → predeterminado configurado (ver `caveman-config.js`, por defecto `full`)
 - `/caveman lite` → `lite`
 - `/caveman ultra` → `ultra`
-- `/caveman wenyan` or `/caveman wenyan-full` → `wenyan`
+- `/caveman wenyan` o `/caveman wenyan-full` → `wenyan`
 - `/caveman wenyan-lite` → `wenyan-lite`
 - `/caveman wenyan-ultra` → `wenyan-ultra`
 - `/caveman-commit` → `commit`
 - `/caveman-review` → `review`
 - `/caveman-compress` → `compress`
 
-Detects "stop caveman" or "normal mode" in prompt and deletes flag file.
+Detecta "stop caveman" o "modo normal" en el prompt y borra el archivo de bandera.
 
-### `hooks/caveman-statusline.sh` — Statusline badge
+### `hooks/caveman-statusline.sh` — Insignia de statusline
 
-Reads flag file. Outputs colored badge string for Claude Code statusline:
-- `full` or empty → `[CAVEMAN]` (orange)
-- anything else → `[CAVEMAN:<MODE_UPPERCASED>]` (orange)
+Lee el archivo de bandera. Devuelve cadena de insignia coloreada para la statusline de Claude Code:
+- `full` o vacío → `[CAVEMAN]` (naranja)
+- cualquier otro → `[CAVEMAN:<MODO_EN_MAYÚSCULAS>]` (naranja)
 
-Configured in `~/.claude/settings.json` under `statusLine.command`.
+Se configura en `~/.claude/settings.json` bajo `statusLine.command`.
 
-### Hook installation
+### Instalación de hooks
 
-**Plugin install** — hooks wired automatically by plugin system.
+**Instalación vía plugin** — los hooks se conectan automáticamente mediante el sistema de plugins.
 
-**Standalone install** — `hooks/install.sh` (macOS/Linux) or `hooks/install.ps1` (Windows) copies hook files into `~/.claude/hooks/` and patches `~/.claude/settings.json` to register SessionStart and UserPromptSubmit hooks plus statusline.
+**Instalación independiente** — `hooks/install.sh` (macOS/Linux) o `hooks/install.ps1` (Windows) copia los archivos de hooks en `~/.claude/hooks/` y parchea `~/.claude/settings.json` para registrar los hooks SessionStart y UserPromptSubmit además de la statusline.
 
-**Uninstall** — `hooks/uninstall.sh` / `hooks/uninstall.ps1` removes hook files and patches settings.json.
+**Desinstalación** — `hooks/uninstall.sh` / `hooks/uninstall.ps1` elimina los archivos de hooks y parchea settings.json.
 
 ---
 
-## Skill system
+## Sistema de skills
 
-Skills = Markdown files with YAML frontmatter consumed by Claude Code's skill/plugin system and by `npx skills` for other agents.
+Skills = archivos Markdown con frontmatter YAML consumidos por el sistema de skills/plugins de Claude Code y por `npx skills` para otros agentes.
 
-### Intensity levels
+### Niveles de intensidad
 
-Defined in `skills/caveman/SKILL.md`. Six levels: `lite`, `full` (default), `ultra`, `wenyan-lite`, `wenyan-full`, `wenyan-ultra`. Persists until changed or session ends.
+Definidos en `skills/caveman/SKILL.md`. Seis niveles: `lite`, `full` (predeterminado), `ultra`, `wenyan-lite`, `wenyan-full`, `wenyan-ultra`. Persiste hasta que se cambie o finalice la sesión.
 
-### Auto-clarity rule
+### Regla de auto-claridad
 
-Caveman drops to normal prose for: security warnings, irreversible action confirmations, multi-step sequences where fragment ambiguity risks misread, user confused or repeating question. Resumes after. Defined in skill — preserve in any SKILL.md edit.
+Caveman vuelve a prosa normal para: advertencias de seguridad, confirmaciones de acciones irreversibles, secuencias de múltiples pasos donde la ambigüedad de fragmentos implica riesgo de malinterpretación, usuario confundido o repitiendo pregunta. Reanuda después. Definido en el skill — preservar en cualquier edición de SKILL.md.
 
 ### caveman-compress
 
-Sub-skill in `caveman-compress/SKILL.md`. Takes file path, compresses prose to caveman style, writes to original path, saves backup at `<filename>.original.md`. Validates headings, code blocks, URLs, file paths, commands preserved. Retries up to 2 times on failure with targeted patches only. Requires Python 3.10+.
+Sub-skill en `caveman-compress/SKILL.md`. Toma una ruta de archivo, comprime la prosa a estilo caveman, escribe en la ruta original, guarda copia de seguridad en `<filename>.original.md`. Valida que headings, bloques de código, URLs, rutas de archivo y comandos se preserven. Reintenta hasta 2 veces ante fallos con parches específicos únicamente. Requiere Python 3.10+.
 
 ### caveman-commit / caveman-review
 
-Independent skills in `skills/caveman-commit/SKILL.md` and `skills/caveman-review/SKILL.md`. Both have own `description` and `name` frontmatter so they load independently. caveman-commit: Conventional Commits, ≤50 char subject. caveman-review: one-line comments in `L<line>: <severity> <problem>. <fix>.` format.
+Skills independientes en `skills/caveman-commit/SKILL.md` y `skills/caveman-review/SKILL.md`. Ambos tienen frontmatter propio con `description` y `name` para cargarse de forma independiente. caveman-commit: Conventional Commits, sujeto ≤50 caracteres. caveman-review: comentarios de una línea en formato `L<línea>: <severidad> <problema>. <solución>.`
 
 ---
 
-## Agent distribution
+## Distribución por agente
 
-How caveman reaches each agent type:
+Cómo llega caveman a cada tipo de agente:
 
-| Agent | Mechanism | Auto-activates? |
-|-------|-----------|----------------|
-| Claude Code | Plugin (hooks + skills) or standalone hooks | Yes — SessionStart hook injects rules |
-| Codex | Plugin in `plugins/caveman/` with `hooks.json` | Yes — SessionStart hook |
-| Gemini CLI | Extension with `GEMINI.md` context file | Yes — context file loads every session |
-| Cursor | `.cursor/rules/caveman.mdc` with `alwaysApply: true` | Yes — always-on rule |
-| Windsurf | `.windsurf/rules/caveman.md` with `trigger: always_on` | Yes — always-on rule |
-| Cline | `.clinerules/caveman.md` (auto-discovered) | Yes — Cline injects all .clinerules files |
-| Copilot | `.github/copilot-instructions.md` + `AGENTS.md` | Yes — repo-wide instructions |
-| Others | `npx skills add JuliusBrussee/caveman` | No — user must say `/caveman` each session |
+| Agente | Mecanismo | ¿Auto-activa? |
+|--------|-----------|---------------|
+| Claude Code | Plugin (hooks + skills) o hooks independientes | Sí — hook SessionStart inyecta reglas |
+| Codex | Plugin en `plugins/caveman/` con `hooks.json` | Sí — hook SessionStart |
+| Gemini CLI | Extensión con archivo de contexto `GEMINI.md` | Sí — el archivo de contexto carga cada sesión |
+| Cursor | `.cursor/rules/caveman.mdc` con `alwaysApply: true` | Sí — regla siempre activa |
+| Windsurf | `.windsurf/rules/caveman.md` con `trigger: always_on` | Sí — regla siempre activa |
+| Cline | `.clinerules/caveman.md` (auto-descubierto) | Sí — Cline inyecta todos los archivos .clinerules |
+| Copilot | `.github/copilot-instructions.md` + `AGENTS.md` | Sí — instrucciones para todo el repositorio |
+| Otros | `npx skills add JuliusBrussee/caveman` | No — el usuario debe ejecutar `/caveman` cada sesión |
 
-For agents without hook systems, minimal always-on snippet lives in README under "Want it always on?" — keep current with `rules/caveman-activate.md`.
+Para agentes sin sistema de hooks, el fragmento mínimo siempre activo vive en el README bajo "¿Quieres que esté siempre activo?" — mantener actualizado con `rules/caveman-activate.md`.
 
 ---
 
-## Evals
+## Evaluaciones
 
-`evals/` has three-arm harness:
-- `__baseline__` — no system prompt
+`evals/` tiene un harness de tres ramas:
+- `__baseline__` — sin system prompt
 - `__terse__` — `Answer concisely.`
 - `<skill>` — `Answer concisely.\n\n{SKILL.md}`
 
-Honest delta = **skill vs terse**, not skill vs baseline. Baseline comparison conflates skill with generic terseness — that cheating. Harness designed to prevent this.
+Delta honesto = **skill vs terse**, no skill vs baseline. La comparación con baseline confunde el skill con terseness genérica — eso es hacer trampa. El harness está diseñado para evitarlo.
 
-`llm_run.py` calls `claude -p --system-prompt ...` per (prompt, arm), saves to `evals/snapshots/results.json`. `measure.py` reads snapshot offline with tiktoken (OpenAI BPE — approximates Claude tokenizer, ratios meaningful, absolute numbers approximate).
+`llm_run.py` llama a `claude -p --system-prompt ...` por (prompt, rama), guarda en `evals/snapshots/results.json`. `measure.py` lee el snapshot offline con tiktoken (BPE de OpenAI — aproxima el tokenizador de Claude; las ratios son significativas, los números absolutos son aproximados).
 
-Add skill: drop `skills/<name>/SKILL.md`. Harness auto-discovers. Add prompt: append line to `evals/prompts/en.txt`.
+Añadir skill: depositar `skills/<nombre>/SKILL.md`. El harness lo descubre automáticamente. Añadir prompt: añadir línea a `evals/prompts/en.txt`.
 
-Snapshots committed to git. CI reads without API calls. Only regenerate when SKILL.md or prompts change.
+Snapshots guardados en git. CI los lee sin llamadas a la API. Solo regenerar cuando cambie SKILL.md o los prompts.
 
 ---
 
 ## Benchmarks
 
-`benchmarks/` runs real prompts through Claude API (not Claude Code CLI), records raw token counts. Results committed as JSON in `benchmarks/results/`. Benchmark table in README generated from results — update when regenerating.
+`benchmarks/` ejecuta prompts reales a través de la API de Claude (no la CLI de Claude Code), registra recuentos de tokens reales. Resultados guardados como JSON en `benchmarks/results/`. La tabla de benchmarks en el README se genera a partir de los resultados — actualizar al regenerar.
 
-To reproduce: `uv run python benchmarks/run.py` (needs `ANTHROPIC_API_KEY` in `.env.local`).
+Para reproducir: `uv run python benchmarks/run.py` (necesita `ANTHROPIC_API_KEY` en `.env.local`).
 
 ---
 
-## Key rules for agents working here
+## Reglas clave para agentes que trabajen aquí
 
-- Edit `skills/caveman/SKILL.md` for behavior changes. Never edit synced copies.
-- Edit `rules/caveman-activate.md` for auto-activation rule changes. Never edit agent-specific rule copies.
-- README most important file for user-facing impact. Optimize for non-technical readers. Preserve caveman voice.
-- Benchmark and eval numbers must be real. Never fabricate or estimate.
-- CI workflow commits back to main after merge. Account for when checking branch state.
-- Hook files must silent-fail on all filesystem errors. Never let hook crash block session start.
+- Editar `skills/caveman/SKILL.md` para cambios de comportamiento. Nunca editar las copias sincronizadas.
+- Editar `rules/caveman-activate.md` para cambios en la regla de auto-activación. Nunca editar las copias específicas de cada agente.
+- El README es el archivo más importante para el impacto en el usuario. Optimizar para lectores no técnicos. Preservar la voz caveman.
+- Los números de benchmark y evaluación deben ser reales. Nunca fabricar ni estimar.
+- El workflow de CI hace commit de vuelta a main tras la fusión. Tenerlo en cuenta al verificar el estado de la rama.
+- Los archivos de hooks deben fallar en silencio ante todos los errores del sistema de archivos. Nunca dejar que un crash del hook bloquee el inicio de sesión.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,20 @@
-# Contributing
+# Contribuir
 
-Improvements to the SKILL.md prompt are welcome — open a PR with before/after examples showing the change.
+Las mejoras al prompt en SKILL.md son bienvenidas — abre un PR con ejemplos antes/después que muestren el cambio.
 
-## How
+## Cómo
 
-1. Fork repo
-2. Edit `skills/caveman/SKILL.md` — this is the only copy you need to touch
-3. Open PR with:
-   - **Before:** what caveman say now
-   - **After:** what caveman say with change
-   - One sentence why change better
+1. Hacer fork del repo
+2. Editar `skills/caveman/SKILL.md` — es la única copia que necesitas tocar
+3. Abrir PR con:
+   - **Antes:** qué dice caveman ahora
+   - **Después:** qué diría caveman con el cambio
+   - Una frase explicando por qué el cambio es mejor
 
-> **Note:** `caveman/SKILL.md`, `plugins/caveman/skills/caveman/SKILL.md`, `.cursor/skills/caveman/SKILL.md`, and `caveman.skill` are auto-synced by CI after merge. Do not edit them directly.
+> **Nota:** `caveman/SKILL.md`, `plugins/caveman/skills/caveman/SKILL.md`, `.cursor/skills/caveman/SKILL.md` y `caveman.skill` son sincronizados automáticamente por CI tras el merge. No editarlos directamente.
 
-Small focused change > big rewrite. Caveman like simple.
+Cambio pequeño y enfocado > reescritura grande. Caveman prefiere simple.
 
 ## Ideas
 
-See [issues labeled `good first issue`](../../issues?q=label%3A%22good+first+issue%22) for starter tasks.
+Ver [issues etiquetados como `good first issue`](../../issues?q=label%3A%22good+first+issue%22) para tareas de inicio.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">caveman</h1>
 
 <p align="center">
-  <strong>why use many token when few do trick</strong>
+  <strong>por qué usar muchos token cuando pocos hacer el truco</strong>
 </p>
 
 <p align="center">
@@ -15,60 +15,60 @@
 </p>
 
 <p align="center">
-  <a href="#before--after">Before/After</a> •
-  <a href="#install">Install</a> •
-  <a href="#intensity-levels">Levels</a> •
-  <a href="#caveman-skills">Skills</a> •
+  <a href="#antes--después">Antes/Después</a> •
+  <a href="#instalar">Instalar</a> •
+  <a href="#niveles-de-intensidad">Niveles</a> •
+  <a href="#skills-caveman">Skills</a> •
   <a href="#benchmarks">Benchmarks</a> •
   <a href="#evals">Evals</a>
 </p>
 
 ---
 
-A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin and Codex plugin that makes agent talk like caveman — cutting **~75% of output tokens** while keeping full technical accuracy. Now with [文言文 mode](#文言文-wenyan-mode), [terse commits](#caveman-commit), [one-line code reviews](#caveman-review), and a [compression tool](#caveman-compress) that cuts **~46% of input tokens** every session.
+Un skill/plugin para [Claude Code](https://docs.anthropic.com/en/docs/claude-code) y plugin para Codex que hace que el agente hable como cavernícola — recortando **~75% de los tokens de salida** manteniendo plena precisión técnica. Ahora con [modo 文言文](#modo-文言文-wenyan), [commits concisos](#caveman-commit), [revisiones de código de una línea](#caveman-review), y una [herramienta de compresión](#caveman-compress) que recorta **~46% de los tokens de entrada** en cada sesión.
 
-Based on the viral observation that caveman-speak dramatically reduces LLM token usage without losing technical substance. So we made it a one-line install.
+Basado en la observación viral de que hablar como cavernícola reduce drásticamente el uso de tokens de LLM sin perder sustancia técnica. Así que lo convertimos en instalación de un solo comando.
 
-## Before / After
+## Antes / Después
 
 <table>
 <tr>
 <td width="50%">
 
-### 🗣️ Normal Claude (69 tokens)
+### 🗣️ Claude Normal (69 tokens)
 
 > "The reason your React component is re-rendering is likely because you're creating a new object reference on each render cycle. When you pass an inline object as a prop, React's shallow comparison sees it as a different object every time, which triggers a re-render. I'd recommend using useMemo to memoize the object."
 
 </td>
 <td width="50%">
 
-### 🪨 Caveman Claude (19 tokens)
+### 🪨 Claude Cavernícola (19 tokens)
 
-> "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+> "Nueva ref objeto en cada render. Prop objeto inline = nueva ref = re-render. Envolver en `useMemo`."
 
 </td>
 </tr>
 <tr>
 <td>
 
-### 🗣️ Normal Claude
+### 🗣️ Claude Normal
 
 > "Sure! I'd be happy to help you with that. The issue you're experiencing is most likely caused by your authentication middleware not properly validating the token expiry. Let me take a look and suggest a fix."
 
 </td>
 <td>
 
-### 🪨 Caveman Claude
+### 🪨 Claude Cavernícola
 
-> "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+> "Bug en auth middleware. Token expiry check usa `<` no `<=`. Fix:"
 
 </td>
 </tr>
 </table>
 
-**Same fix. 75% less word. Brain still big.**
+**Mismo fix. 75% menos palabras. Cerebro sigue grande.**
 
-**Pick your level of grunt:**
+**Elige tu nivel de gruñido:**
 
 <table>
 <tr>
@@ -76,21 +76,21 @@ Based on the viral observation that caveman-speak dramatically reduces LLM token
 
 #### 🪶 Lite
 
-> "Your component re-renders because you create a new object reference each render. Inline object props fail shallow comparison every time. Wrap it in `useMemo`."
+> "Tu componente hace re-render porque creas una nueva referencia de objeto en cada render. Las props de objeto inline fallan la comparación superficial cada vez. Envuélvelo en `useMemo`."
 
 </td>
 <td width="25%">
 
 #### 🪨 Full
 
-> "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+> "Nueva ref objeto en cada render. Prop objeto inline = nueva ref = re-render. Envolver en `useMemo`."
 
 </td>
 <td width="25%">
 
 #### 🔥 Ultra
 
-> "Inline obj prop → new ref → re-render. `useMemo`."
+> "Prop obj inline → nueva ref → re-render. `useMemo`."
 
 </td>
 <td width="25%">
@@ -103,75 +103,75 @@ Based on the viral observation that caveman-speak dramatically reduces LLM token
 </tr>
 </table>
 
-**Same answer. You pick how many word.**
+**Misma respuesta. Tú eliges cuántas palabras.**
 
 ```
 ┌─────────────────────────────────────┐
-│  TOKENS SAVED          ████████ 75% │
-│  TECHNICAL ACCURACY    ████████ 100%│
-│  SPEED INCREASE        ████████ ~3x │
-│  VIBES                 ████████ OOG │
+│  TOKENS AHORRADOS      ████████ 75% │
+│  PRECISIÓN TÉCNICA     ████████ 100%│
+│  AUMENTO DE VELOCIDAD  ████████ ~3x │
+│  VIBRAS                ████████ OOG │
 └─────────────────────────────────────┘
 ```
 
-- **Faster response** — less token to generate = speed go brrr
-- **Easier to read** — no wall of text, just the answer
-- **Same accuracy** — all technical info kept, only fluff removed ([science say so](https://arxiv.org/abs/2604.00025))
-- **Save money** — ~71% less output token = less cost
-- **Fun** — every code review become comedy
+- **Respuesta más rápida** — menos tokens generar = velocidad ir brrrr
+- **Más fácil de leer** — sin pared de texto, solo la respuesta
+- **Misma precisión** — toda info técnica guardada, solo paja eliminada ([ciencia lo dice](https://arxiv.org/abs/2604.00025))
+- **Ahorrar dinero** — ~71% menos tokens de salida = menos coste
+- **Divertido** — cada revisión de código se vuelve comedia
 
-## Install
+## Instalar
 
-Pick your agent. One command. Done.
+Elige tu agente. Un comando. Listo.
 
-| Agent | Install |
-|-------|---------|
+| Agente | Instalación |
+|--------|-------------|
 | **Claude Code** | `claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman` |
-| **Codex** | Clone repo → `/plugins` → Search "Caveman" → Install |
+| **Codex** | Clonar repo → `/plugins` → Buscar "Caveman" → Instalar |
 | **Gemini CLI** | `gemini extensions install https://github.com/JuliusBrussee/caveman` |
 | **Cursor** | `npx skills add JuliusBrussee/caveman -a cursor` |
 | **Windsurf** | `npx skills add JuliusBrussee/caveman -a windsurf` |
 | **Copilot** | `npx skills add JuliusBrussee/caveman -a github-copilot` |
 | **Cline** | `npx skills add JuliusBrussee/caveman -a cline` |
-| **Any other** | `npx skills add JuliusBrussee/caveman` |
+| **Cualquier otro** | `npx skills add JuliusBrussee/caveman` |
 
-Install once. Use in every session for that install target after that. One rock. That it.
+Instalar una vez. Usar en cada sesión para ese destino de instalación. Una piedra. Eso es todo.
 
-### What You Get
+### Qué obtienes
 
-Auto-activation is built in for Claude Code, Gemini CLI, and the repo-local Codex setup below. `npx skills add` installs the skill for other agents, but does **not** install repo rule/instruction files, so Caveman does not auto-start there unless you add the always-on snippet below.
+La auto-activación está integrada para Claude Code, Gemini CLI y la configuración local de Codex indicada abajo. `npx skills add` instala el skill para otros agentes, pero **no** instala archivos de reglas/instrucciones del repo, así que Caveman no arranca solo allí a menos que añadas el fragmento siempre activo de abajo.
 
-| Feature | Claude Code | Codex | Gemini CLI | Cursor | Windsurf | Cline | Copilot |
+| Función | Claude Code | Codex | Gemini CLI | Cursor | Windsurf | Cline | Copilot |
 |---------|:-----------:|:-----:|:----------:|:------:|:--------:|:-----:|:-------:|
-| Caveman mode | Y | Y | Y | Y | Y | Y | Y |
-| Auto-activate every session | Y | Y¹ | Y | —² | —² | —² | —² |
-| `/caveman` command | Y | Y¹ | Y | — | — | — | — |
-| Mode switching (lite/full/ultra) | Y | Y¹ | Y | Y³ | Y³ | — | — |
-| Statusline badge | Y⁴ | — | — | — | — | — | — |
-| caveman-commit | Y | — | Y | Y | Y | Y | Y |
-| caveman-review | Y | — | Y | Y | Y | Y | Y |
-| caveman-compress | Y | Y | Y | Y | Y | Y | Y |
-| caveman-help | Y | — | Y | Y | Y | Y | Y |
+| Modo caveman | S | S | S | S | S | S | S |
+| Auto-activar cada sesión | S | S¹ | S | —² | —² | —² | —² |
+| Comando `/caveman` | S | S¹ | S | — | — | — | — |
+| Cambio de modo (lite/full/ultra) | S | S¹ | S | S³ | S³ | — | — |
+| Insignia statusline | S⁴ | — | — | — | — | — | — |
+| caveman-commit | S | — | S | S | S | S | S |
+| caveman-review | S | — | S | S | S | S | S |
+| caveman-compress | S | S | S | S | S | S | S |
+| caveman-help | S | — | S | S | S | S | S |
 
 > [!NOTE]
-> Auto-activation works differently per agent: Claude Code uses SessionStart hooks, this repo's Codex dogfood setup uses `.codex/hooks.json`, Gemini uses context files. Cursor/Windsurf/Cline/Copilot can be made always-on, but `npx skills add` installs only the skill, not the repo rule/instruction files.
+> La auto-activación funciona diferente por agente: Claude Code usa hooks SessionStart, la configuración dogfood de Codex en este repo usa `.codex/hooks.json`, Gemini usa archivos de contexto. Cursor/Windsurf/Cline/Copilot pueden configurarse siempre activos, pero `npx skills add` instala solo el skill, no los archivos de reglas/instrucciones del repo.
 >
-> ¹ Codex uses `$caveman` syntax, not `/caveman`. This repo ships `.codex/hooks.json`, so caveman auto-starts when you run Codex inside this repo. The installed plugin itself gives you `$caveman`; copy the same hook into another repo if you want always-on behavior there too. caveman-commit and caveman-review are not in the Codex plugin bundle — use the SKILL.md files directly.
-> ² Add the "Want it always on?" snippet below to those agents' system prompt or rule file if you want session-start activation.
-> ³ Cursor and Windsurf receive the full SKILL.md with all intensity levels. Mode switching works on-demand via the skill; no slash command.
-> ⁴ Available in Claude Code, but plugin install only nudges setup. Standalone `install.sh` / `install.ps1` configures it automatically when no custom `statusLine` exists.
+> ¹ Codex usa sintaxis `$caveman`, no `/caveman`. Este repo incluye `.codex/hooks.json`, así que caveman arranca automáticamente al ejecutar Codex dentro del repo. El plugin instalado te da `$caveman`; copia el mismo hook en otro repo si quieres comportamiento siempre activo allí también. caveman-commit y caveman-review no están en el paquete del plugin de Codex — usa los archivos SKILL.md directamente.
+> ² Añade el fragmento "¿Quieres que esté siempre activo?" de abajo al system prompt o archivo de reglas de esos agentes si quieres activación al inicio de sesión.
+> ³ Cursor y Windsurf reciben el SKILL.md completo con todos los niveles de intensidad. El cambio de modo funciona bajo demanda vía el skill; sin comando slash.
+> ⁴ Disponible en Claude Code, pero la instalación vía plugin solo sugiere la configuración. `install.sh` / `install.ps1` standalone lo configura automáticamente si no hay `statusLine` personalizada.
 
 <details>
-<summary><strong>Claude Code — full details</strong></summary>
+<summary><strong>Claude Code — detalles completos</strong></summary>
 
-The plugin install gives you skills + auto-loading hooks. If no custom `statusLine` is configured, Caveman nudges Claude to offer badge setup on first session.
+La instalación del plugin te da skills + hooks de carga automática. Si no hay `statusLine` personalizada configurada, Caveman anima a Claude a ofrecer configuración de la insignia en la primera sesión.
 
 ```bash
 claude plugin marketplace add JuliusBrussee/caveman
 claude plugin install caveman@caveman
 ```
 
-**Standalone hooks (without plugin):** If you prefer not to use the plugin system:
+**Hooks standalone (sin plugin):** Si prefieres no usar el sistema de plugins:
 ```bash
 # macOS / Linux / WSL
 bash <(curl -s https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks/install.sh)
@@ -180,224 +180,224 @@ bash <(curl -s https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hook
 irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks/install.ps1 | iex
 ```
 
-Or from a local clone: `bash hooks/install.sh` / `powershell -File hooks\install.ps1`
+O desde un clon local: `bash hooks/install.sh` / `powershell -File hooks\install.ps1`
 
-Uninstall: `bash hooks/uninstall.sh` or `powershell -File hooks\uninstall.ps1`
+Desinstalar: `bash hooks/uninstall.sh` o `powershell -File hooks\uninstall.ps1`
 
-**Statusline badge:** Shows `[CAVEMAN]`, `[CAVEMAN:ULTRA]`, etc. in your Claude Code status bar.
+**Insignia statusline:** Muestra `[CAVEMAN]`, `[CAVEMAN:ULTRA]`, etc. en la barra de estado de Claude Code.
 
-- **Plugin install:** If you do not already have a custom `statusLine`, Claude should offer to configure it on first session
-- **Standalone install:** Configured automatically by `install.sh` / `install.ps1` unless you already have a custom statusline
-- **Custom statusline:** Installer leaves your existing statusline alone. See [`hooks/README.md`](hooks/README.md) for the merge snippet
+- **Instalación con plugin:** Si no tienes una `statusLine` personalizada, Claude debería ofrecer configurarla en la primera sesión
+- **Instalación standalone:** Configurada automáticamente por `install.sh` / `install.ps1` a menos que ya tengas una statusline personalizada
+- **Statusline personalizada:** El instalador deja tu statusline existente intacta. Ver [`hooks/README.md`](hooks/README.md) para el fragmento de fusión
 
 </details>
 
 <details>
-<summary><strong>Codex — full details</strong></summary>
+<summary><strong>Codex — detalles completos</strong></summary>
 
 **macOS / Linux:**
-1. Clone repo → Open Codex in the repo directory → `/plugins` → Search "Caveman" → Install
+1. Clonar repo → Abrir Codex en el directorio del repo → `/plugins` → Buscar "Caveman" → Instalar
 
 **Windows:**
-1. Enable symlinks first: `git config --global core.symlinks true` (requires Developer Mode or admin)
-2. Clone repo → Open VS Code → Codex Settings → Plugins → find "Caveman" under local marketplace → Install → Reload Window
+1. Habilitar symlinks primero: `git config --global core.symlinks true` (requiere Modo Desarrollador o admin)
+2. Clonar repo → Abrir VS Code → Configuración Codex → Plugins → encontrar "Caveman" en el marketplace local → Instalar → Recargar ventana
 
-This repo also ships `.codex/hooks.json`, so caveman auto-activates while you run Codex inside this repo. The installed plugin gives you `$caveman`; if you want always-on behavior in other repos too, add the same SessionStart hook there.
+Este repo también incluye `.codex/hooks.json`, así que caveman se auto-activa mientras ejecutas Codex dentro del repo. El plugin instalado te da `$caveman`; si quieres comportamiento siempre activo en otros repos también, añade el mismo hook SessionStart allí.
 
 </details>
 
 <details>
-<summary><strong>Gemini CLI — full details</strong></summary>
+<summary><strong>Gemini CLI — detalles completos</strong></summary>
 
 ```bash
 gemini extensions install https://github.com/JuliusBrussee/caveman
 ```
 
-Update: `gemini extensions update caveman` · Uninstall: `gemini extensions uninstall caveman`
+Actualizar: `gemini extensions update caveman` · Desinstalar: `gemini extensions uninstall caveman`
 
-Auto-activates via `GEMINI.md` context file. Also ships custom Gemini commands:
-- `/caveman` — switch intensity level (lite/full/ultra/wenyan)
-- `/caveman-commit` — generate terse commit message
-- `/caveman-review` — one-line code review
-
-</details>
-
-<details>
-<summary><strong>Cursor / Windsurf / Cline / Copilot — full details</strong></summary>
-
-`npx skills add` installs the skill file only — it does **not** install the agent's rule/instruction file, so caveman does not auto-start. For always-on, add the "Want it always on?" snippet below to your agent's rules or system prompt.
-
-| Agent | Command | Not installed | Mode switching | Always-on location |
-|-------|---------|--------------|:--------------:|--------------------|
-| Cursor | `npx skills add JuliusBrussee/caveman -a cursor` | `.cursor/rules/caveman.mdc` | Y | Cursor rules |
-| Windsurf | `npx skills add JuliusBrussee/caveman -a windsurf` | `.windsurf/rules/caveman.md` | Y | Windsurf rules |
-| Cline | `npx skills add JuliusBrussee/caveman -a cline` | `.clinerules/caveman.md` | — | Cline rules or system prompt |
-| Copilot | `npx skills add JuliusBrussee/caveman -a github-copilot` | `.github/copilot-instructions.md` + `AGENTS.md` | — | Copilot custom instructions |
-
-Uninstall: `npx skills remove caveman`
-
-Copilot works with Chat, Edits, and Coding Agent.
+Se auto-activa vía archivo de contexto `GEMINI.md`. También incluye comandos Gemini personalizados:
+- `/caveman` — cambiar nivel de intensidad (lite/full/ultra/wenyan)
+- `/caveman-commit` — generar mensaje de commit conciso
+- `/caveman-review` — revisión de código de una línea
 
 </details>
 
 <details>
-<summary><strong>Any other agent (opencode, Roo, Amp, Goose, Kiro, and 40+ more)</strong></summary>
+<summary><strong>Cursor / Windsurf / Cline / Copilot — detalles completos</strong></summary>
 
-[npx skills](https://github.com/vercel-labs/skills) supports 40+ agents:
+`npx skills add` instala solo el archivo del skill — **no** instala el archivo de reglas/instrucciones del agente, así que caveman no arranca solo. Para siempre activo, añade el fragmento "¿Quieres que esté siempre activo?" de abajo a las reglas o system prompt de tu agente.
+
+| Agente | Comando | No instalado | Cambio de modo | Ubicación siempre activo |
+|--------|---------|--------------|:--------------:|--------------------------|
+| Cursor | `npx skills add JuliusBrussee/caveman -a cursor` | `.cursor/rules/caveman.mdc` | S | Reglas de Cursor |
+| Windsurf | `npx skills add JuliusBrussee/caveman -a windsurf` | `.windsurf/rules/caveman.md` | S | Reglas de Windsurf |
+| Cline | `npx skills add JuliusBrussee/caveman -a cline` | `.clinerules/caveman.md` | — | Reglas de Cline o system prompt |
+| Copilot | `npx skills add JuliusBrussee/caveman -a github-copilot` | `.github/copilot-instructions.md` + `AGENTS.md` | — | Instrucciones personalizadas de Copilot |
+
+Desinstalar: `npx skills remove caveman`
+
+Copilot funciona con Chat, Edits y Coding Agent.
+
+</details>
+
+<details>
+<summary><strong>Cualquier otro agente (opencode, Roo, Amp, Goose, Kiro, y más de 40 más)</strong></summary>
+
+[npx skills](https://github.com/vercel-labs/skills) soporta más de 40 agentes:
 
 ```bash
-npx skills add JuliusBrussee/caveman           # auto-detect agent
+npx skills add JuliusBrussee/caveman           # auto-detectar agente
 npx skills add JuliusBrussee/caveman -a amp
 npx skills add JuliusBrussee/caveman -a augment
 npx skills add JuliusBrussee/caveman -a goose
 npx skills add JuliusBrussee/caveman -a kiro-cli
 npx skills add JuliusBrussee/caveman -a roo
-# ... and many more
+# ... y muchos más
 ```
 
-Uninstall: `npx skills remove caveman`
+Desinstalar: `npx skills remove caveman`
 
-> **Windows note:** `npx skills` uses symlinks by default. If symlinks fail, add `--copy`: `npx skills add JuliusBrussee/caveman --copy`
+> **Nota Windows:** `npx skills` usa symlinks por defecto. Si los symlinks fallan, añade `--copy`: `npx skills add JuliusBrussee/caveman --copy`
 
-**Important:** These agents don't have a hook system, so caveman won't auto-start. Say `/caveman` or "talk like caveman" to activate each session.
+**Importante:** Estos agentes no tienen sistema de hooks, así que caveman no arrancará solo. Di `/caveman` o "habla como cavernícola" para activar en cada sesión.
 
-**Want it always on?** Paste this into your agent's system prompt or rules file — caveman will be active from the first message, every session:
+**¿Quieres que esté siempre activo?** Pega esto en el system prompt o archivo de reglas de tu agente — caveman estará activo desde el primer mensaje, en cada sesión:
 
 ```
-Terse like caveman. Technical substance exact. Only fluff die.
-Drop: articles, filler (just/really/basically), pleasantries, hedging.
-Fragments OK. Short synonyms. Code unchanged.
-Pattern: [thing] [action] [reason]. [next step].
-ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift.
-Code/commits/PRs: normal. Off: "stop caveman" / "normal mode".
+Conciso como cavernícola. Sustancia técnica exacta. Solo paja muere.
+Eliminar: artículos, relleno (just/really/basically), formalidades, vacilaciones.
+Fragmentos OK. Sinónimos cortos. Código sin cambios.
+Patrón: [cosa] [acción] [razón]. [siguiente paso].
+ACTIVO EN CADA RESPUESTA. No revertir tras muchos turnos. Sin deriva de relleno.
+Código/commits/PRs: normal. Desactivar: "stop caveman" / "modo normal".
 ```
 
-Where to put it:
-| Agent | File |
-|-------|------|
+Dónde ponerlo:
+| Agente | Archivo |
+|--------|---------|
 | opencode | `.config/opencode/AGENTS.md` |
 | Roo | `.roo/rules/caveman.md` |
-| Amp | your workspace system prompt |
-| Others | your agent's system prompt or rules file |
+| Amp | system prompt de tu workspace |
+| Otros | system prompt o archivo de reglas de tu agente |
 
 </details>
 
-## Usage
+## Uso
 
-Trigger with:
-- `/caveman` or Codex `$caveman`
-- "talk like caveman"
-- "caveman mode"
-- "less tokens please"
+Activar con:
+- `/caveman` o `$caveman` en Codex
+- "habla como cavernícola"
+- "modo caveman"
+- "menos tokens por favor"
 
-Stop with: "stop caveman" or "normal mode"
+Desactivar con: "stop caveman" o "modo normal"
 
-### Intensity Levels
+### Niveles de Intensidad
 
-| Level | Trigger | What it do |
-|-------|---------|------------|
-| **Lite** | `/caveman lite` | Drop filler, keep grammar. Professional but no fluff |
-| **Full** | `/caveman full` | Default caveman. Drop articles, fragments, full grunt |
-| **Ultra** | `/caveman ultra` | Maximum compression. Telegraphic. Abbreviate everything |
+| Nivel | Activar | Qué hace |
+|-------|---------|----------|
+| **Lite** | `/caveman lite` | Elimina relleno, mantiene gramática. Profesional pero sin paja |
+| **Full** | `/caveman full` | Caveman predeterminado. Elimina artículos, fragmentos, gruñido completo |
+| **Ultra** | `/caveman ultra` | Compresión máxima. Telegráfico. Abreviar todo |
 
-### 文言文 (Wenyan) Mode
+### Modo 文言文 (Wenyan)
 
-Classical Chinese literary compression — same technical accuracy, but in the most token-efficient written language humans ever invented.
+Compresión literaria en chino clásico — misma precisión técnica, pero en el lenguaje escrito más eficiente en tokens que los humanos han inventado.
 
-| Level | Trigger | What it do |
-|-------|---------|------------|
-| **Wenyan-Lite** | `/caveman wenyan-lite` | Semi-classical. Grammar intact, filler gone |
-| **Wenyan-Full** | `/caveman wenyan` | Full 文言文. Maximum classical terseness |
-| **Wenyan-Ultra** | `/caveman wenyan-ultra` | Extreme. Ancient scholar on a budget |
+| Nivel | Activar | Qué hace |
+|-------|---------|----------|
+| **Wenyan-Lite** | `/caveman wenyan-lite` | Semi-clásico. Gramática intacta, relleno eliminado |
+| **Wenyan-Full** | `/caveman wenyan` | 文言文 completo. Máxima tersura clásica |
+| **Wenyan-Ultra** | `/caveman wenyan-ultra` | Extremo. Erudito antiguo con presupuesto ajustado |
 
-Level stick until you change it or session end.
+Nivel persiste hasta que lo cambies o finalice la sesión.
 
-## Caveman Skills
+## Skills Caveman
 
-| Skill | What it do | Trigger |
-|-------|-----------|---------|
-| **caveman-commit** | Terse commit messages. Conventional Commits. ≤50 char subject. Why over what. | `/caveman-commit` |
-| **caveman-review** | One-line PR comments: `L42: 🔴 bug: user null. Add guard.` No throat-clearing. | `/caveman-review` |
-| **caveman-help** | Quick-reference card. All modes, skills, commands, one command away. | `/caveman-help` |
+| Skill | Qué hace | Activar |
+|-------|----------|---------|
+| **caveman-commit** | Mensajes de commit concisos. Conventional Commits. Sujeto ≤50 chars. Por qué antes que qué. | `/caveman-commit` |
+| **caveman-review** | Comentarios de PR de una línea: `L42: 🔴 bug: user nulo. Añadir guard.` Sin preámbulos. | `/caveman-review` |
+| **caveman-help** | Tarjeta de referencia rápida. Todos los modos, skills, comandos, a un comando de distancia. | `/caveman-help` |
 
 ### caveman-compress
 
-Caveman make Claude *speak* with fewer tokens. **Compress** make Claude *read* fewer tokens.
+Caveman hace que Claude *hable* con menos tokens. **Compress** hace que Claude *lea* menos tokens.
 
-Your `CLAUDE.md` loads on **every session start**. Caveman Compress rewrites memory files into caveman-speak so Claude reads less — without you losing the human-readable original.
+Tu `CLAUDE.md` carga en **cada inicio de sesión**. Caveman Compress reescribe los archivos de memoria en estilo caveman para que Claude lea menos — sin que pierdas el original legible para humanos.
 
 ```
 /caveman:compress CLAUDE.md
 ```
 
 ```
-CLAUDE.md          ← compressed (Claude reads this every session — fewer tokens)
-CLAUDE.original.md ← human-readable backup (you read and edit this)
+CLAUDE.md          ← comprimido (Claude lee esto en cada sesión — menos tokens)
+CLAUDE.original.md ← backup legible (tú lees y editas esto)
 ```
 
-| File | Original | Compressed | Saved |
-|------|----------:|----------:|------:|
-| `claude-md-preferences.md` | 706 | 285 | **59.6%** |
-| `project-notes.md` | 1145 | 535 | **53.3%** |
-| `claude-md-project.md` | 1122 | 636 | **43.3%** |
-| `todo-list.md` | 627 | 388 | **38.1%** |
-| `mixed-with-code.md` | 888 | 560 | **36.9%** |
-| **Average** | **898** | **481** | **46%** |
+| Archivo | Original | Comprimido | Ahorro |
+|---------|----------:|----------:|-------:|
+| `claude-md-preferences.md` | 706 | 285 | **59,6%** |
+| `project-notes.md` | 1145 | 535 | **53,3%** |
+| `claude-md-project.md` | 1122 | 636 | **43,3%** |
+| `todo-list.md` | 627 | 388 | **38,1%** |
+| `mixed-with-code.md` | 888 | 560 | **36,9%** |
+| **Media** | **898** | **481** | **46%** |
 
-Code blocks, URLs, file paths, commands, headings, dates, version numbers — anything technical passes through untouched. Only prose gets compressed. See the full [caveman-compress README](caveman-compress/README.md) for details. [Security note](./caveman-compress/SECURITY.md): Snyk flags this as High Risk due to subprocess/file patterns — it's a false positive.
+Bloques de código, URLs, rutas de archivo, comandos, headings, fechas, números de versión — todo lo técnico pasa sin tocar. Solo la prosa se comprime. Ver el [README completo de caveman-compress](caveman-compress/README.md) para más detalles. [Nota de seguridad](./caveman-compress/SECURITY.md): Snyk marca esto como Alto Riesgo por patrones de subprocess/archivos — es un falso positivo.
 
 ## Benchmarks
 
-Real token counts from the Claude API ([reproduce it yourself](benchmarks/)):
+Recuentos de tokens reales de la API de Claude ([reprodúcelo tú mismo](benchmarks/)):
 
 <!-- BENCHMARK-TABLE-START -->
-| Task | Normal (tokens) | Caveman (tokens) | Saved |
-|------|---------------:|----------------:|------:|
-| Explain React re-render bug | 1180 | 159 | 87% |
-| Fix auth middleware token expiry | 704 | 121 | 83% |
-| Set up PostgreSQL connection pool | 2347 | 380 | 84% |
-| Explain git rebase vs merge | 702 | 292 | 58% |
-| Refactor callback to async/await | 387 | 301 | 22% |
-| Architecture: microservices vs monolith | 446 | 310 | 30% |
-| Review PR for security issues | 678 | 398 | 41% |
-| Docker multi-stage build | 1042 | 290 | 72% |
-| Debug PostgreSQL race condition | 1200 | 232 | 81% |
-| Implement React error boundary | 3454 | 456 | 87% |
-| **Average** | **1214** | **294** | **65%** |
+| Tarea | Normal (tokens) | Caveman (tokens) | Ahorro |
+|-------|---------------:|----------------:|-------:|
+| Explicar bug de re-render en React | 1180 | 159 | 87% |
+| Arreglar expiración de token en auth middleware | 704 | 121 | 83% |
+| Configurar pool de conexiones PostgreSQL | 2347 | 380 | 84% |
+| Explicar git rebase vs merge | 702 | 292 | 58% |
+| Refactorizar callback a async/await | 387 | 301 | 22% |
+| Arquitectura: microservicios vs monolito | 446 | 310 | 30% |
+| Revisar PR por problemas de seguridad | 678 | 398 | 41% |
+| Build multi-stage de Docker | 1042 | 290 | 72% |
+| Depurar race condition en PostgreSQL | 1200 | 232 | 81% |
+| Implementar error boundary en React | 3454 | 456 | 87% |
+| **Media** | **1214** | **294** | **65%** |
 
-*Range: 22%–87% savings across prompts.*
+*Rango: 22%–87% de ahorro según el prompt.*
 <!-- BENCHMARK-TABLE-END -->
 
 > [!IMPORTANT]
-> Caveman only affects output tokens — thinking/reasoning tokens are untouched. Caveman no make brain smaller. Caveman make *mouth* smaller. Biggest win is **readability and speed**, cost savings are a bonus.
+> Caveman solo afecta a tokens de salida — los tokens de razonamiento/thinking no se tocan. Caveman no hace cerebro más pequeño. Caveman hace *boca* más pequeña. La mayor ganancia es **legibilidad y velocidad**, el ahorro de coste es un bonus.
 
-A March 2026 paper ["Brevity Constraints Reverse Performance Hierarchies in Language Models"](https://arxiv.org/abs/2604.00025) found that constraining large models to brief responses **improved accuracy by 26 percentage points** on certain benchmarks and completely reversed performance hierarchies. Verbose not always better. Sometimes less word = more correct.
+Un paper de marzo de 2026 ["Brevity Constraints Reverse Performance Hierarchies in Language Models"](https://arxiv.org/abs/2604.00025) encontró que limitar a los modelos grandes a respuestas breves **mejoró la precisión en 26 puntos porcentuales** en ciertos benchmarks e invirtió completamente las jerarquías de rendimiento. Verboso no siempre mejor. A veces menos palabra = más correcto.
 
 ## Evals
 
-Caveman not just claim 75%. Caveman **prove** it.
+Caveman no solo afirma 75%. Caveman lo **demuestra**.
 
-The `evals/` directory has a three-arm eval harness that measures real token compression against a proper control — not just "verbose vs skill" but "terse vs skill". Because comparing caveman to verbose Claude conflate the skill with generic terseness. That cheating. Caveman not cheat.
+El directorio `evals/` tiene un harness de evaluación de tres ramas que mide la compresión real de tokens frente a un control adecuado — no solo "verboso vs skill" sino "conciso vs skill". Porque comparar caveman con Claude verboso confunde el skill con tersura genérica. Eso es hacer trampa. Caveman no hace trampa.
 
 ```bash
-# Run the eval (needs claude CLI)
+# Ejecutar eval (necesita CLI de claude)
 uv run python evals/llm_run.py
 
-# Read results (no API key, runs offline)
+# Leer resultados (sin API key, ejecuta offline)
 uv run --with tiktoken python evals/measure.py
 ```
 
-## Star This Repo
+## Dale una estrella al repo
 
-If caveman save you mass token, mass money — leave mass star. ⭐
+Si caveman ahorra muchos tokens, muchos euros — dejar muchas estrellas. ⭐
 
 [![Star History Chart](https://api.star-history.com/svg?repos=JuliusBrussee/caveman&type=Date)](https://star-history.com/#JuliusBrussee/caveman&Date)
 
-## Also by Julius Brussee
+## También por Julius Brussee
 
-- **[Cavekit](https://github.com/JuliusBrussee/cavekit)** — specification-driven development for Claude Code. Caveman language → specs → parallel builds → working software.
-- **[Revu](https://github.com/JuliusBrussee/revu-swift)** — local-first macOS study app with FSRS spaced repetition, decks, exams, and study guides. [revu.cards](https://revu.cards)
+- **[Cavekit](https://github.com/JuliusBrussee/cavekit)** — desarrollo guiado por especificaciones para Claude Code. Lenguaje caveman → specs → builds paralelos → software funcionando.
+- **[Revu](https://github.com/JuliusBrussee/revu-swift)** — app de estudio local-first para macOS con repetición espaciada FSRS, mazos, exámenes y guías de estudio. [revu.cards](https://revu.cards)
 
-## License
+## Licencia
 
-MIT — free like mass mammoth on open plain.
+MIT — libre como mamut en llanura abierta.

--- a/caveman-compress/README.md
+++ b/caveman-compress/README.md
@@ -5,44 +5,44 @@
 <h1 align="center">caveman-compress</h1>
 
 <p align="center">
-  <strong>shrink memory file. save token every session.</strong>
+  <strong>comprimir archivo de memoria. ahorrar token en cada sesión.</strong>
 </p>
 
 ---
 
-A Claude Code skill that compresses your project memory files (`CLAUDE.md`, todos, preferences) into caveman format — so every session loads fewer tokens automatically.
+Un skill de Claude Code que comprime tus archivos de memoria del proyecto (`CLAUDE.md`, todos, preferencias) al formato caveman — para que cada sesión cargue menos tokens automáticamente.
 
-Claude read `CLAUDE.md` on every session start. If file big, cost big. Caveman make file small. Cost go down forever.
+Claude lee `CLAUDE.md` en cada inicio de sesión. Si archivo grande, coste grande. Caveman hace archivo pequeño. Coste baja para siempre.
 
-## What It Do
+## Qué Hace
 
 ```
 /caveman:compress CLAUDE.md
 ```
 
 ```
-CLAUDE.md          ← compressed (Claude reads this — fewer tokens every session)
-CLAUDE.original.md ← human-readable backup (you edit this)
+CLAUDE.md          ← comprimido (Claude lee esto — menos tokens en cada sesión)
+CLAUDE.original.md ← backup legible (tú editas esto)
 ```
 
-Original never lost. You can read and edit `.original.md`. Run skill again to re-compress after edits.
+El original nunca se pierde. Puedes leer y editar `.original.md`. Ejecutar el skill de nuevo para re-comprimir tras las ediciones.
 
 ## Benchmarks
 
-Real results on real project files:
+Resultados reales en archivos reales de proyectos:
 
-| File | Original | Compressed | Saved |
-|------|----------:|----------:|------:|
-| `claude-md-preferences.md` | 706 | 285 | **59.6%** |
-| `project-notes.md` | 1145 | 535 | **53.3%** |
-| `claude-md-project.md` | 1122 | 636 | **43.3%** |
-| `todo-list.md` | 627 | 388 | **38.1%** |
-| `mixed-with-code.md` | 888 | 560 | **36.9%** |
-| **Average** | **898** | **481** | **46%** |
+| Archivo | Original | Comprimido | Ahorro |
+|---------|----------:|----------:|-------:|
+| `claude-md-preferences.md` | 706 | 285 | **59,6%** |
+| `project-notes.md` | 1145 | 535 | **53,3%** |
+| `claude-md-project.md` | 1122 | 636 | **43,3%** |
+| `todo-list.md` | 627 | 388 | **38,1%** |
+| `mixed-with-code.md` | 888 | 560 | **36,9%** |
+| **Media** | **898** | **481** | **46%** |
 
-All validations passed ✅ — headings, code blocks, URLs, file paths preserved exactly.
+Todas las validaciones pasaron ✅ — headings, bloques de código, URLs, rutas de archivo preservados exactamente.
 
-## Before / After
+## Antes / Después
 
 <table>
 <tr>
@@ -63,101 +63,101 @@ All validations passed ✅ — headings, code blocks, URLs, file paths preserved
 </tr>
 </table>
 
-**Same instructions. 60% fewer tokens. Every. Single. Session.**
+**Mismas instrucciones. 60% menos tokens. Cada. Sesión.**
 
-## Security
+## Seguridad
 
-`caveman-compress` is flagged as Snyk High Risk due to subprocess and file I/O patterns detected by static analysis. This is a false positive — see [SECURITY.md](./SECURITY.md) for a full explanation of what the skill does and does not do.
+`caveman-compress` está marcado como Alto Riesgo por Snyk debido a patrones de subprocess y E/S de archivos detectados por análisis estático. Es un falso positivo — ver [SECURITY.md](./SECURITY.md) para una explicación completa de lo que el skill hace y no hace.
 
-## Install
+## Instalar
 
-Compress is built in with the `caveman` plugin. Install `caveman` once, then use `/caveman:compress`.
+Compress está incluido con el plugin `caveman`. Instala `caveman` una vez, luego usa `/caveman:compress`.
 
-If you need local files, the compress skill lives at:
+Si necesitas los archivos locales, el skill de compress está en:
 
 ```bash
 caveman-compress/
 ```
 
-**Requires:** Python 3.10+
+**Requiere:** Python 3.10+
 
-## Usage
+## Uso
 
 ```
-/caveman:compress <filepath>
+/caveman:compress <ruta_archivo>
 ```
 
-Examples:
+Ejemplos:
 ```
 /caveman:compress CLAUDE.md
 /caveman:compress docs/preferences.md
 /caveman:compress todos.md
 ```
 
-### What files work
+### Qué archivos funcionan
 
-| Type | Compress? |
-|------|-----------|
-| `.md`, `.txt`, `.rst` | ✅ Yes |
-| Extensionless natural language | ✅ Yes |
-| `.py`, `.js`, `.ts`, `.json`, `.yaml` | ❌ Skip (code/config) |
-| `*.original.md` | ❌ Skip (backup files) |
+| Tipo | ¿Comprimir? |
+|------|-------------|
+| `.md`, `.txt`, `.rst` | ✅ Sí |
+| Lenguaje natural sin extensión | ✅ Sí |
+| `.py`, `.js`, `.ts`, `.json`, `.yaml` | ❌ Ignorar (código/config) |
+| `*.original.md` | ❌ Ignorar (archivos de backup) |
 
-## How It Work
+## Cómo Funciona
 
 ```
 /caveman:compress CLAUDE.md
         ↓
-detect file type        (no tokens)
+detectar tipo de archivo        (sin tokens)
         ↓
-Claude compresses       (tokens — one call)
+Claude comprime                 (tokens — una llamada)
         ↓
-validate output         (no tokens)
-  checks: headings, code blocks, URLs, file paths, bullets
+validar salida                  (sin tokens)
+  comprueba: headings, bloques de código, URLs, rutas de archivo, viñetas
         ↓
-if errors: Claude fixes cherry-picked issues only   (tokens — targeted fix)
-  does NOT recompress — only patches broken parts
+si errores: Claude fix solo problemas concretos   (tokens — fix específico)
+  NO recomprime — solo parchea las partes rotas
         ↓
-retry up to 2 times
+reintentar hasta 2 veces
         ↓
-write compressed → CLAUDE.md
-write original   → CLAUDE.original.md
+escribir comprimido → CLAUDE.md
+escribir original   → CLAUDE.original.md
 ```
 
-Only two things use tokens: initial compression + targeted fix if validation fails. Everything else is local Python.
+Solo dos cosas usan tokens: compresión inicial + fix específico si falla la validación. Todo lo demás es Python local.
 
-## What Is Preserved
+## Qué se Preserva
 
-Caveman compress natural language. It never touch:
+Caveman comprime lenguaje natural. Nunca toca:
 
-- Code blocks (` ``` ` fenced or indented)
-- Inline code (`` `backtick content` ``)
-- URLs and links
-- File paths (`/src/components/...`)
-- Commands (`npm install`, `git commit`)
-- Technical terms, library names, API names
-- Headings (exact text preserved)
-- Tables (structure preserved, cell text compressed)
-- Dates, version numbers, numeric values
+- Bloques de código (` ``` ` cercados o indentados)
+- Código inline (`` `contenido backtick` ``)
+- URLs y enlaces
+- Rutas de archivo (`/src/components/...`)
+- Comandos (`npm install`, `git commit`)
+- Términos técnicos, nombres de librerías, nombres de APIs
+- Headings (texto exacto preservado)
+- Tablas (estructura preservada, texto de celdas comprimido)
+- Fechas, números de versión, valores numéricos
 
-## Why This Matter
+## Por Qué Importa
 
-`CLAUDE.md` loads on **every session start**. A 1000-token project memory file costs tokens every single time you open a project. Over 100 sessions that's 100,000 tokens of overhead — just for context you already wrote.
+`CLAUDE.md` carga en **cada inicio de sesión**. Un archivo de memoria del proyecto de 1000 tokens cuesta tokens cada vez que abres un proyecto. En 100 sesiones son 100.000 tokens de overhead — solo por contexto que ya escribiste.
 
-Caveman cut that by ~46% on average. Same instructions. Same accuracy. Less waste.
+Caveman lo reduce ~46% de media. Mismas instrucciones. Misma precisión. Menos desperdicio.
 
 ```
 ┌────────────────────────────────────────────┐
-│  TOKEN SAVINGS PER FILE    █████       46% │
-│  SESSIONS THAT BENEFIT     ██████████ 100% │
-│  INFORMATION PRESERVED     ██████████ 100% │
-│  SETUP TIME                █            1x │
+│  AHORRO DE TOKENS POR ARCHIVO  █████   46% │
+│  SESIONES QUE SE BENEFICIAN    ██████ 100% │
+│  INFORMACIÓN PRESERVADA        ██████ 100% │
+│  TIEMPO DE CONFIGURACIÓN       █         1x│
 └────────────────────────────────────────────┘
 ```
 
-## Part of Caveman
+## Parte de Caveman
 
-This skill is part of the [caveman](https://github.com/JuliusBrussee/caveman) toolkit — making Claude use fewer tokens without losing accuracy.
+Este skill es parte del toolkit [caveman](https://github.com/JuliusBrussee/caveman) — haciendo que Claude use menos tokens sin perder precisión.
 
-- **caveman** — make Claude *speak* like caveman (cuts response tokens ~65%)
-- **caveman-compress** — make Claude *read* less (cuts context tokens ~46%)
+- **caveman** — hace que Claude *hable* como cavernícola (recorta tokens de respuesta ~65%)
+- **caveman-compress** — hace que Claude *lea* menos (recorta tokens de contexto ~46%)

--- a/caveman-compress/SECURITY.md
+++ b/caveman-compress/SECURITY.md
@@ -1,31 +1,31 @@
-# Security
+# Seguridad
 
-## Snyk High Risk Rating
+## Calificación de Alto Riesgo de Snyk
 
-`caveman-compress` receives a Snyk High Risk rating due to static analysis heuristics. This document explains what the skill does and does not do.
+`caveman-compress` recibe una calificación de Alto Riesgo de Snyk debido a heurísticas de análisis estático. Este documento explica lo que el skill hace y no hace.
 
-### What triggers the rating
+### Qué activa la calificación
 
-1. **subprocess usage**: The skill calls the `claude` CLI via `subprocess.run()` as a fallback when `ANTHROPIC_API_KEY` is not set. The subprocess call uses a fixed argument list — no shell interpolation occurs. User file content is passed via stdin, not as a shell argument.
+1. **Uso de subprocess**: El skill llama a la CLI `claude` vía `subprocess.run()` como fallback cuando `ANTHROPIC_API_KEY` no está establecida. La llamada al subprocess usa una lista de argumentos fija — no ocurre interpolación de shell. El contenido del archivo de usuario se pasa vía stdin, no como argumento de shell.
 
-2. **File read/write**: The skill reads the file the user explicitly points it at, compresses it, and writes the result back to the same path. A `.original.md` backup is saved alongside it. No files outside the user-specified path are read or written.
+2. **Lectura/escritura de archivos**: El skill lee el archivo al que el usuario lo apunta explícitamente, lo comprime, y escribe el resultado de vuelta en la misma ruta. Se guarda un backup `.original.md` junto a él. No se leen ni escriben archivos fuera de la ruta especificada por el usuario.
 
-### What the skill does NOT do
+### Lo que el skill NO hace
 
-- Does not execute user file content as code
-- Does not make network requests except to Anthropic's API (via SDK or CLI)
-- Does not access files outside the path the user provides
-- Does not use shell=True or string interpolation in subprocess calls
-- Does not collect or transmit any data beyond the file being compressed
+- No ejecuta el contenido del archivo de usuario como código
+- No hace peticiones de red excepto a la API de Anthropic (vía SDK o CLI)
+- No accede a archivos fuera de la ruta que el usuario proporciona
+- No usa `shell=True` ni interpolación de cadenas en llamadas a subprocess
+- No recopila ni transmite ningún dato más allá del archivo que se está comprimiendo
 
-### Auth behavior
+### Comportamiento de autenticación
 
-If `ANTHROPIC_API_KEY` is set, the skill uses the Anthropic Python SDK directly (no subprocess). If not set, it falls back to the `claude` CLI, which uses the user's existing Claude desktop authentication.
+Si `ANTHROPIC_API_KEY` está establecida, el skill usa el SDK de Python de Anthropic directamente (sin subprocess). Si no está establecida, recurre a la CLI `claude`, que usa la autenticación de escritorio de Claude existente del usuario.
 
-### File size limit
+### Límite de tamaño de archivo
 
-Files larger than 500KB are rejected before any API call is made.
+Los archivos mayores de 500KB son rechazados antes de que se haga cualquier llamada a la API.
 
-### Reporting a vulnerability
+### Reportar una vulnerabilidad
 
-If you believe you've found a genuine security issue, please open a GitHub issue with the label `security`.
+Si crees que has encontrado un problema de seguridad genuino, abre un issue en GitHub con la etiqueta `security`.

--- a/caveman-compress/SKILL.md
+++ b/caveman-compress/SKILL.md
@@ -1,111 +1,111 @@
 ---
 name: caveman-compress
 description: >
-  Compress natural language memory files (CLAUDE.md, todos, preferences) into caveman format
-  to save input tokens. Preserves all technical substance, code, URLs, and structure.
-  Compressed version overwrites the original file. Human-readable backup saved as FILE.original.md.
-  Trigger: /caveman:compress <filepath> or "compress memory file"
+  Comprime archivos de memoria en lenguaje natural (CLAUDE.md, todos, preferencias) al formato
+  caveman para ahorrar tokens de entrada. Preserva toda la sustancia técnica, código, URLs y estructura.
+  La versión comprimida sobreescribe el archivo original. El backup legible se guarda como FILE.original.md.
+  Activar: /caveman:compress <ruta_archivo> o "comprimir archivo de memoria"
 ---
 
 # Caveman Compress
 
-## Purpose
+## Propósito
 
-Compress natural language files (CLAUDE.md, todos, preferences) into caveman-speak to reduce input tokens. Compressed version overwrites original. Human-readable backup saved as `<filename>.original.md`.
+Comprimir archivos en lenguaje natural (CLAUDE.md, todos, preferencias) a estilo caveman para reducir tokens de entrada. La versión comprimida sobreescribe el original. El backup legible se guarda como `<nombre_archivo>.original.md`.
 
-## Trigger
+## Activación
 
-`/caveman:compress <filepath>` or when user asks to compress a memory file.
+`/caveman:compress <ruta_archivo>` o cuando el usuario pida comprimir un archivo de memoria.
 
-## Process
+## Proceso
 
-1. The compression scripts live in `caveman-compress/scripts/` (adjacent to this SKILL.md). If the path is not immediately available, search for `caveman-compress/scripts/__main__.py`.
+1. Los scripts de compresión están en `caveman-compress/scripts/` (junto a este SKILL.md). Si la ruta no está disponible inmediatamente, buscar `caveman-compress/scripts/__main__.py`.
 
-2. Run:
+2. Ejecutar:
 
-cd caveman-compress && python3 -m scripts <absolute_filepath>
+cd caveman-compress && python3 -m scripts <ruta_absoluta_archivo>
 
-3. The CLI will:
-- detect file type (no tokens)
-- call Claude to compress
-- validate output (no tokens)
-- if errors: cherry-pick fix with Claude (targeted fixes only, no recompression)
-- retry up to 2 times
-- if still failing after 2 retries: report error to user, leave original file untouched
+3. La CLI:
+- detecta el tipo de archivo (sin tokens)
+- llama a Claude para comprimir
+- valida la salida (sin tokens)
+- si hay errores: aplica fix específico con Claude (solo parches concretos, sin recompresión)
+- reintenta hasta 2 veces
+- si sigue fallando tras 2 reintentos: reportar error al usuario, dejar archivo original sin tocar
 
-4. Return result to user
+4. Devolver resultado al usuario
 
-## Compression Rules
+## Reglas de Compresión
 
-### Remove
-- Articles: a, an, the
-- Filler: just, really, basically, actually, simply, essentially, generally
-- Pleasantries: "sure", "certainly", "of course", "happy to", "I'd recommend"
-- Hedging: "it might be worth", "you could consider", "it would be good to"
-- Redundant phrasing: "in order to" → "to", "make sure to" → "ensure", "the reason is because" → "because"
-- Connective fluff: "however", "furthermore", "additionally", "in addition"
+### Eliminar
+- Artículos: un, una, el, la, los, las
+- Relleno: just, really, básicamente, realmente, simplemente, esencialmente, generalmente
+- Formalidades: "claro", "por supuesto", "encantado de", "recomendaría"
+- Vacilaciones: "podría valer la pena", "podrías considerar", "sería bueno"
+- Frases redundantes: "con el fin de" → "para", "asegurarse de" → "asegurar", "la razón es porque" → "porque"
+- Relleno conectivo: "sin embargo", "además", "adicionalmente", "por otro lado"
 
-### Preserve EXACTLY (never modify)
-- Code blocks (fenced ``` and indented)
-- Inline code (`backtick content`)
-- URLs and links (full URLs, markdown links)
-- File paths (`/src/components/...`, `./config.yaml`)
-- Commands (`npm install`, `git commit`, `docker build`)
-- Technical terms (library names, API names, protocols, algorithms)
-- Proper nouns (project names, people, companies)
-- Dates, version numbers, numeric values
-- Environment variables (`$HOME`, `NODE_ENV`)
+### Preservar EXACTAMENTE (nunca modificar)
+- Bloques de código (cercados con ``` e indentados)
+- Código inline (contenido en `backticks`)
+- URLs y enlaces (URLs completas, enlaces markdown)
+- Rutas de archivo (`/src/components/...`, `./config.yaml`)
+- Comandos (`npm install`, `git commit`, `docker build`)
+- Términos técnicos (nombres de librerías, APIs, protocolos, algoritmos)
+- Nombres propios (nombres de proyectos, personas, empresas)
+- Fechas, números de versión, valores numéricos
+- Variables de entorno (`$HOME`, `NODE_ENV`)
 
-### Preserve Structure
-- All markdown headings (keep exact heading text, compress body below)
-- Bullet point hierarchy (keep nesting level)
-- Numbered lists (keep numbering)
-- Tables (compress cell text, keep structure)
-- Frontmatter/YAML headers in markdown files
+### Preservar Estructura
+- Todos los headings markdown (mantener texto exacto del heading, comprimir cuerpo debajo)
+- Jerarquía de viñetas (mantener nivel de anidamiento)
+- Listas numeradas (mantener numeración)
+- Tablas (comprimir texto de celdas, mantener estructura)
+- Frontmatter/cabeceras YAML en archivos markdown
 
-### Compress
-- Use short synonyms: "big" not "extensive", "fix" not "implement a solution for", "use" not "utilize"
-- Fragments OK: "Run tests before commit" not "You should always run tests before committing"
-- Drop "you should", "make sure to", "remember to" — just state the action
-- Merge redundant bullets that say the same thing differently
-- Keep one example where multiple examples show the same pattern
+### Comprimir
+- Usar sinónimos cortos: "grande" no "extenso", "fix" no "implementar una solución para", "usar" no "utilizar"
+- Fragmentos OK: "Ejecutar tests antes de commit" no "Siempre deberías ejecutar los tests antes de hacer commit"
+- Eliminar "deberías", "asegúrate de", "recuerda" — solo enunciar la acción
+- Fusionar viñetas redundantes que dicen lo mismo de forma diferente
+- Mantener un ejemplo donde múltiples ejemplos muestran el mismo patrón
 
-CRITICAL RULE:
-Anything inside ``` ... ``` must be copied EXACTLY.
-Do not:
-- remove comments
-- remove spacing
-- reorder lines
-- shorten commands
-- simplify anything
+REGLA CRÍTICA:
+Cualquier cosa dentro de ``` ... ``` debe copiarse EXACTAMENTE.
+No:
+- eliminar comentarios
+- eliminar espacios
+- reordenar líneas
+- acortar comandos
+- simplificar nada
 
-Inline code (`...`) must be preserved EXACTLY.
-Do not modify anything inside backticks.
+El código inline (`...`) debe preservarse EXACTAMENTE.
+No modificar nada dentro de backticks.
 
-If file contains code blocks:
-- Treat code blocks as read-only regions
-- Only compress text outside them
-- Do not merge sections around code
+Si el archivo contiene bloques de código:
+- Tratar los bloques de código como regiones de solo lectura
+- Solo comprimir texto fuera de ellos
+- No fusionar secciones alrededor de código
 
-## Pattern
-
-Original:
-> You should always make sure to run the test suite before pushing any changes to the main branch. This is important because it helps catch bugs early and prevents broken builds from being deployed to production.
-
-Compressed:
-> Run tests before push to main. Catch bugs early, prevent broken prod deploys.
+## Patrón
 
 Original:
-> The application uses a microservices architecture with the following components. The API gateway handles all incoming requests and routes them to the appropriate service. The authentication service is responsible for managing user sessions and JWT tokens.
+> Siempre deberías asegurarte de ejecutar la suite de tests antes de hacer push de cualquier cambio a la rama main. Esto es importante porque ayuda a detectar bugs pronto y evita que builds rotos se desplieguen a producción.
 
-Compressed:
-> Microservices architecture. API gateway route all requests to services. Auth service manage user sessions + JWT tokens.
+Comprimido:
+> Ejecutar tests antes de push a main. Detectar bugs pronto, prevenir deploys rotos en prod.
 
-## Boundaries
+Original:
+> La aplicación usa una arquitectura de microservicios con los siguientes componentes. El API gateway gestiona todas las peticiones entrantes y las enruta al servicio apropiado. El servicio de autenticación se encarga de gestionar las sesiones de usuario y los tokens JWT.
 
-- ONLY compress natural language files (.md, .txt, extensionless)
-- NEVER modify: .py, .js, .ts, .json, .yaml, .yml, .toml, .env, .lock, .css, .html, .xml, .sql, .sh
-- If file has mixed content (prose + code), compress ONLY the prose sections
-- If unsure whether something is code or prose, leave it unchanged
-- Original file is backed up as FILE.original.md before overwriting
-- Never compress FILE.original.md (skip it)
+Comprimido:
+> Arquitectura microservicios. API gateway enruta todas las peticiones a los servicios. Servicio auth gestiona sesiones usuario + tokens JWT.
+
+## Límites
+
+- SOLO comprimir archivos en lenguaje natural (.md, .txt, sin extensión)
+- NUNCA modificar: .py, .js, .ts, .json, .yaml, .yml, .toml, .env, .lock, .css, .html, .xml, .sql, .sh
+- Si el archivo tiene contenido mixto (prosa + código), comprimir SOLO las secciones de prosa
+- Si hay duda sobre si algo es código o prosa, dejarlo sin cambios
+- El archivo original se respalda como FILE.original.md antes de sobreescribir
+- Nunca comprimir FILE.original.md (ignorarlo)

--- a/caveman/SKILL.md
+++ b/caveman/SKILL.md
@@ -3,65 +3,84 @@ name: caveman
 description: >
   Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
   while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
-  wenyan-lite, wenyan-full, wenyan-ultra.
-  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
-  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+  wenyan-lite, wenyan-full, wenyan-ultra. Supports language targeting: /caveman es (Spanish),
+  /caveman en (English). Without language flag, matches the user's language automatically.
+  Use when user says "caveman mode", "talk like caveman", "modo caveman", "habla como cavernícola",
+  "less tokens", "menos tokens", or invokes /caveman.
 ---
 
 Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
+## Language
+
+**Default (no lang flag):** detect user language and respond in same language using caveman style.
+**With lang flag** (`/caveman es`, `/caveman en`): always respond in that language regardless of input.
+
 ## Persistence
 
-ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure.
+Off only: "stop caveman" / "normal mode" / "modo normal".
 
-Default: **full**. Switch: `/caveman lite|full|ultra`.
+Default: **full**. Switch: `/caveman lite|full|ultra`. Language: `/caveman es|en`.
+Combine: `/caveman lite es`, `/caveman ultra en`.
 
 ## Rules
 
-Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+**English — Drop:** articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
 
-Pattern: `[thing] [action] [reason]. [next step].`
+**Castellano — Eliminar:** artículos (un/una/el/la/los/las/unos/unas), relleno (básicamente/realmente/simplemente/esencialmente/solo/tan solo), formalidades (claro/por supuesto/encantado/desde luego), vacilaciones (quizás/tal vez/podría ser/creo que). Fragmentos OK. Sinónimos cortos. Términos técnicos exactos. Código sin cambios.
 
-Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
-Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+Pattern / Patrón: `[thing/cosa] [action/acción] [reason/razón]. [next step/siguiente paso].`
 
 ## Intensity
 
-| Level | What change |
-|-------|------------|
-| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
-| **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
-| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
-| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
-| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
-| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+| Level | What changes |
+|-------|-------------|
+| **lite** | Drop filler/hedging. Keep articles + full sentences. Professional but tight. |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman. |
+| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), arrows for causality (X → Y), one word when one word enough. |
+| **wenyan-lite** | Semi-classical Chinese. Drop filler but keep grammar. |
+| **wenyan-full** | Full 文言文. Maximum classical terseness. |
+| **wenyan-ultra** | Extreme. Ancient scholar on a budget. |
 
-Example — "Why React component re-render?"
-- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
-- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
-- ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+## Examples
+
+**English — "Why React component re-render?"**
+- lite-en: "Component re-renders because you create a new object reference each render. Wrap in `useMemo`."
+- full-en: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra-en: "Inline obj prop → new ref → re-render. `useMemo`."
+
+**Castellano — "¿Por qué hace re-render el componente React?"**
+- lite-es: "Tu componente hace re-render porque creas una nueva referencia de objeto en cada render. Envuélvelo en `useMemo`."
+- full-es: "Nueva ref objeto en cada render. Prop inline = nueva ref = re-render. Envolver en `useMemo`."
+- ultra-es: "Prop inline → nueva ref → re-render. `useMemo`."
+
+**English — "Explain database connection pooling."**
+- lite-en: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full-en: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra-en: "Pool = reuse DB conn. Skip handshake → fast under load."
+
+**Castellano — "Explica el connection pooling."**
+- lite-es: "El connection pooling reutiliza conexiones abiertas en lugar de crear nuevas por petición. Evita la sobrecarga del handshake."
+- full-es: "Pool reutiliza conexiones DB abiertas. Sin nueva conexión por petición. Skip overhead handshake."
+- ultra-es: "Pool = reutilizar conn DB. Skip handshake → rápido bajo carga."
+
+**Wenyan — "Why React component re-render?"**
 - wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
-- wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
+- wenyan-full: "物出新參照，致重繪。useMemo Wrap之。"
 - wenyan-ultra: "新參照→重繪。useMemo Wrap。"
-
-Example — "Explain database connection pooling."
-- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
-- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
-- ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
-- wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
-- wenyan-ultra: "池reuse conn。skip handshake → fast。"
 
 ## Auto-Clarity
 
-Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.
+Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user confused or repeating question. Resume after.
 
 Example — destructive op:
-> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> **Warning / Advertencia:** This will permanently delete all rows in `users` and cannot be undone. / Esto eliminará permanentemente todas las filas de `users` y no se puede deshacer.
 > ```sql
 > DROP TABLE users;
 > ```
-> Caveman resume. Verify backup exist first.
+> Caveman resume. Verify backup exist first. / Caveman reanuda. Verificar backup primero.
 
 ## Boundaries
 
-Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+Code/commits/PRs: write normal. "stop caveman" / "normal mode" / "modo normal": revert. Level + language persist until changed or session ends.

--- a/commands/caveman-commit.toml
+++ b/commands/caveman-commit.toml
@@ -1,2 +1,2 @@
-description = "Generate terse caveman-style commit message"
-prompt = "Generate a terse commit message for the current staged changes. Conventional Commits format. Subject: ≤50 chars, imperative, lowercase after type. Body: only when 'why' isn't obvious from subject. Why over what. No period on subject."
+description = "Generar mensaje de commit conciso estilo caveman"
+prompt = "Generar un mensaje de commit conciso para los cambios actuales en staging. Formato Conventional Commits. Asunto: ≤50 chars, imperativo, minúsculas tras el tipo. Cuerpo: solo cuando el 'por qué' no es obvio en el asunto. Por qué antes que qué. Sin punto final en el asunto."

--- a/commands/caveman-review.toml
+++ b/commands/caveman-review.toml
@@ -1,2 +1,2 @@
-description = "One-line code review comments"
-prompt = "Review the current code changes. One-line per finding. Format: L<line>: <severity> <problem>. <fix>. Severity: bug, risk, nit, q. Skip praise. Skip obvious. If code look good, say 'LGTM' and stop."
+description = "Comentarios de revisión de código de una línea"
+prompt = "Revisar los cambios de código actuales. Una línea por hallazgo. Formato: L<línea>: <severidad> <problema>. <fix>. Severidad: bug, risk, nit, q. Omitir elogios. Omitir lo obvio. Si el código se ve bien, decir 'LGTM' y parar."

--- a/commands/caveman.toml
+++ b/commands/caveman.toml
@@ -1,2 +1,2 @@
-description = "Switch caveman intensity level (lite/full/ultra/wenyan)"
-prompt = "Switch to caveman {{args}} mode. If no level specified, use full. Respond terse like smart caveman — drop articles, filler, pleasantries. Fragments OK. Technical terms exact. Code unchanged. Pattern: [thing] [action] [reason]. [next step]."
+description = "Cambiar nivel de intensidad caveman (lite/full/ultra/wenyan)"
+prompt = "Cambiar a modo caveman {{args}}. Si no se especifica nivel, usar full. Responder conciso como cavernícola inteligente — eliminar artículos, relleno, formalidades. Fragmentos OK. Términos técnicos exactos. Código sin cambios. Patrón: [cosa] [acción] [razón]. [siguiente paso]."

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,84 +1,83 @@
 # Evals
 
-Measures real token compression of caveman skills by running the same
-prompts through Claude Code under three conditions and comparing the
-generated output token counts.
+Mide la compresión real de tokens de los skills caveman ejecutando los mismos
+prompts a través de Claude Code bajo tres condiciones y comparando los
+recuentos de tokens de salida generados.
 
-## The three arms
+## Las tres ramas
 
-| Arm | System prompt |
-|-----|--------------|
-| `__baseline__` | none |
+| Rama | System prompt |
+|------|--------------|
+| `__baseline__` | ninguno |
 | `__terse__` | `Answer concisely.` |
 | `<skill>` | `Answer concisely.\n\n{SKILL.md}` |
 
-The honest delta for any skill is **`<skill>` vs `__terse__`** — i.e.
-how much the skill itself adds on top of a plain "be terse" instruction.
-Comparing a skill to the no-system-prompt baseline conflates the skill
-with the generic terseness ask, which is what an earlier version of
-this harness did and is why its numbers were inflated.
+El delta honesto para cualquier skill es **`<skill>` vs `__terse__`** — es decir,
+cuánto añade el skill por encima de una instrucción simple de "sé conciso".
+Comparar un skill con el baseline sin system prompt confunde el skill
+con la petición de tersura genérica, que es lo que hacía una versión anterior
+de este harness y por eso sus números estaban inflados.
 
-## Why this design
+## Por qué este diseño
 
-- **Real LLM output**, not hand-written examples (no circularity).
-- **Same Claude Code** the skills target — no separate API key.
-- **Snapshot committed to git** so CI runs are deterministic and free,
-  and so any change to the numbers is reviewable as a diff.
-- **Control arm** isolates the skill's contribution from the generic
-  "be terse" effect.
+- **Salida LLM real**, no ejemplos escritos a mano (sin circularidad).
+- **El mismo Claude Code** que los skills tienen como objetivo — sin API key separada.
+- **Snapshot guardado en git** para que las ejecuciones de CI sean deterministas y gratuitas,
+  y para que cualquier cambio en los números sea revisable como diff.
+- **Rama de control** aísla la contribución del skill del efecto genérico
+  "sé conciso".
 
-## Files
+## Archivos
 
-- `prompts/en.txt` — fixed list of dev questions, one per line.
-- `llm_run.py` — runs `claude -p --system-prompt …` per (prompt, arm),
-  captures real LLM output, writes `snapshots/results.json` along with
-  metadata (model, CLI version, generation timestamp).
-- `measure.py` — reads the snapshot, counts tokens with tiktoken
-  `o200k_base`, prints a markdown table with median / mean / min / max /
-  stdev across prompts.
-- `snapshots/results.json` — committed source of truth, regenerated only
-  when SKILL.md files or prompts change.
+- `prompts/en.txt` — lista fija de preguntas de desarrollo, una por línea.
+- `llm_run.py` — ejecuta `claude -p --system-prompt …` por (prompt, rama),
+  captura salida LLM real, escribe `snapshots/results.json` junto con
+  metadatos (modelo, versión CLI, timestamp de generación).
+- `measure.py` — lee el snapshot, cuenta tokens con tiktoken
+  `o200k_base`, imprime tabla markdown con mediana / media / mín / máx /
+  desviación estándar por prompts.
+- `snapshots/results.json` — fuente de verdad guardada, regenerada solo
+  cuando cambian los archivos SKILL.md o los prompts.
 
-## Refresh the snapshot (requires `claude` CLI logged in)
+## Regenerar el snapshot (requiere CLI `claude` con sesión activa)
 
 ```bash
 uv run python evals/llm_run.py
 ```
 
-This calls Claude once per prompt × (N skills + 2 control arms). Use
-a small model to keep it cheap:
+Esto llama a Claude una vez por prompt × (N skills + 2 ramas de control). Usar
+un modelo pequeño para mantener el coste bajo:
 
 ```bash
 CAVEMAN_EVAL_MODEL=claude-haiku-4-5 uv run python evals/llm_run.py
 ```
 
-## Read the snapshot (no LLM, no API key, runs in CI)
+## Leer el snapshot (sin LLM, sin API key, ejecuta en CI)
 
 ```bash
 uv run --with tiktoken python evals/measure.py
 ```
 
-## Adding a prompt
+## Añadir un prompt
 
-Append a line to `prompts/en.txt`, then refresh the snapshot.
+Añadir una línea a `prompts/en.txt`, luego regenerar el snapshot.
 
-## Adding a skill
+## Añadir un skill
 
-Drop a `skills/<name>/SKILL.md`, then refresh the snapshot. `llm_run.py`
-picks up every skill directory automatically.
+Depositar un `skills/<nombre>/SKILL.md`, luego regenerar el snapshot. `llm_run.py`
+detecta automáticamente todos los directorios de skills.
 
-## What this does NOT measure
+## Qué NO mide esto
 
-- **Fidelity** — does the compressed answer preserve the technical
-  claims? A skill that replies `k` to everything would score −99% and
-  "win". A future v2 could add a judge-model rubric.
-- **Latency or cost** — out of scope. Note that skills add input tokens
-  on every call, so output savings are not the full economic picture.
-- **Cross-model behavior** — only the model used to generate the
-  snapshot is measured.
-- **Exact Claude tokens** — `tiktoken o200k_base` is OpenAI's BPE and is
-  only an approximation of Claude's tokenizer. Ratios between arms are
-  meaningful; absolute numbers are approximate.
-- **Statistical significance** — single run per (prompt, arm) at default
-  temperature. The min/max/stdev columns let you eyeball whether a
-  number is solid or noisy, but this is not a powered experiment.
+- **Fidelidad** — ¿preserva la respuesta comprimida las afirmaciones técnicas?
+  Un skill que responda `k` a todo puntuaría −99% y "ganaría". Una v2 futura
+  podría añadir una rúbrica de modelo-juez.
+- **Latencia o coste** — fuera de alcance. Nótese que los skills añaden tokens de
+  entrada en cada llamada, así que el ahorro en salida no es la imagen económica completa.
+- **Comportamiento entre modelos** — solo se mide el modelo usado para generar el snapshot.
+- **Tokens exactos de Claude** — `tiktoken o200k_base` es el BPE de OpenAI y es
+  solo una aproximación del tokenizador de Claude. Las ratios entre ramas son
+  significativas; los números absolutos son aproximados.
+- **Significancia estadística** — ejecución única por (prompt, rama) a temperatura
+  predeterminada. Las columnas mín/máx/desviación permiten estimar si un número
+  es sólido o ruidoso, pero esto no es un experimento con potencia estadística.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "caveman",
-  "description": "Ultra-compressed communication mode. Cuts ~75% of tokens while keeping full technical accuracy by speaking like a caveman.",
+  "description": "Modo de comunicación ultra-comprimido. Recorta ~75% de tokens manteniendo plena precisión técnica hablando como cavernícola.",
   "version": "1.0.0",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,46 +1,46 @@
-# Caveman Hooks
+# Hooks de Caveman
 
-These hooks are **bundled with the caveman plugin** and activate automatically when the plugin is installed. No manual setup required.
+Estos hooks están **incluidos en el plugin caveman** y se activan automáticamente cuando el plugin se instala. No se requiere configuración manual.
 
-If you installed caveman standalone (without the plugin), you can use `bash hooks/install.sh` to wire them into your settings.json manually.
+Si instalaste caveman de forma standalone (sin el plugin), puedes usar `bash hooks/install.sh` para conectarlos a tu settings.json manualmente.
 
-## What's Included
+## Qué se incluye
 
-### `caveman-activate.js` — SessionStart hook
+### `caveman-activate.js` — Hook SessionStart
 
-- Runs once when Claude Code starts
-- Writes `full` to `~/.claude/.caveman-active` (flag file)
-- Emits caveman rules as hidden SessionStart context
-- Detects missing statusline config and emits setup nudge (Claude will offer to help)
+- Se ejecuta una vez cuando Claude Code arranca
+- Escribe `full` en `~/.claude/.caveman-active` (archivo de bandera)
+- Emite las reglas caveman como contexto SessionStart oculto
+- Detecta configuración de statusline faltante y emite sugerencia de configuración (Claude ofrecerá ayuda)
 
-### `caveman-mode-tracker.js` — UserPromptSubmit hook
+### `caveman-mode-tracker.js` — Hook UserPromptSubmit
 
-- Fires on every user prompt, checks for `/caveman` commands
-- Writes the active mode to the flag file when a caveman command is detected
-- Supports: `full`, `lite`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-ultra`, `commit`, `review`, `compress`
+- Se dispara en cada prompt de usuario, comprueba comandos `/caveman`
+- Escribe el modo activo en el archivo de bandera cuando detecta un comando caveman
+- Soporta: `full`, `lite`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-ultra`, `commit`, `review`, `compress`
 
-### `caveman-statusline.sh` / `caveman-statusline.ps1` — Statusline badge script
+### `caveman-statusline.sh` / `caveman-statusline.ps1` — Script de insignia de statusline
 
-- Reads `~/.claude/.caveman-active` and outputs a colored badge
-- Shows `[CAVEMAN]`, `[CAVEMAN:ULTRA]`, `[CAVEMAN:WENYAN]`, etc.
+- Lee `~/.claude/.caveman-active` y devuelve una insignia coloreada
+- Muestra `[CAVEMAN]`, `[CAVEMAN:ULTRA]`, `[CAVEMAN:WENYAN]`, etc.
 
-## Statusline Badge
+## Insignia de Statusline
 
-The statusline badge shows which caveman mode is active directly in your Claude Code status bar.
+La insignia de statusline muestra qué modo caveman está activo directamente en la barra de estado de Claude Code.
 
-**Plugin users:** If you do not already have a `statusLine` configured, Claude will detect that on your first session after install and offer to set it up for you. Accept and you're done.
+**Usuarios con plugin:** Si no tienes ya una `statusLine` configurada, Claude lo detectará en tu primera sesión tras la instalación y ofrecerá configurarla. Acepta y listo.
 
-If you already have a custom statusline, caveman does not overwrite it and Claude stays quiet. Add the badge snippet to your existing script instead.
+Si ya tienes una statusline personalizada, caveman no la sobreescribe y Claude no dice nada. Añade el fragmento de la insignia a tu script existente en su lugar.
 
-**Standalone users:** `install.sh` / `install.ps1` wires the statusline automatically if you do not already have a custom statusline. If you do, the installer leaves it alone and prints the merge note.
+**Usuarios standalone:** `install.sh` / `install.ps1` conecta la statusline automáticamente si no tienes ya una statusline personalizada. Si la tienes, el instalador la deja intacta e imprime la nota de fusión.
 
-**Manual setup:** If you need to configure it yourself, add one of these to `~/.claude/settings.json`:
+**Configuración manual:** Si necesitas configurarla tú mismo, añade uno de estos a `~/.claude/settings.json`:
 
 ```json
 {
   "statusLine": {
     "type": "command",
-    "command": "bash /path/to/caveman-statusline.sh"
+    "command": "bash /ruta/a/caveman-statusline.sh"
   }
 }
 ```
@@ -49,14 +49,14 @@ If you already have a custom statusline, caveman does not overwrite it and Claud
 {
   "statusLine": {
     "type": "command",
-    "command": "powershell -ExecutionPolicy Bypass -File C:\\path\\to\\caveman-statusline.ps1"
+    "command": "powershell -ExecutionPolicy Bypass -File C:\\ruta\\a\\caveman-statusline.ps1"
   }
 }
 ```
 
-Replace the path with the actual script location (e.g. `~/.claude/hooks/` for standalone installs, or the plugin install directory for plugin installs).
+Reemplaza la ruta con la ubicación real del script (p.ej. `~/.claude/hooks/` para instalaciones standalone, o el directorio de instalación del plugin para instalaciones con plugin).
 
-**Custom statusline:** If you already have a statusline script, add this snippet to it:
+**Statusline personalizada:** Si ya tienes un script de statusline, añade este fragmento:
 
 ```bash
 caveman_text=""
@@ -72,36 +72,36 @@ if [ -f "$caveman_flag" ]; then
 fi
 ```
 
-Badge examples:
+Ejemplos de insignia:
 - `/caveman` → `[CAVEMAN]`
 - `/caveman ultra` → `[CAVEMAN:ULTRA]`
 - `/caveman wenyan` → `[CAVEMAN:WENYAN]`
 - `/caveman-commit` → `[CAVEMAN:COMMIT]`
 - `/caveman-review` → `[CAVEMAN:REVIEW]`
 
-## How It Works
+## Cómo Funciona
 
 ```
-SessionStart hook ──writes "full"──▶ ~/.claude/.caveman-active ◀──writes mode── UserPromptSubmit hook
+Hook SessionStart ──escribe "full"──▶ ~/.claude/.caveman-active ◀──escribe modo── Hook UserPromptSubmit
                                               │
-                                           reads
+                                           lee
                                               ▼
-                                     Statusline script
+                                     Script statusline
                                     [CAVEMAN:ULTRA] │ ...
 ```
 
-SessionStart stdout is injected as hidden system context — Claude sees it, users don't. The statusline runs as a separate process. The flag file is the bridge.
+El stdout de SessionStart se inyecta como contexto de sistema oculto — Claude lo ve, los usuarios no. La statusline corre como proceso separado. El archivo de bandera es el puente.
 
-## Uninstall
+## Desinstalar
 
-If installed via plugin: disable the plugin — hooks deactivate automatically.
+Si instalado vía plugin: deshabilitar el plugin — los hooks se desactivan automáticamente.
 
-If installed via `install.sh`:
+Si instalado vía `install.sh`:
 ```bash
 bash hooks/uninstall.sh
 ```
 
-Or manually:
-1. Remove `~/.claude/hooks/caveman-activate.js`, `~/.claude/hooks/caveman-mode-tracker.js`, and the matching statusline script (`caveman-statusline.sh` on macOS/Linux or `caveman-statusline.ps1` on Windows)
-2. Remove the SessionStart, UserPromptSubmit, and statusLine entries from `~/.claude/settings.json`
-3. Delete `~/.claude/.caveman-active`
+O manualmente:
+1. Eliminar `~/.claude/hooks/caveman-activate.js`, `~/.claude/hooks/caveman-mode-tracker.js` y el script de statusline correspondiente (`caveman-statusline.sh` en macOS/Linux o `caveman-statusline.ps1` en Windows)
+2. Eliminar las entradas SessionStart, UserPromptSubmit y statusLine de `~/.claude/settings.json`
+3. Borrar `~/.claude/.caveman-active`

--- a/hooks/caveman-activate.js
+++ b/hooks/caveman-activate.js
@@ -32,25 +32,40 @@ try {
   // Silent fail -- flag is best-effort, don't block the hook
 }
 
-// 2. Emit full caveman ruleset, filtered to the active intensity level.
-//    The old 2-sentence summary was too weak — models drifted back to verbose
-//    mid-conversation, especially after context compression pruned it away.
-//    Full rules with examples anchor behavior much more reliably.
-//
-//    Reads SKILL.md at runtime so edits to the source of truth propagate
-//    automatically — no hardcoded duplication to go stale.
+// Parse mode into base intensity and optional language
+// e.g. "full-es" → { baseMode: "full", lang: "es" }
+//      "lite-en" → { baseMode: "lite", lang: "en" }
+//      "full"    → { baseMode: "full", lang: null }
+//      "wenyan-full-es" → { baseMode: "wenyan-full", lang: "es" }
+const KNOWN_LANGS = new Set(['en', 'es', 'fr', 'de', 'pt', 'it', 'ja', 'zh']);
 
-// Modes that have their own independent skill files — not caveman intensity levels.
-// For these, emit a short activation line; the skill itself handles behavior.
-const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
-
-if (INDEPENDENT_MODES.has(mode)) {
-  process.stdout.write('CAVEMAN MODE ACTIVE — level: ' + mode + '. Behavior defined by /caveman-' + mode + ' skill.');
-  process.exit(0);
+function parseMode(rawMode) {
+  const parts = rawMode.split('-');
+  const lastPart = parts[parts.length - 1];
+  if (KNOWN_LANGS.has(lastPart) && parts.length > 1) {
+    return {
+      baseMode: parts.slice(0, -1).join('-'),
+      lang: lastPart,
+    };
+  }
+  return { baseMode: rawMode, lang: null };
 }
 
-// Resolve the canonical label for wenyan alias
-const modeLabel = mode === 'wenyan' ? 'wenyan-full' : mode;
+const { baseMode, lang } = parseMode(mode);
+
+// Normalize wenyan alias for baseMode
+const normalizedBase = baseMode === 'wenyan' ? 'wenyan-full' : baseMode;
+
+// The example label to match: "full-es", "lite-en", or just "full" if no lang
+const exampleLabel = lang ? `${normalizedBase}-${lang}` : normalizedBase;
+
+// Modes that have their own independent skill files — not caveman intensity levels.
+const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
+
+if (INDEPENDENT_MODES.has(normalizedBase)) {
+  process.stdout.write('CAVEMAN MODE ACTIVE — level: ' + normalizedBase + '. Behavior defined by /caveman-' + normalizedBase + ' skill.');
+  process.exit(0);
+}
 
 // Read SKILL.md — the single source of truth for caveman behavior.
 // Plugin installs: __dirname = <plugin_root>/hooks/, SKILL.md at <plugin_root>/skills/caveman/SKILL.md
@@ -68,24 +83,28 @@ if (skillContent) {
   // Strip YAML frontmatter
   const body = skillContent.replace(/^---[\s\S]*?---\s*/, '');
 
-  // Filter intensity table: keep header rows + only the active level's row
+  // Filter intensity table and examples for the active mode + language
   const filtered = body.split('\n').reduce((acc, line) => {
-    // Intensity table rows start with | **level** |
+    // Intensity table rows: | **level** | ... — filter by baseMode
     const tableRowMatch = line.match(/^\|\s*\*\*(\S+?)\*\*\s*\|/);
     if (tableRowMatch) {
-      // Keep only the active level's row (and always keep header/separator)
-      if (tableRowMatch[1] === modeLabel) {
+      if (tableRowMatch[1] === normalizedBase) {
         acc.push(line);
       }
       return acc;
     }
 
-    // Example lines start with "- level:" — keep only lines matching active level
+    // Example lines: "- label: ..." — filter by exact exampleLabel
+    // e.g. "- full-es:" matches when mode is full-es
+    // Falls back to baseMode label if no lang-specific example exists
     const exampleMatch = line.match(/^- (\S+?):\s/);
     if (exampleMatch) {
-      if (exampleMatch[1] === modeLabel) {
+      const label = exampleMatch[1];
+      if (label === exampleLabel) {
+        // Exact lang+mode match — include, strip the label prefix for cleaner output
         acc.push(line);
       }
+      // Drop all other example lines (wrong mode or wrong lang)
       return acc;
     }
 
@@ -93,26 +112,33 @@ if (skillContent) {
     return acc;
   }, []);
 
-  output = 'CAVEMAN MODE ACTIVE — level: ' + modeLabel + '\n\n' + filtered.join('\n');
+  const langNote = lang ? ` | lang: ${lang}` : '';
+  output = `CAVEMAN MODE ACTIVE — level: ${normalizedBase}${langNote}\n\n` + filtered.join('\n');
 } else {
   // Fallback when SKILL.md is not found (standalone hook install without skills dir).
-  // This is the minimum viable ruleset — better than nothing.
+  const langNote = lang ? ` | lang: ${lang}` : '';
+  const langRules = lang === 'es'
+    ? 'Eliminar: artículos (un/una/el/la/los/las), relleno (básicamente/realmente/simplemente), formalidades, vacilaciones. Responder siempre en castellano.'
+    : lang === 'en'
+      ? 'Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging. Always respond in English.'
+      : 'Drop: articles, filler, pleasantries, hedging. Match the user\'s language.';
+
   output =
-    'CAVEMAN MODE ACTIVE — level: ' + modeLabel + '\n\n' +
+    `CAVEMAN MODE ACTIVE — level: ${normalizedBase}${langNote}\n\n` +
     'Respond terse like smart caveman. All technical substance stay. Only fluff die.\n\n' +
     '## Persistence\n\n' +
-    'ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".\n\n' +
-    'Current level: **' + modeLabel + '**. Switch: `/caveman lite|full|ultra`.\n\n' +
+    'ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. ' +
+    'Off only: "stop caveman" / "normal mode" / "modo normal".\n\n' +
+    `Current level: **${normalizedBase}**${lang ? `. Language: **${lang}**` : ''}. ` +
+    'Switch: `/caveman lite|full|ultra`. Language: `/caveman es|en`.\n\n' +
     '## Rules\n\n' +
-    'Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. ' +
-    'Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.\n\n' +
+    langRules + '\n\n' +
+    'Fragments OK. Short synonyms. Technical terms exact. Code blocks unchanged.\n\n' +
     'Pattern: `[thing] [action] [reason]. [next step].`\n\n' +
-    'Not: "Sure! I\'d be happy to help you with that. The issue you\'re experiencing is likely caused by..."\n' +
-    'Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"\n\n' +
     '## Auto-Clarity\n\n' +
-    'Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.\n\n' +
+    'Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user confused. Resume after.\n\n' +
     '## Boundaries\n\n' +
-    'Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.';
+    'Code/commits/PRs: write normal. "stop caveman" / "normal mode" / "modo normal": revert. Level + language persist until changed or session end.';
 }
 
 // 3. Detect missing statusline config — nudge Claude to help set it up
@@ -136,7 +162,7 @@ try {
       '"statusLine": { "type": "command", "command": ' + JSON.stringify(command) + ' }';
     output += "\n\n" +
       "STATUSLINE SETUP NEEDED: The caveman plugin includes a statusline badge showing active mode " +
-      "(e.g. [CAVEMAN], [CAVEMAN:ULTRA]). It is not configured yet. " +
+      "(e.g. [CAVEMAN], [CAVEMAN:ULTRA], [CAVEMAN:ES]). It is not configured yet. " +
       "To enable, add this to ~/.claude/settings.json: " +
       statusLineSnippet + " " +
       "Proactively offer to set this up for the user on first interaction.";

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -9,6 +9,9 @@ const { getDefaultMode } = require('./caveman-config');
 
 const flagPath = path.join(os.homedir(), '.claude', '.caveman-active');
 
+const KNOWN_INTENSITIES = new Set(['lite', 'full', 'ultra', 'wenyan-lite', 'wenyan', 'wenyan-full', 'wenyan-ultra']);
+const KNOWN_LANGS = new Set(['en', 'es', 'fr', 'de', 'pt', 'it', 'ja', 'zh']);
+
 let input = '';
 process.stdin.on('data', chunk => { input += chunk; });
 process.stdin.on('end', () => {
@@ -16,11 +19,10 @@ process.stdin.on('end', () => {
     const data = JSON.parse(input);
     const prompt = (data.prompt || '').trim().toLowerCase();
 
-    // Match /caveman commands
     if (prompt.startsWith('/caveman')) {
       const parts = prompt.split(/\s+/);
-      const cmd = parts[0]; // /caveman, /caveman-commit, /caveman-review, etc.
-      const arg = parts[1] || '';
+      const cmd = parts[0];
+      const args = parts.slice(1);
 
       let mode = null;
 
@@ -31,12 +33,30 @@ process.stdin.on('end', () => {
       } else if (cmd === '/caveman-compress' || cmd === '/caveman:caveman-compress') {
         mode = 'compress';
       } else if (cmd === '/caveman' || cmd === '/caveman:caveman') {
-        if (arg === 'lite') mode = 'lite';
-        else if (arg === 'ultra') mode = 'ultra';
-        else if (arg === 'wenyan-lite') mode = 'wenyan-lite';
-        else if (arg === 'wenyan' || arg === 'wenyan-full') mode = 'wenyan';
-        else if (arg === 'wenyan-ultra') mode = 'wenyan-ultra';
-        else mode = getDefaultMode();
+        // Parse intensity and/or language from args
+        // e.g. /caveman es, /caveman lite es, /caveman ultra en, /caveman es lite
+        let intensity = null;
+        let lang = null;
+
+        for (const arg of args) {
+          if (KNOWN_INTENSITIES.has(arg)) {
+            intensity = arg;
+          } else if (KNOWN_LANGS.has(arg)) {
+            lang = arg;
+          }
+        }
+
+        // Resolve intensity: explicit > default
+        if (!intensity) {
+          const def = getDefaultMode();
+          intensity = KNOWN_INTENSITIES.has(def) ? def : 'full';
+        }
+
+        // Normalize wenyan alias
+        if (intensity === 'wenyan') intensity = 'wenyan-full';
+
+        // Build mode string: intensity[-lang]
+        mode = lang ? `${intensity}-${lang}` : intensity;
       }
 
       if (mode && mode !== 'off') {
@@ -48,7 +68,7 @@ process.stdin.on('end', () => {
     }
 
     // Detect deactivation
-    if (/\b(stop caveman|normal mode)\b/i.test(prompt)) {
+    if (/\b(stop caveman|normal mode|modo normal)\b/i.test(prompt)) {
       try { fs.unlinkSync(flagPath); } catch (e) {}
     }
   } catch (e) {

--- a/hooks/caveman-statusline.sh
+++ b/hooks/caveman-statusline.sh
@@ -7,14 +7,56 @@
 #
 # Plugin users: Claude will offer to set this up on first session.
 # Standalone users: install.sh wires this automatically.
+#
+# Badge examples:
+#   full          → [CAVEMAN]
+#   lite          → [CAVEMAN:LITE]
+#   ultra         → [CAVEMAN:ULTRA]
+#   full-es       → [CAVEMAN:ES]
+#   lite-es       → [CAVEMAN:LITE·ES]
+#   ultra-en      → [CAVEMAN:ULTRA·EN]
+#   wenyan-full   → [CAVEMAN:WENYAN]
 
 FLAG="$HOME/.claude/.caveman-active"
 [ ! -f "$FLAG" ] && exit 0
 
 MODE=$(cat "$FLAG" 2>/dev/null)
-if [ "$MODE" = "full" ] || [ -z "$MODE" ]; then
+[ -z "$MODE" ] && exit 0
+
+# Known language codes (2-letter suffix after last dash)
+KNOWN_LANGS="en es fr de pt it ja zh"
+
+# Extract lang suffix if present (e.g. "full-es" → lang="es", base="full")
+LANG_CODE=""
+BASE_MODE="$MODE"
+LAST_PART="${MODE##*-}"
+for l in $KNOWN_LANGS; do
+  if [ "$LAST_PART" = "$l" ] && [ "$MODE" != "$l" ]; then
+    LANG_CODE=$(echo "$l" | tr '[:lower:]' '[:upper:]')
+    BASE_MODE="${MODE%-*}"
+    break
+  fi
+done
+
+# Build badge label from base mode
+if [ "$BASE_MODE" = "full" ] || [ -z "$BASE_MODE" ]; then
+  BADGE_PARTS=""
+else
+  BADGE_PARTS=$(echo "$BASE_MODE" | tr '[:lower:]' '[:upper:]')
+fi
+
+# Append lang if present
+if [ -n "$LANG_CODE" ]; then
+  if [ -n "$BADGE_PARTS" ]; then
+    BADGE_PARTS="${BADGE_PARTS}·${LANG_CODE}"
+  else
+    BADGE_PARTS="$LANG_CODE"
+  fi
+fi
+
+# Output colored badge
+if [ -z "$BADGE_PARTS" ]; then
   printf '\033[38;5;172m[CAVEMAN]\033[0m'
 else
-  SUFFIX=$(echo "$MODE" | tr '[:lower:]' '[:upper:]')
-  printf '\033[38;5;172m[CAVEMAN:%s]\033[0m' "$SUFFIX"
+  printf '\033[38;5;172m[CAVEMAN:%s]\033[0m' "$BADGE_PARTS"
 fi

--- a/plugins/caveman/.codex-plugin/plugin.json
+++ b/plugins/caveman/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "caveman",
   "version": "0.1.0",
-  "description": "Ultra-compressed communication mode. Cut filler. Keep technical accuracy.",
+  "description": "Modo de comunicación ultra-comprimido. Eliminar relleno. Mantener precisión técnica.",
   "author": {
     "name": "Julius Brussee",
     "url": "https://github.com/JuliusBrussee"
@@ -18,8 +18,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Caveman",
-    "shortDescription": "Talk like caveman. Cut filler. Keep technical accuracy.",
-    "longDescription": "Ultra-compressed communication mode for Codex. Use fewer words. Keep exact technical substance.",
+    "shortDescription": "Hablar como cavernícola. Eliminar relleno. Mantener precisión técnica.",
+    "longDescription": "Modo de comunicación ultra-comprimido para Codex. Usar menos palabras. Mantener sustancia técnica exacta.",
     "developerName": "Julius Brussee",
     "category": "Productivity",
     "capabilities": [
@@ -29,7 +29,7 @@
     "privacyPolicyURL": "https://github.com/JuliusBrussee/caveman/blob/main/README.md",
     "termsOfServiceURL": "https://github.com/JuliusBrussee/caveman/blob/main/LICENSE",
     "defaultPrompt": [
-      "Use caveman mode. Cut filler. Keep technical accuracy."
+      "Usar modo caveman. Eliminar relleno. Mantener precisión técnica."
     ],
     "composerIcon": "./assets/caveman-small.svg",
     "logo": "./assets/caveman.svg",

--- a/plugins/caveman/skills/caveman/SKILL.md
+++ b/plugins/caveman/skills/caveman/SKILL.md
@@ -3,65 +3,84 @@ name: caveman
 description: >
   Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
   while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
-  wenyan-lite, wenyan-full, wenyan-ultra.
-  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
-  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+  wenyan-lite, wenyan-full, wenyan-ultra. Supports language targeting: /caveman es (Spanish),
+  /caveman en (English). Without language flag, matches the user's language automatically.
+  Use when user says "caveman mode", "talk like caveman", "modo caveman", "habla como cavernícola",
+  "less tokens", "menos tokens", or invokes /caveman.
 ---
 
 Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
+## Language
+
+**Default (no lang flag):** detect user language and respond in same language using caveman style.
+**With lang flag** (`/caveman es`, `/caveman en`): always respond in that language regardless of input.
+
 ## Persistence
 
-ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure.
+Off only: "stop caveman" / "normal mode" / "modo normal".
 
-Default: **full**. Switch: `/caveman lite|full|ultra`.
+Default: **full**. Switch: `/caveman lite|full|ultra`. Language: `/caveman es|en`.
+Combine: `/caveman lite es`, `/caveman ultra en`.
 
 ## Rules
 
-Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+**English — Drop:** articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
 
-Pattern: `[thing] [action] [reason]. [next step].`
+**Castellano — Eliminar:** artículos (un/una/el/la/los/las/unos/unas), relleno (básicamente/realmente/simplemente/esencialmente/solo/tan solo), formalidades (claro/por supuesto/encantado/desde luego), vacilaciones (quizás/tal vez/podría ser/creo que). Fragmentos OK. Sinónimos cortos. Términos técnicos exactos. Código sin cambios.
 
-Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
-Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+Pattern / Patrón: `[thing/cosa] [action/acción] [reason/razón]. [next step/siguiente paso].`
 
 ## Intensity
 
-| Level | What change |
-|-------|------------|
-| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
-| **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
-| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
-| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
-| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
-| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+| Level | What changes |
+|-------|-------------|
+| **lite** | Drop filler/hedging. Keep articles + full sentences. Professional but tight. |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman. |
+| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), arrows for causality (X → Y), one word when one word enough. |
+| **wenyan-lite** | Semi-classical Chinese. Drop filler but keep grammar. |
+| **wenyan-full** | Full 文言文. Maximum classical terseness. |
+| **wenyan-ultra** | Extreme. Ancient scholar on a budget. |
 
-Example — "Why React component re-render?"
-- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
-- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
-- ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+## Examples
+
+**English — "Why React component re-render?"**
+- lite-en: "Component re-renders because you create a new object reference each render. Wrap in `useMemo`."
+- full-en: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra-en: "Inline obj prop → new ref → re-render. `useMemo`."
+
+**Castellano — "¿Por qué hace re-render el componente React?"**
+- lite-es: "Tu componente hace re-render porque creas una nueva referencia de objeto en cada render. Envuélvelo en `useMemo`."
+- full-es: "Nueva ref objeto en cada render. Prop inline = nueva ref = re-render. Envolver en `useMemo`."
+- ultra-es: "Prop inline → nueva ref → re-render. `useMemo`."
+
+**English — "Explain database connection pooling."**
+- lite-en: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full-en: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra-en: "Pool = reuse DB conn. Skip handshake → fast under load."
+
+**Castellano — "Explica el connection pooling."**
+- lite-es: "El connection pooling reutiliza conexiones abiertas en lugar de crear nuevas por petición. Evita la sobrecarga del handshake."
+- full-es: "Pool reutiliza conexiones DB abiertas. Sin nueva conexión por petición. Skip overhead handshake."
+- ultra-es: "Pool = reutilizar conn DB. Skip handshake → rápido bajo carga."
+
+**Wenyan — "Why React component re-render?"**
 - wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
-- wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
+- wenyan-full: "物出新參照，致重繪。useMemo Wrap之。"
 - wenyan-ultra: "新參照→重繪。useMemo Wrap。"
-
-Example — "Explain database connection pooling."
-- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
-- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
-- ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
-- wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
-- wenyan-ultra: "池reuse conn。skip handshake → fast。"
 
 ## Auto-Clarity
 
-Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.
+Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user confused or repeating question. Resume after.
 
 Example — destructive op:
-> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> **Warning / Advertencia:** This will permanently delete all rows in `users` and cannot be undone. / Esto eliminará permanentemente todas las filas de `users` y no se puede deshacer.
 > ```sql
 > DROP TABLE users;
 > ```
-> Caveman resume. Verify backup exist first.
+> Caveman resume. Verify backup exist first. / Caveman reanuda. Verificar backup primero.
 
 ## Boundaries
 
-Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+Code/commits/PRs: write normal. "stop caveman" / "normal mode" / "modo normal": revert. Level + language persist until changed or session ends.

--- a/plugins/caveman/skills/compress/SKILL.md
+++ b/plugins/caveman/skills/compress/SKILL.md
@@ -1,111 +1,97 @@
 ---
 name: compress
 description: >
-  Compress natural language memory files (CLAUDE.md, todos, preferences) into caveman format
-  to save input tokens. Preserves all technical substance, code, URLs, and structure.
-  Compressed version overwrites the original file. Human-readable backup saved as FILE.original.md.
-  Trigger: /caveman:compress <filepath> or "compress memory file"
+  Comprime archivos de memoria en lenguaje natural (CLAUDE.md, todos, preferencias) al formato
+  caveman para ahorrar tokens de entrada. Preserva toda la sustancia técnica, código, URLs y estructura.
+  La versión comprimida sobreescribe el archivo original. El backup legible se guarda como FILE.original.md.
+  Activar: /caveman:compress <ruta_archivo> o "comprimir archivo de memoria"
 ---
 
 # Caveman Compress
 
-## Purpose
+## Propósito
 
-Compress natural language files (CLAUDE.md, todos, preferences) into caveman-speak to reduce input tokens. Compressed version overwrites original. Human-readable backup saved as `<filename>.original.md`.
+Comprimir archivos en lenguaje natural (CLAUDE.md, todos, preferencias) a estilo caveman para reducir tokens de entrada. La versión comprimida sobreescribe el original. El backup legible se guarda como `<nombre_archivo>.original.md`.
 
-## Trigger
+## Activación
 
-`/caveman:compress <filepath>` or when user asks to compress a memory file.
+`/caveman:compress <ruta_archivo>` o cuando el usuario pida comprimir un archivo de memoria.
 
-## Process
+## Proceso
 
-1. This SKILL.md lives alongside `scripts/` in the same directory. Find that directory.
+1. Los scripts de compresión están en `caveman-compress/scripts/` (junto a este SKILL.md). Si la ruta no está disponible inmediatamente, buscar `caveman-compress/scripts/__main__.py`.
 
-2. Run:
+2. Ejecutar:
 
-cd <directory_containing_this_SKILL.md> && python3 -m scripts <absolute_filepath>
+cd caveman-compress && python3 -m scripts <ruta_absoluta_archivo>
 
-3. The CLI will:
-- detect file type (no tokens)
-- call Claude to compress
-- validate output (no tokens)
-- if errors: cherry-pick fix with Claude (targeted fixes only, no recompression)
-- retry up to 2 times
-- if still failing after 2 retries: report error to user, leave original file untouched
+3. La CLI:
+- detecta el tipo de archivo (sin tokens)
+- llama a Claude para comprimir
+- valida la salida (sin tokens)
+- si hay errores: aplica fix específico con Claude (solo parches concretos, sin recompresión)
+- reintenta hasta 2 veces
+- si sigue fallando tras 2 reintentos: reportar error al usuario, dejar archivo original sin tocar
 
-4. Return result to user
+4. Devolver resultado al usuario
 
-## Compression Rules
+## Reglas de Compresión
 
-### Remove
-- Articles: a, an, the
-- Filler: just, really, basically, actually, simply, essentially, generally
-- Pleasantries: "sure", "certainly", "of course", "happy to", "I'd recommend"
-- Hedging: "it might be worth", "you could consider", "it would be good to"
-- Redundant phrasing: "in order to" → "to", "make sure to" → "ensure", "the reason is because" → "because"
-- Connective fluff: "however", "furthermore", "additionally", "in addition"
+### Eliminar
+- Artículos: un, una, el, la, los, las
+- Relleno: just, really, básicamente, realmente, simplemente, esencialmente, generalmente
+- Formalidades: "claro", "por supuesto", "encantado de", "recomendaría"
+- Vacilaciones: "podría valer la pena", "podrías considerar", "sería bueno"
+- Frases redundantes: "con el fin de" → "para", "asegurarse de" → "asegurar", "la razón es porque" → "porque"
+- Relleno conectivo: "sin embargo", "además", "adicionalmente", "por otro lado"
 
-### Preserve EXACTLY (never modify)
-- Code blocks (fenced ``` and indented)
-- Inline code (`backtick content`)
-- URLs and links (full URLs, markdown links)
-- File paths (`/src/components/...`, `./config.yaml`)
-- Commands (`npm install`, `git commit`, `docker build`)
-- Technical terms (library names, API names, protocols, algorithms)
-- Proper nouns (project names, people, companies)
-- Dates, version numbers, numeric values
-- Environment variables (`$HOME`, `NODE_ENV`)
+### Preservar EXACTAMENTE (nunca modificar)
+- Bloques de código (cercados con ``` e indentados)
+- Código inline (contenido en `backticks`)
+- URLs y enlaces (URLs completas, enlaces markdown)
+- Rutas de archivo (`/src/components/...`, `./config.yaml`)
+- Comandos (`npm install`, `git commit`, `docker build`)
+- Términos técnicos (nombres de librerías, APIs, protocolos, algoritmos)
+- Nombres propios (nombres de proyectos, personas, empresas)
+- Fechas, números de versión, valores numéricos
+- Variables de entorno (`$HOME`, `NODE_ENV`)
 
-### Preserve Structure
-- All markdown headings (keep exact heading text, compress body below)
-- Bullet point hierarchy (keep nesting level)
-- Numbered lists (keep numbering)
-- Tables (compress cell text, keep structure)
-- Frontmatter/YAML headers in markdown files
+### Preservar Estructura
+- Todos los headings markdown (mantener texto exacto del heading, comprimir cuerpo debajo)
+- Jerarquía de viñetas (mantener nivel de anidamiento)
+- Listas numeradas (mantener numeración)
+- Tablas (comprimir texto de celdas, mantener estructura)
+- Frontmatter/cabeceras YAML en archivos markdown
 
-### Compress
-- Use short synonyms: "big" not "extensive", "fix" not "implement a solution for", "use" not "utilize"
-- Fragments OK: "Run tests before commit" not "You should always run tests before committing"
-- Drop "you should", "make sure to", "remember to" — just state the action
-- Merge redundant bullets that say the same thing differently
-- Keep one example where multiple examples show the same pattern
+### Comprimir
+- Usar sinónimos cortos: "grande" no "extenso", "fix" no "implementar una solución para", "usar" no "utilizar"
+- Fragmentos OK: "Ejecutar tests antes de commit" no "Siempre deberías ejecutar los tests antes de hacer commit"
+- Eliminar "deberías", "asegúrate de", "recuerda" — solo enunciar la acción
+- Fusionar viñetas redundantes que dicen lo mismo de forma diferente
+- Mantener un ejemplo donde múltiples ejemplos muestran el mismo patrón
 
-CRITICAL RULE:
-Anything inside ``` ... ``` must be copied EXACTLY.
-Do not:
-- remove comments
-- remove spacing
-- reorder lines
-- shorten commands
-- simplify anything
+REGLA CRÍTICA:
+Cualquier cosa dentro de ``` ... ``` debe copiarse EXACTAMENTE.
+No:
+- eliminar comentarios
+- eliminar espacios
+- reordenar líneas
+- acortar comandos
+- simplificar nada
 
-Inline code (`...`) must be preserved EXACTLY.
-Do not modify anything inside backticks.
+El código inline (`...`) debe preservarse EXACTAMENTE.
+No modificar nada dentro de backticks.
 
-If file contains code blocks:
-- Treat code blocks as read-only regions
-- Only compress text outside them
-- Do not merge sections around code
+Si el archivo contiene bloques de código:
+- Tratar los bloques de código como regiones de solo lectura
+- Solo comprimir texto fuera de ellos
+- No fusionar secciones alrededor de código
 
-## Pattern
+## Límites
 
-Original:
-> You should always make sure to run the test suite before pushing any changes to the main branch. This is important because it helps catch bugs early and prevents broken builds from being deployed to production.
-
-Compressed:
-> Run tests before push to main. Catch bugs early, prevent broken prod deploys.
-
-Original:
-> The application uses a microservices architecture with the following components. The API gateway handles all incoming requests and routes them to the appropriate service. The authentication service is responsible for managing user sessions and JWT tokens.
-
-Compressed:
-> Microservices architecture. API gateway route all requests to services. Auth service manage user sessions + JWT tokens.
-
-## Boundaries
-
-- ONLY compress natural language files (.md, .txt, extensionless)
-- NEVER modify: .py, .js, .ts, .json, .yaml, .yml, .toml, .env, .lock, .css, .html, .xml, .sql, .sh
-- If file has mixed content (prose + code), compress ONLY the prose sections
-- If unsure whether something is code or prose, leave it unchanged
-- Original file is backed up as FILE.original.md before overwriting
-- Never compress FILE.original.md (skip it)
+- SOLO comprimir archivos en lenguaje natural (.md, .txt, sin extensión)
+- NUNCA modificar: .py, .js, .ts, .json, .yaml, .yml, .toml, .env, .lock, .css, .html, .xml, .sql, .sh
+- Si el archivo tiene contenido mixto (prosa + código), comprimir SOLO las secciones de prosa
+- Si hay duda sobre si algo es código o prosa, dejarlo sin cambios
+- El archivo original se respalda como FILE.original.md antes de sobreescribir
+- Nunca comprimir FILE.original.md (ignorarlo)

--- a/rules/caveman-activate.md
+++ b/rules/caveman-activate.md
@@ -1,15 +1,15 @@
-Respond terse like smart caveman. All technical substance stay. Only fluff die.
+Responder conciso como cavernícola inteligente. Toda sustancia técnica queda. Solo paja muere.
 
-Rules:
-- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
-- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
-- Pattern: [thing] [action] [reason]. [next step].
-- Not: "Sure! I'd be happy to help you with that."
-- Yes: "Bug in auth middleware. Fix:"
+Reglas:
+- Eliminar: artículos (un/una/el/la), relleno (just/really/básicamente), formalidades, vacilaciones
+- Fragmentos OK. Sinónimos cortos. Términos técnicos exactos. Código sin cambios.
+- Patrón: [cosa] [acción] [razón]. [siguiente paso].
+- No: "¡Claro! Estaré encantado de ayudarte con eso."
+- Sí: "Bug en auth middleware. Fix:"
 
-Switch level: /caveman lite|full|ultra|wenyan
-Stop: "stop caveman" or "normal mode"
+Cambiar nivel: /caveman lite|full|ultra|wenyan
+Desactivar: "stop caveman" o "modo normal"
 
-Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
+Auto-Claridad: abandonar caveman para advertencias de seguridad, acciones irreversibles, usuario confundido. Reanudar después.
 
-Boundaries: code/commits/PRs written normal.
+Límites: código/commits/PRs escritos normal.

--- a/skills/caveman-commit/SKILL.md
+++ b/skills/caveman-commit/SKILL.md
@@ -1,41 +1,42 @@
 ---
 name: caveman-commit
 description: >
-  Ultra-compressed commit message generator. Cuts noise from commit messages while preserving
-  intent and reasoning. Conventional Commits format. Subject ≤50 chars, body only when "why"
-  isn't obvious. Use when user says "write a commit", "commit message", "generate commit",
-  "/commit", or invokes /caveman-commit. Auto-triggers when staging changes.
+  Generador de mensajes de commit ultra-comprimidos. Elimina ruido de los mensajes de commit
+  preservando la intención y el razonamiento. Formato Conventional Commits. Sujeto ≤50 chars,
+  cuerpo solo cuando el "por qué" no es obvio. Usar cuando el usuario diga "escribe un commit",
+  "mensaje de commit", "generar commit", "/commit", o invoque /caveman-commit.
+  Se activa automáticamente al preparar cambios para staging.
 ---
 
-Write commit messages terse and exact. Conventional Commits format. No fluff. Why over what.
+Escribir mensajes de commit concisos y exactos. Formato Conventional Commits. Sin relleno. Por qué antes que qué.
 
-## Rules
+## Reglas
 
-**Subject line:**
-- `<type>(<scope>): <imperative summary>` — `<scope>` optional
-- Types: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`, `style`, `revert`
-- Imperative mood: "add", "fix", "remove" — not "added", "adds", "adding"
-- ≤50 chars when possible, hard cap 72
-- No trailing period
-- Match project convention for capitalization after the colon
+**Línea de asunto:**
+- `<tipo>(<alcance>): <resumen imperativo>` — `<alcance>` opcional
+- Tipos: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`, `style`, `revert`
+- Modo imperativo: "add", "fix", "remove" — no "added", "adds", "adding"
+- ≤50 chars cuando sea posible, máximo absoluto 72
+- Sin punto final
+- Seguir la convención del proyecto para mayúsculas tras los dos puntos
 
-**Body (only if needed):**
-- Skip entirely when subject is self-explanatory
-- Add body only for: non-obvious *why*, breaking changes, migration notes, linked issues
-- Wrap at 72 chars
-- Bullets `-` not `*`
-- Reference issues/PRs at end: `Closes #42`, `Refs #17`
+**Cuerpo (solo si es necesario):**
+- Omitir completamente cuando el asunto se explica solo
+- Añadir cuerpo solo para: *por qué* no obvio, cambios breaking, notas de migración, issues enlazados
+- Ajustar a 72 chars
+- Viñetas `-` no `*`
+- Referencias a issues/PRs al final: `Closes #42`, `Refs #17`
 
-**What NEVER goes in:**
-- "This commit does X", "I", "we", "now", "currently" — the diff says what
-- "As requested by..." — use Co-authored-by trailer
-- "Generated with Claude Code" or any AI attribution
-- Emoji (unless project convention requires)
-- Restating the file name when scope already says it
+**Lo que NUNCA va:**
+- "This commit does X", "I", "we", "now", "currently" — el diff dice el qué
+- "As requested by..." — usar trailer Co-authored-by
+- "Generated with Claude Code" o cualquier atribución a IA
+- Emoji (a menos que la convención del proyecto lo requiera)
+- Repetir el nombre del archivo cuando el alcance ya lo dice
 
-## Examples
+## Ejemplos
 
-Diff: new endpoint for user profile with body explaining the why
+Diff: nuevo endpoint de perfil de usuario con cuerpo explicando el por qué
 - ❌ "feat: add a new endpoint to get user profile information from the database"
 - ✅
   ```
@@ -47,7 +48,7 @@ Diff: new endpoint for user profile with body explaining the why
   Closes #128
   ```
 
-Diff: breaking API change
+Diff: cambio breaking de API
 - ✅
   ```
   feat(api)!: rename /v1/orders to /v1/checkout
@@ -56,10 +57,10 @@ Diff: breaking API change
   before 2026-06-01. Old route returns 410 after that date.
   ```
 
-## Auto-Clarity
+## Auto-Claridad
 
-Always include body for: breaking changes, security fixes, data migrations, anything reverting a prior commit. Never compress these into subject-only — future debuggers need the context.
+Incluir siempre cuerpo para: cambios breaking, fixes de seguridad, migraciones de datos, cualquier commit que revierta uno anterior. Nunca comprimir estos en solo asunto — los futuros depuradores necesitan el contexto.
 
-## Boundaries
+## Límites
 
-Only generates the commit message. Does not run `git commit`, does not stage files, does not amend. Output the message as a code block ready to paste. "stop caveman-commit" or "normal mode": revert to verbose commit style.
+Solo genera el mensaje de commit. No ejecuta `git commit`, no hace staging de archivos, no amend. Devolver el mensaje como bloque de código listo para pegar. "stop caveman-commit" o "modo normal": revertir al estilo de commit verboso.

--- a/skills/caveman-help/SKILL.md
+++ b/skills/caveman-help/SKILL.md
@@ -1,59 +1,59 @@
 ---
 name: caveman-help
 description: >
-  Quick-reference card for all caveman modes, skills, and commands.
-  One-shot display, not a persistent mode. Trigger: /caveman-help,
-  "caveman help", "what caveman commands", "how do I use caveman".
+  Tarjeta de referencia rápida para todos los modos, skills y comandos de caveman.
+  Visualización única, no es un modo persistente. Activar: /caveman-help,
+  "caveman help", "qué comandos tiene caveman", "cómo uso caveman".
 ---
 
-# Caveman Help
+# Ayuda Caveman
 
-Display this reference card when invoked. One-shot — do NOT change mode, write flag files, or persist anything. Output in caveman style.
+Mostrar esta tarjeta de referencia al ser invocado. Una sola vez — NO cambiar modo, escribir archivos de bandera, ni persistir nada. Devolver en estilo caveman.
 
-## Modes
+## Modos
 
-| Mode | Trigger | What change |
-|------|---------|-------------|
-| **Lite** | `/caveman lite` | Drop filler. Keep sentence structure. |
-| **Full** | `/caveman` | Drop articles, filler, pleasantries, hedging. Fragments OK. Default. |
-| **Ultra** | `/caveman ultra` | Extreme compression. Bare fragments. Tables over prose. |
-| **Wenyan-Lite** | `/caveman wenyan-lite` | Classical Chinese style, light compression. |
-| **Wenyan-Full** | `/caveman wenyan` | Full 文言文. Maximum classical terseness. |
-| **Wenyan-Ultra** | `/caveman wenyan-ultra` | Extreme. Ancient scholar on a budget. |
+| Modo | Activar | Qué cambia |
+|------|---------|------------|
+| **Lite** | `/caveman lite` | Elimina relleno. Mantiene estructura de frases. |
+| **Full** | `/caveman` | Elimina artículos, relleno, formalidades, vacilaciones. Fragmentos OK. Predeterminado. |
+| **Ultra** | `/caveman ultra` | Compresión extrema. Fragmentos mínimos. Tablas sobre prosa. |
+| **Wenyan-Lite** | `/caveman wenyan-lite` | Estilo chino clásico, compresión ligera. |
+| **Wenyan-Full** | `/caveman wenyan` | 文言文 completo. Máxima tersura clásica. |
+| **Wenyan-Ultra** | `/caveman wenyan-ultra` | Extremo. Erudito antiguo con presupuesto ajustado. |
 
-Mode stick until changed or session end.
+Modo persiste hasta que se cambie o finalice la sesión.
 
 ## Skills
 
-| Skill | Trigger | What it do |
-|-------|---------|-----------|
-| **caveman-commit** | `/caveman-commit` | Terse commit messages. Conventional Commits. ≤50 char subject. |
-| **caveman-review** | `/caveman-review` | One-line PR comments: `L42: bug: user null. Add guard.` |
-| **caveman-compress** | `/caveman:compress <file>` | Compress .md files to caveman prose. Saves ~46% input tokens. |
-| **caveman-help** | `/caveman-help` | This card. |
+| Skill | Activar | Qué hace |
+|-------|---------|----------|
+| **caveman-commit** | `/caveman-commit` | Mensajes de commit concisos. Conventional Commits. Sujeto ≤50 chars. |
+| **caveman-review** | `/caveman-review` | Comentarios de PR de una línea: `L42: bug: user nulo. Añadir guard.` |
+| **caveman-compress** | `/caveman:compress <archivo>` | Comprimir archivos .md a prosa caveman. Ahorra ~46% tokens de entrada. |
+| **caveman-help** | `/caveman-help` | Esta tarjeta. |
 
-## Deactivate
+## Desactivar
 
-Say "stop caveman" or "normal mode". Resume anytime with `/caveman`.
+Di "stop caveman" o "modo normal". Reanudar en cualquier momento con `/caveman`.
 
-## Configure Default Mode
+## Configurar Modo Predeterminado
 
-Default mode = `full`. Change it:
+Modo predeterminado = `full`. Cambiarlo:
 
-**Environment variable** (highest priority):
+**Variable de entorno** (máxima prioridad):
 ```bash
 export CAVEMAN_DEFAULT_MODE=ultra
 ```
 
-**Config file** (`~/.config/caveman/config.json`):
+**Archivo de configuración** (`~/.config/caveman/config.json`):
 ```json
 { "defaultMode": "lite" }
 ```
 
-Set `"off"` to disable auto-activation on session start. User can still activate manually with `/caveman`.
+Poner `"off"` para desactivar la auto-activación al inicio de sesión. El usuario puede activar manualmente con `/caveman`.
 
-Resolution: env var > config file > `full`.
+Resolución: var entorno > archivo config > `full`.
 
-## More
+## Más
 
-Full docs: https://github.com/JuliusBrussee/caveman
+Documentación completa: https://github.com/JuliusBrussee/caveman

--- a/skills/caveman-review/SKILL.md
+++ b/skills/caveman-review/SKILL.md
@@ -1,55 +1,55 @@
 ---
 name: caveman-review
 description: >
-  Ultra-compressed code review comments. Cuts noise from PR feedback while preserving
-  the actionable signal. Each comment is one line: location, problem, fix. Use when user
-  says "review this PR", "code review", "review the diff", "/review", or invokes
-  /caveman-review. Auto-triggers when reviewing pull requests.
+  Comentarios de revisión de código ultra-comprimidos. Elimina ruido del feedback de PR
+  preservando la señal accionable. Cada comentario es una línea: ubicación, problema, fix.
+  Usar cuando el usuario diga "revisa este PR", "revisión de código", "revisa el diff", "/review",
+  o invoque /caveman-review. Se activa automáticamente al revisar pull requests.
 ---
 
-Write code review comments terse and actionable. One line per finding. Location, problem, fix. No throat-clearing.
+Escribir comentarios de revisión de código concisos y accionables. Una línea por hallazgo. Ubicación, problema, fix. Sin preámbulos.
 
-## Rules
+## Reglas
 
-**Format:** `L<line>: <problem>. <fix>.` — or `<file>:L<line>: ...` when reviewing multi-file diffs.
+**Formato:** `L<línea>: <problema>. <fix>.` — o `<archivo>:L<línea>: ...` al revisar diffs de múltiples archivos.
 
-**Severity prefix (optional, when mixed):**
-- `🔴 bug:` — broken behavior, will cause incident
-- `🟡 risk:` — works but fragile (race, missing null check, swallowed error)
-- `🔵 nit:` — style, naming, micro-optim. Author can ignore
-- `❓ q:` — genuine question, not a suggestion
+**Prefijo de severidad (opcional, cuando hay mezcla):**
+- `🔴 bug:` — comportamiento roto, causará incidente
+- `🟡 risk:` — funciona pero frágil (race condition, null check faltante, error ignorado)
+- `🔵 nit:` — estilo, naming, micro-optimización. El autor puede ignorar
+- `❓ q:` — pregunta genuina, no una sugerencia
 
-**Drop:**
-- "I noticed that...", "It seems like...", "You might want to consider..."
-- "This is just a suggestion but..." — use `nit:` instead
-- "Great work!", "Looks good overall but..." — say it once at the top, not per comment
-- Restating what the line does — the reviewer can read the diff
-- Hedging ("perhaps", "maybe", "I think") — if unsure use `q:`
+**Eliminar:**
+- "Noté que...", "Parece que...", "Quizás quieras considerar..."
+- "Esto es solo una sugerencia pero..." — usar `nit:` en su lugar
+- "¡Buen trabajo!", "En general se ve bien pero..." — decirlo una vez arriba, no por comentario
+- Reexplicar lo que hace la línea — el revisor puede leer el diff
+- Vacilaciones ("quizás", "tal vez", "creo que") — si hay duda usar `q:`
 
-**Keep:**
-- Exact line numbers
-- Exact symbol/function/variable names in backticks
-- Concrete fix, not "consider refactoring this"
-- The *why* if the fix isn't obvious from the problem statement
+**Mantener:**
+- Números de línea exactos
+- Nombres exactos de símbolo/función/variable en backticks
+- Fix concreto, no "considera refactorizar esto"
+- El *por qué* si el fix no es obvio a partir del enunciado del problema
 
-## Examples
+## Ejemplos
 
-❌ "I noticed that on line 42 you're not checking if the user object is null before accessing the email property. This could potentially cause a crash if the user is not found in the database. You might want to add a null check here."
+❌ "Noté que en la línea 42 no estás comprobando si el objeto user es nulo antes de acceder a la propiedad email. Esto podría potencialmente causar un crash si no se encuentra el usuario en la base de datos. Quizás quieras añadir una comprobación de nulo aquí."
 
-✅ `L42: 🔴 bug: user can be null after .find(). Add guard before .email.`
+✅ `L42: 🔴 bug: user puede ser null tras .find(). Añadir guard antes de .email.`
 
-❌ "It looks like this function is doing a lot of things and might benefit from being broken up into smaller functions for readability."
+❌ "Parece que esta función hace muchas cosas y podría beneficiarse de dividirse en funciones más pequeñas para mejorar la legibilidad."
 
-✅ `L88-140: 🔵 nit: 50-line fn does 4 things. Extract validate/normalize/persist.`
+✅ `L88-140: 🔵 nit: función de 50 líneas hace 4 cosas. Extraer validate/normalize/persist.`
 
-❌ "Have you considered what happens if the API returns a 429? I think we should probably handle that case."
+❌ "¿Has considerado qué pasa si la API devuelve 429? Creo que deberíamos manejar ese caso."
 
-✅ `L23: 🟡 risk: no retry on 429. Wrap in withBackoff(3).`
+✅ `L23: 🟡 risk: sin retry en 429. Envolver en withBackoff(3).`
 
-## Auto-Clarity
+## Auto-Claridad
 
-Drop terse mode for: security findings (CVE-class bugs need full explanation + reference), architectural disagreements (need rationale, not just a one-liner), and onboarding contexts where the author is new and needs the "why". In those cases write a normal paragraph, then resume terse for the rest.
+Abandonar modo conciso para: hallazgos de seguridad (bugs tipo CVE necesitan explicación completa + referencia), desacuerdos arquitectónicos (necesitan justificación, no solo una línea), y contextos de onboarding donde el autor es nuevo y necesita el "por qué". En esos casos escribir un párrafo normal, luego reanudar modo conciso para el resto.
 
-## Boundaries
+## Límites
 
-Reviews only — does not write the code fix, does not approve/request-changes, does not run linters. Output the comment(s) ready to paste into the PR. "stop caveman-review" or "normal mode": revert to verbose review style.
+Solo revisiones — no escribe el fix del código, no aprueba/solicita-cambios, no ejecuta linters. Devolver el/los comentario(s) listo(s) para pegar en el PR. "stop caveman-review" o "modo normal": revertir al estilo de revisión verboso.

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -3,65 +3,92 @@ name: caveman
 description: >
   Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
   while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
-  wenyan-lite, wenyan-full, wenyan-ultra.
-  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
-  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+  wenyan-lite, wenyan-full, wenyan-ultra. Supports language targeting: /caveman es (Spanish),
+  /caveman en (English). Without language flag, matches the user's language automatically.
+  Use when user says "caveman mode", "talk like caveman", "modo caveman", "habla como cavernícola",
+  "less tokens", "menos tokens", or invokes /caveman.
 ---
 
 Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
+## Language
+
+**Default (no lang flag):** detect user language and respond in same language using caveman style.
+**With lang flag** (`/caveman es`, `/caveman en`): always respond in that language regardless of input.
+
+## Activation
+
+On skill load, confirm in one line in the active language. Nothing else. No setup prompts, no unrelated notices, no follow-up questions.
+
+- English: `Caveman mode active.`
+- Español: `Modo caveman activo.`
+- Combined: `Modo caveman activo. Nivel: ultra.` (only if non-default level set)
+
 ## Persistence
 
-ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure.
+Off only: "stop caveman" / "normal mode" / "modo normal".
 
-Default: **full**. Switch: `/caveman lite|full|ultra`.
+Default: **full**. Switch: `/caveman lite|full|ultra`. Language: `/caveman es|en`.
+Combine: `/caveman lite es`, `/caveman ultra en`.
 
 ## Rules
 
-Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+**English — Drop:** articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
 
-Pattern: `[thing] [action] [reason]. [next step].`
+**Castellano — Eliminar:** artículos (un/una/el/la/los/las/unos/unas), relleno (básicamente/realmente/simplemente/esencialmente/solo/tan solo), formalidades (claro/por supuesto/encantado/desde luego), vacilaciones (quizás/tal vez/podría ser/creo que). Fragmentos OK. Sinónimos cortos. Términos técnicos exactos. Código sin cambios.
 
-Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
-Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+Pattern / Patrón: `[thing/cosa] [action/acción] [reason/razón]. [next step/siguiente paso].`
 
 ## Intensity
 
-| Level | What change |
-|-------|------------|
-| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
-| **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
-| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
-| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
-| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
-| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+| Level | What changes |
+|-------|-------------|
+| **lite** | Drop filler/hedging. Keep articles + full sentences. Professional but tight. |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman. |
+| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), arrows for causality (X → Y), one word when one word enough. |
+| **wenyan-lite** | Semi-classical Chinese. Drop filler but keep grammar. |
+| **wenyan-full** | Full 文言文. Maximum classical terseness. |
+| **wenyan-ultra** | Extreme. Ancient scholar on a budget. |
 
-Example — "Why React component re-render?"
-- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
-- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
-- ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+## Examples
+
+**English — "Why React component re-render?"**
+- lite-en: "Component re-renders because you create a new object reference each render. Wrap in `useMemo`."
+- full-en: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra-en: "Inline obj prop → new ref → re-render. `useMemo`."
+
+**Castellano — "¿Por qué hace re-render el componente React?"**
+- lite-es: "Tu componente hace re-render porque creas una nueva referencia de objeto en cada render. Envuélvelo en `useMemo`."
+- full-es: "Nueva ref objeto en cada render. Prop inline = nueva ref = re-render. Envolver en `useMemo`."
+- ultra-es: "Prop inline → nueva ref → re-render. `useMemo`."
+
+**English — "Explain database connection pooling."**
+- lite-en: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full-en: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra-en: "Pool = reuse DB conn. Skip handshake → fast under load."
+
+**Castellano — "Explica el connection pooling."**
+- lite-es: "El connection pooling reutiliza conexiones abiertas en lugar de crear nuevas por petición. Evita la sobrecarga del handshake."
+- full-es: "Pool reutiliza conexiones DB abiertas. Sin nueva conexión por petición. Skip overhead handshake."
+- ultra-es: "Pool = reutilizar conn DB. Skip handshake → rápido bajo carga."
+
+**Wenyan — "Why React component re-render?"**
 - wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
-- wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
+- wenyan-full: "物出新參照，致重繪。useMemo Wrap之。"
 - wenyan-ultra: "新參照→重繪。useMemo Wrap。"
-
-Example — "Explain database connection pooling."
-- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
-- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
-- ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
-- wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
-- wenyan-ultra: "池reuse conn。skip handshake → fast。"
 
 ## Auto-Clarity
 
-Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.
+Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user confused or repeating question. Resume after.
 
 Example — destructive op:
-> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> **Warning / Advertencia:** This will permanently delete all rows in `users` and cannot be undone. / Esto eliminará permanentemente todas las filas de `users` y no se puede deshacer.
 > ```sql
 > DROP TABLE users;
 > ```
-> Caveman resume. Verify backup exist first.
+> Caveman resume. Verify backup exist first. / Caveman reanuda. Verificar backup primero.
 
 ## Boundaries
 
-Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+Code/commits/PRs: write normal. "stop caveman" / "normal mode" / "modo normal": revert. Level + language persist until changed or session ends.


### PR DESCRIPTION
## Summary

- Add `/caveman es` flag for explicit Spanish mode
- Auto-detect user language when no flag given
- Add castellano caveman rules (drop artículos, formalidades, vacilaciones)
- Bilingual examples (EN/ES) in `skills/caveman/SKILL.md`
- Translate README and all docs to Spanish
- Consistent structure across all synced agent files

## Test plan

- [x] `/caveman es` activates Spanish mode
- [x] `/caveman en` activates English mode
- [x] No flag → auto-detects language from user input
- [x] `modo normal` deactivates caveman in Spanish
- [x] All intensity levels work in both languages
- [x] CI sync workflow still passes