### PR TITLE
feat(ultra): me no conjugate third-person singular verb

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -18,7 +18,7 @@ Default: **full**. Switch: `/caveman lite|full|ultra`.
 
 ## Rules
 
-Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging, third-person singular -s (say "it work" not "it works", "someone fill" not "someone fills"). Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
 
 Pattern: `[thing] [action] [reason]. [next step].`
 


### PR DESCRIPTION
Add explicit rule to drop the -s/-es suffix on third-person singular verbs (e.g. "it work" not "it works"). Already demonstrated in existing examples but now codified in the Rules section. Lite level unaffected since it preserves full sentences.

<img width="658" height="422" alt="caveman-ultra" src="https://github.com/user-attachments/assets/0c2bc581-b4be-4bfb-b5bc-687565973a3e" />
