### PR TITLE
fix: respect CLAUDE_CONFIG_DIR env var across all hooks

### DIFF
--- a/hooks/caveman-activate.js
+++ b/hooks/caveman-activate.js
@@ -2,7 +2,7 @@
 // caveman — Claude Code SessionStart activation hook
 //
 // Runs on every session start:
-//   1. Writes flag file at ~/.claude/.caveman-active (statusline reads this)
+//   1. Writes flag file at $CLAUDE_CONFIG_DIR/.caveman-active (statusline reads this)
 //   2. Emits caveman ruleset as hidden SessionStart context
 //   3. Detects missing statusline config and emits setup nudge
 
@@ -11,7 +11,7 @@ const path = require('path');
 const os = require('os');
 const { getDefaultMode } = require('./caveman-config');
 
-const claudeDir = path.join(os.homedir(), '.claude');
+const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');
 const settingsPath = path.join(claudeDir, 'settings.json');
 
@@ -54,7 +54,7 @@ const modeLabel = mode === 'wenyan' ? 'wenyan-full' : mode;
 
 // Read SKILL.md — the single source of truth for caveman behavior.
 // Plugin installs: __dirname = <plugin_root>/hooks/, SKILL.md at <plugin_root>/skills/caveman/SKILL.md
-// Standalone installs: __dirname = ~/.claude/hooks/, SKILL.md won't exist — falls back to hardcoded rules.
+// Standalone installs: __dirname = $CLAUDE_CONFIG_DIR/hooks/, SKILL.md won't exist — falls back to hardcoded rules.
 let skillContent = '';
 try {
   skillContent = fs.readFileSync(
@@ -137,7 +137,7 @@ try {
     output += "\n\n" +
       "STATUSLINE SETUP NEEDED: The caveman plugin includes a statusline badge showing active mode " +
       "(e.g. [CAVEMAN], [CAVEMAN:ULTRA]). It is not configured yet. " +
-      "To enable, add this to ~/.claude/settings.json: " +
+      "To enable, add this to " + path.join(claudeDir, 'settings.json') + ": " +
       statusLineSnippet + " " +
       "Proactively offer to set this up for the user on first interaction.";
   }

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -7,7 +7,8 @@ const path = require('path');
 const os = require('os');
 const { getDefaultMode } = require('./caveman-config');
 
-const flagPath = path.join(os.homedir(), '.claude', '.caveman-active');
+const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+const flagPath = path.join(claudeDir, '.caveman-active');
 
 let input = '';
 process.stdin.on('data', chunk => { input += chunk; });

--- a/hooks/caveman-statusline.ps1
+++ b/hooks/caveman-statusline.ps1
@@ -1,4 +1,5 @@
-$Flag = Join-Path $HOME ".claude/.caveman-active"
+$ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
+$Flag = Join-Path $ClaudeDir ".caveman-active"
 if (-not (Test-Path $Flag)) {
     exit 0
 }

--- a/hooks/caveman-statusline.sh
+++ b/hooks/caveman-statusline.sh
@@ -8,7 +8,7 @@
 # Plugin users: Claude will offer to set this up on first session.
 # Standalone users: install.sh wires this automatically.
 
-FLAG="$HOME/.claude/.caveman-active"
+FLAG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.caveman-active"
 [ ! -f "$FLAG" ] && exit 0
 
 MODE=$(cat "$FLAG" 2>/dev/null)

--- a/hooks/install.ps1
+++ b/hooks/install.ps1
@@ -19,7 +19,7 @@ if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
     exit 1
 }
 
-$ClaudeDir = Join-Path $env:USERPROFILE ".claude"
+$ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $env:USERPROFILE ".claude" }
 $HooksDir = Join-Path $ClaudeDir "hooks"
 $Settings = Join-Path $ClaudeDir "settings.json"
 $RepoUrl = "https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks"

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -32,7 +32,7 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
-CLAUDE_DIR="$HOME/.claude"
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS="$CLAUDE_DIR/settings.json"
 REPO_URL="https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks"

--- a/hooks/uninstall.ps1
+++ b/hooks/uninstall.ps1
@@ -6,7 +6,7 @@ param()
 
 $ErrorActionPreference = "Stop"
 
-$ClaudeDir = Join-Path $env:USERPROFILE ".claude"
+$ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $env:USERPROFILE ".claude" }
 $HooksDir = Join-Path $ClaudeDir "hooks"
 $Settings = Join-Path $ClaudeDir "settings.json"
 $FlagFile = Join-Path $ClaudeDir ".caveman-active"

--- a/hooks/uninstall.sh
+++ b/hooks/uninstall.sh
@@ -5,7 +5,7 @@
 #   or:  bash <(curl -s https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks/uninstall.sh)
 set -e
 
-CLAUDE_DIR="$HOME/.claude"
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS="$CLAUDE_DIR/settings.json"
 FLAG_FILE="$CLAUDE_DIR/.caveman-active"


### PR DESCRIPTION
## Summary
- All hook files (JS, sh, ps1) hardcoded `~/.claude` as the Claude config directory
- Users who set `CLAUDE_CONFIG_DIR` (e.g. for XDG compliance) had hooks reading/writing to the wrong location
- Now every hook checks `CLAUDE_CONFIG_DIR` first, falling back to `~/.claude`

## Files changed
- `hooks/caveman-activate.js` — use env var + updated comments and statusline nudge path
- `hooks/caveman-mode-tracker.js` — use env var for flag file path
- `hooks/caveman-statusline.sh` — `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`
- `hooks/caveman-statusline.ps1` — `$env:CLAUDE_CONFIG_DIR` with fallback
- `hooks/install.sh` / `install.ps1` — use env var for install target dir
- `hooks/uninstall.sh` / `uninstall.ps1` — use env var for uninstall target dir

## Test plan
- [ ] Set `CLAUDE_CONFIG_DIR` to a custom path, run `install.sh` — hooks install to custom dir
- [ ] Unset `CLAUDE_CONFIG_DIR`, run `install.sh` — hooks install to `~/.claude` (default behavior unchanged)
- [ ] Start a Claude Code session with `CLAUDE_CONFIG_DIR` set — flag file written to correct location
- [ ] Statusline badge reads from correct location when env var is set

Closes #140