### PR TITLE
Add Kiro Docs to Caveman Skills repo

### DIFF
--- a/.github/workflows/sync-skill.yml
+++ b/.github/workflows/sync-skill.yml
@@ -36,6 +36,8 @@ jobs:
           cp skills/caveman/SKILL.md .cursor/skills/caveman/SKILL.md
           mkdir -p .windsurf/skills/caveman
           cp skills/caveman/SKILL.md .windsurf/skills/caveman/SKILL.md
+          mkdir -p .kiro/skills/caveman
+          cp skills/caveman/SKILL.md .kiro/skills/caveman/SKILL.md
 
       - name: Sync compress skill to plugin
         run: |
@@ -71,6 +73,10 @@ jobs:
           printf '%s\n' '---' 'trigger: always_on' '---' '' > .windsurf/rules/caveman.md
           cat "$BODY" >> .windsurf/rules/caveman.md
 
+          # Kiro — steering file (inclusion: always is default, no frontmatter needed)
+          mkdir -p .kiro/steering
+          cp "$BODY" .kiro/steering/caveman.md
+
       - name: Commit and push if changed
         run: |
           git add \
@@ -79,6 +85,8 @@ jobs:
             plugins/caveman/skills/caveman/SKILL.md \
             .cursor/skills/caveman/SKILL.md \
             .windsurf/skills/caveman/SKILL.md \
+            .kiro/skills/caveman/SKILL.md \
+            .kiro/steering/caveman.md \
             caveman.skill \
             .clinerules/caveman.md \
             .github/copilot-instructions.md \

--- a/.kiro/skills/caveman/SKILL.md
+++ b/.kiro/skills/caveman/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
+  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
+  wenyan-lite, wenyan-full, wenyan-ultra.
+  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
+  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+
+Default: **full**. Switch: `/caveman lite|full|ultra`.
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
+| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
+| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
+| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
+| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+
+Example — "Why React component re-render?"
+- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
+- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+- wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
+- wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
+- wenyan-ultra: "新參照→重繪。useMemo Wrap。"
+
+Example — "Explain database connection pooling."
+- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
+- wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
+- wenyan-ultra: "池reuse conn。skip handshake → fast。"
+
+## Auto-Clarity
+
+Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.
+
+Example — destructive op:
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> ```sql
+> DROP TABLE users;
+> ```
+> Caveman resume. Verify backup exist first.
+
+## Boundaries
+
+Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.

--- a/.kiro/steering/caveman.md
+++ b/.kiro/steering/caveman.md
@@ -1,0 +1,15 @@
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+Rules:
+- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
+- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
+- Pattern: [thing] [action] [reason]. [next step].
+- Not: "Sure! I'd be happy to help you with that."
+- Yes: "Bug in auth middleware. Fix:"
+
+Switch level: /caveman lite|full|ultra|wenyan
+Stop: "stop caveman" or "normal mode"
+
+Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
+
+Boundaries: code/commits/PRs written normal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ Overwritten by CI on push to main when sources change. Edits here lost.
 | `.github/copilot-instructions.md` | `rules/caveman-activate.md` |
 | `.cursor/rules/caveman.mdc` | `rules/caveman-activate.md` + Cursor frontmatter |
 | `.windsurf/rules/caveman.md` | `rules/caveman-activate.md` + Windsurf frontmatter |
+| `.kiro/skills/caveman/SKILL.md` | `skills/caveman/SKILL.md` |
+| `.kiro/steering/caveman.md` | `rules/caveman-activate.md` |
 
 ---
 
@@ -61,7 +63,7 @@ Overwritten by CI on push to main when sources change. Edits here lost.
 What it does:
 1. Copies `skills/caveman/SKILL.md` to all agent-specific SKILL.md locations
 2. Rebuilds `caveman.skill` as a ZIP of `skills/caveman/`
-3. Rebuilds all agent rule files from `rules/caveman-activate.md`, prepending agent-specific frontmatter (Cursor needs `alwaysApply: true`, Windsurf needs `trigger: always_on`)
+3. Rebuilds all agent rule files from `rules/caveman-activate.md`, prepending agent-specific frontmatter (Cursor needs `alwaysApply: true`, Windsurf needs `trigger: always_on`, Kiro steering needs no frontmatter)
 4. Commits and pushes with `[skip ci]` to avoid loops
 
 CI bot commits as `github-actions[bot]`. After PR merge, wait for workflow before declaring release complete.
@@ -158,6 +160,7 @@ How caveman reaches each agent type:
 | Windsurf | `.windsurf/rules/caveman.md` with `trigger: always_on` | Yes — always-on rule |
 | Cline | `.clinerules/caveman.md` (auto-discovered) | Yes — Cline injects all .clinerules files |
 | Copilot | `.github/copilot-instructions.md` + `AGENTS.md` | Yes — repo-wide instructions |
+| Kiro | `.kiro/skills/caveman/SKILL.md` + [`.kiro/steering/caveman.md`](https://kiro.dev/docs/steering/) | Yes — steering file always included |
 | Others | `npx skills add JuliusBrussee/caveman` | No — user must say `/caveman` each session |
 
 For agents without hook systems, minimal always-on snippet lives in README under "Want it always on?" — keep current with `rules/caveman-activate.md`.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin and
 
 Based on the viral observation that caveman-speak dramatically reduces LLM token usage without losing technical substance. So we made it a one-line install.
 
+Also works with [Kiro](https://kiro.dev/), Gemini CLI, Codex, Cursor, Windsurf, Copilot, Cline, and [40+ other agents](#install).
+
 ## Before / After
 
 <table>
@@ -133,25 +135,26 @@ Pick your agent. One command. Done.
 | **Windsurf** | `npx skills add JuliusBrussee/caveman -a windsurf` |
 | **Copilot** | `npx skills add JuliusBrussee/caveman -a github-copilot` |
 | **Cline** | `npx skills add JuliusBrussee/caveman -a cline` |
+| **[Kiro](https://kiro.dev/)** | `npx skills add JuliusBrussee/caveman -a kiro-cli` |
 | **Any other** | `npx skills add JuliusBrussee/caveman` |
 
 Install once. Use in every session for that install target after that. One rock. That it.
 
 ### What You Get
 
-Auto-activation is built in for Claude Code, Gemini CLI, and the repo-local Codex setup below. `npx skills add` installs the skill for other agents, but does **not** install repo rule/instruction files, so Caveman does not auto-start there unless you add the always-on snippet below.
+Auto-activation is built in for Claude Code, Gemini CLI, and the repo-local Codex setup below. `npx skills add` installs the skill for other agents, but does **not** install repo rule/instruction files, so Caveman does not auto-start there unless you add the always-on snippet below. This repo ships Kiro steering files, so caveman auto-activates when opened in Kiro.
 
-| Feature | Claude Code | Codex | Gemini CLI | Cursor | Windsurf | Cline | Copilot |
-|---------|:-----------:|:-----:|:----------:|:------:|:--------:|:-----:|:-------:|
-| Caveman mode | Y | Y | Y | Y | Y | Y | Y |
-| Auto-activate every session | Y | Y¹ | Y | —² | —² | —² | —² |
-| `/caveman` command | Y | Y¹ | Y | — | — | — | — |
-| Mode switching (lite/full/ultra) | Y | Y¹ | Y | Y³ | Y³ | — | — |
-| Statusline badge | Y⁴ | — | — | — | — | — | — |
-| caveman-commit | Y | — | Y | Y | Y | Y | Y |
-| caveman-review | Y | — | Y | Y | Y | Y | Y |
-| caveman-compress | Y | Y | Y | Y | Y | Y | Y |
-| caveman-help | Y | — | Y | Y | Y | Y | Y |
+| Feature | Claude Code | Codex | Gemini CLI | Cursor | Windsurf | Kiro | Cline | Copilot |
+|---------|:-----------:|:-----:|:----------:|:------:|:--------:|:----:|:-----:|:-------:|
+| Caveman mode | Y | Y | Y | Y | Y | Y | Y | Y |
+| Auto-activate every session | Y | Y¹ | Y | —² | —² | Y⁵ | —² | —² |
+| `/caveman` command | Y | Y¹ | Y | — | — | Y | — | — |
+| Mode switching (lite/full/ultra) | Y | Y¹ | Y | Y³ | Y³ | Y | — | — |
+| Statusline badge | Y⁴ | — | — | — | — | — | — | — |
+| caveman-commit | Y | — | Y | Y | Y | Y | Y | Y |
+| caveman-review | Y | — | Y | Y | Y | Y | Y | Y |
+| caveman-compress | Y | Y | Y | Y | Y | Y | Y | Y |
+| caveman-help | Y | — | Y | Y | Y | Y | Y | Y |
 
 > [!NOTE]
 > Auto-activation works differently per agent: Claude Code uses SessionStart hooks, this repo's Codex dogfood setup uses `.codex/hooks.json`, Gemini uses context files. Cursor/Windsurf/Cline/Copilot can be made always-on, but `npx skills add` installs only the skill, not the repo rule/instruction files.
@@ -160,6 +163,7 @@ Auto-activation is built in for Claude Code, Gemini CLI, and the repo-local Code
 > ² Add the "Want it always on?" snippet below to those agents' system prompt or rule file if you want session-start activation.
 > ³ Cursor and Windsurf receive the full SKILL.md with all intensity levels. Mode switching works on-demand via the skill; no slash command.
 > ⁴ Available in Claude Code, but plugin install only nudges setup. Standalone `install.sh` / `install.ps1` configures it automatically when no custom `statusLine` exists.
+> ⁵ Kiro auto-activates via `.kiro/steering/caveman.md` (always-included [steering file](https://kiro.dev/docs/steering/)) and loads the full [skill](https://kiro.dev/docs/skills/) from `.kiro/skills/caveman/SKILL.md` on demand.
 
 <details>
 <summary><strong>Claude Code — full details</strong></summary>
@@ -223,6 +227,23 @@ Auto-activates via `GEMINI.md` context file. Also ships custom Gemini commands:
 </details>
 
 <details>
+<summary><strong>Kiro — full details</strong></summary>
+
+```bash
+npx skills add JuliusBrussee/caveman -a kiro-cli
+```
+
+Kiro supports the [Agent Skills](https://agentskills.io/) standard natively. The skill installs to `.kiro/skills/caveman/SKILL.md`. See [Kiro skills docs](https://kiro.dev/docs/skills/) for details on how skills work.
+
+This repo also ships `.kiro/steering/caveman.md` (always-included [steering file](https://kiro.dev/docs/steering/)), so caveman auto-activates when you open this repo in Kiro. For always-on behavior in other repos, copy the "Want it always on?" snippet below into `.kiro/steering/caveman.md` in that repo.
+
+Kiro activates skills on-demand when your request matches the skill description, or you can invoke `/caveman` directly as a slash command. Mode switching (lite/full/ultra/wenyan) works via the skill.
+
+Uninstall: `npx skills remove caveman`
+
+</details>
+
+<details>
 <summary><strong>Cursor / Windsurf / Cline / Copilot — full details</strong></summary>
 
 `npx skills add` installs the skill file only — it does **not** install the agent's rule/instruction file, so caveman does not auto-start. For always-on, add the "Want it always on?" snippet below to your agent's rules or system prompt.
@@ -241,7 +262,7 @@ Copilot works with Chat, Edits, and Coding Agent.
 </details>
 
 <details>
-<summary><strong>Any other agent (opencode, Roo, Amp, Goose, Kiro, and 40+ more)</strong></summary>
+<summary><strong>Any other agent (opencode, Roo, Amp, Goose, and 40+ more)</strong></summary>
 
 [npx skills](https://github.com/vercel-labs/skills) supports 40+ agents:
 
@@ -250,7 +271,6 @@ npx skills add JuliusBrussee/caveman           # auto-detect agent
 npx skills add JuliusBrussee/caveman -a amp
 npx skills add JuliusBrussee/caveman -a augment
 npx skills add JuliusBrussee/caveman -a goose
-npx skills add JuliusBrussee/caveman -a kiro-cli
 npx skills add JuliusBrussee/caveman -a roo
 # ... and many more
 ```
@@ -275,6 +295,7 @@ Code/commits/PRs: normal. Off: "stop caveman" / "normal mode".
 Where to put it:
 | Agent | File |
 |-------|------|
+| Kiro | [`.kiro/steering/caveman.md`](https://kiro.dev/docs/steering/) |
 | opencode | `.config/opencode/AGENTS.md` |
 | Roo | `.roo/rules/caveman.md` |
 | Amp | your workspace system prompt |


### PR DESCRIPTION
Adds Kiro as a fully supported agent with auto-activation via steering files and skill sync through CI.

### What changed

- Added `.kiro/skills/caveman/SKILL.md` and `.kiro/steering/caveman.md` so caveman auto-activates when the repo is opened in Kiro
- Updated `.github/workflows/sync-skill.yml` to sync both files from their single-source-of-truth origins, same as Cursor/Windsurf/Cline/Copilot
- Added Kiro column to the feature matrix in README with install command, details section, and footnote ⁵
- Moved Kiro out of the "Any other agent" catch-all into its own `<details>` block
- Updated `CLAUDE.md` sync table and agent distribution table with Kiro paths

### How it works

- `.kiro/steering/caveman.md` — always-included steering file, no frontmatter needed (Kiro's default is `inclusion: always`)
- `.kiro/skills/caveman/SKILL.md` — full skill loaded on demand when user says `/caveman` or request matches skill description
- CI keeps both in sync from `rules/caveman-activate.md` and `skills/caveman/SKILL.md` respectively
