### PR TITLE
fix: quote CLAUDE_PLUGIN_ROOT in hook commands to support paths with spaces

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/caveman-activate.js",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/caveman-activate.js\"",
             "timeout": 5,
             "statusMessage": "Loading caveman mode..."
           }
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/caveman-mode-tracker.js",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/caveman-mode-tracker.js\"",
             "timeout": 5,
             "statusMessage": "Tracking caveman mode..."
           }


### PR DESCRIPTION
Unquoted variable expansion breaks hook invocation on Windows when the user profile directory contains a space (e.g. C:\Users\Aiu Yap\...)

Fixed this error on Claude Code: 
<img width="1322" height="207" alt="err" src="https://github.com/user-attachments/assets/db1356ac-a8b3-4db8-bac6-bb9f689538fd" />
