### PR TITLE
feat: add zh-tw (Traditional Chinese) compression mode

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -3,7 +3,7 @@ name: caveman
 description: >
   Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
   while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
-  wenyan-lite, wenyan-full, wenyan-ultra.
+  wenyan-lite, wenyan-full, wenyan-ultra, zh-tw-lite, zh-tw-full, zh-tw-ultra.
   Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
   "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
 ---
@@ -14,7 +14,7 @@ Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
 ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
 
-Default: **full**. Switch: `/caveman lite|full|ultra`.
+Default: **full**. Switch: `/caveman lite|full|ultra|zh-tw-lite|zh-tw-full|zh-tw-ultra`.
 
 ## Rules
 
@@ -35,6 +35,9 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 | **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
 | **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+| **zh-tw-lite** | Modern Traditional Chinese. Drop 客套話/填充詞/避險語. Keep complete sentences. Professional but concise |
+| **zh-tw-full** | Drop template openers, hollow claims, repetition. Fragments OK. One point = one sentence. No 首先/其次/總結 |
+| **zh-tw-ultra** | Maximum compression, language-agnostic. English when shorter (pool not 連接池). Arrows, abbreviations, telegram style |
 
 Example — "Why React component re-render?"
 - lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
@@ -50,6 +53,45 @@ Example — "Explain database connection pooling."
 - ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
 - wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
 - wenyan-ultra: "池reuse conn。skip handshake → fast。"
+
+## Chinese Rules (zh-tw)
+
+Chinese LLM verbosity has different sources than English. Articles (a/an/the) don't exist — the waste comes from other patterns.
+
+Drop list (zero semantic loss):
+- Pleasantries: 好的/當然/讓我來幫你/希望這對你有幫助/歡迎繼續提問
+- Filler: 需要注意的是/值得一提的是/一般來說/簡單來說/具體來說/事實上
+- Hedging: 從某種程度上來說/可能需要根據實際情況/這只是我的建議
+- Hollow claims: 具有重要意義/至關重要的/不可或缺的/前所未有的
+- Phantom attribution: 研究表明.../有學者認為.../根據最佳實踐... (with no source)
+- Repetition: saying same thing 2-3 ways (換句話說... = repeat, delete it)
+
+Replace list (compress, not delete):
+- 首先...其次...最後...總結 → drop ordinals, just list points
+- 由於...因此... → arrow or direct statement
+- 不僅是 X，更是 Y → X 也 Y
+- Template openers (根據分析，我們發現...) → direct statement
+- Four-character idiom stacking → keep only necessary ones
+
+Technical terms, code blocks, error messages: unchanged. Same as English caveman.
+
+Example — "Why React component re-render?" (zh-tw)
+- Verbose: "好的，讓我來幫你分析一下這個問題。你的組件之所以會頻繁重新渲染，主要是因為你在每次渲染時都創建了一個新的物件引用。簡單來說，當你把一個 inline object 作為 prop 傳遞時，React 會認為這是一個全新的值，因此觸發重新渲染。需要注意的是，這是一個非常常見的效能問題。建議你使用 `useMemo` 來記憶化這個物件，這樣就能避免不必要的重新渲染了。希望這對你有幫助！"
+- zh-tw-lite: "組件頻繁重新渲染，因為每次渲染都創建新的物件引用。inline object prop 每次都是新 reference，觸發 re-render。用 `useMemo` 包住即可。"
+- zh-tw-full: "inline object prop = 每次新 ref = re-render。`useMemo` 包住。"
+- zh-tw-ultra: "inline obj prop → new ref → re-render。`useMemo`。"
+
+Example — "Explain database connection pooling." (zh-tw)
+- Verbose: "連接池是一種非常重要的資料庫效能優化技術。簡單來說，它的核心概念就是重複使用已經建立好的資料庫連接，而不是每次請求都重新建立一個新的連接。需要注意的是，建立連接涉及 TCP 握手、認證等步驟，是相對耗時的操作。換句話說，透過維護一組預先建立好的連接，可以大幅減少這些重複的開銷。總結來說，連接池能顯著提升系統在高負載下的效能表現。"
+- zh-tw-lite: "連接池重複使用已建立的 DB 連接，避免每次請求都建新連接。省掉重複的 TCP 握手和認證開銷，高負載下效能提升顯著。"
+- zh-tw-full: "連接池 = 重用 DB 連接。不每次新建，省 handshake 開銷。高負載快。"
+- zh-tw-ultra: "Pool reuse conn。Skip handshake → fast under load。"
+
+Example — "Debug: TypeError Cannot read properties of undefined" (zh-tw)
+- Verbose: "根據你提供的錯誤訊息，我分析了一下問題所在。需要注意的是，這個 TypeError: Cannot read properties of undefined 的錯誤通常表示你嘗試存取一個未定義變數的屬性。具體來說，在你的程式碼第 42 行，`user.profile.name` 中的 `user.profile` 是 undefined。這很可能是因為 API 回應的資料結構跟你預期的不同。建議你可以使用 optional chaining 來安全地存取巢狀屬性。此外，你可能也會想了解為什麼 API 結構不同，這可能需要進一步調查。"
+- zh-tw-lite: "第 42 行 `user.profile.name` 報 TypeError，`user.profile` 是 undefined。API 回應結構跟預期不同。用 `user?.profile?.name` 修。"
+- zh-tw-full: "L42 `user.profile` undefined。API 回應結構不符。`user?.profile?.name`。"
+- zh-tw-ultra: "L42 `user.profile` undefined → `user?.profile?.name`。"
 
 ## Auto-Clarity
 


### PR DESCRIPTION
## Summary

Add `zh-tw-lite`, `zh-tw-full`, `zh-tw-ultra` intensity levels for Modern Traditional Chinese (繁體中文).

Chinese LLM verbosity has fundamentally different sources than English — there are no articles (a/an/the) to drop. The existing `wenyan` modes target Classical Chinese stylization, while `zh-tw` targets **practical compression of modern Chinese LLM output patterns**.

## Why Chinese needs its own rules

English caveman's core compression levers don't apply to Chinese:

| English lever | Works in Chinese? |
|---|---|
| Drop articles (a/an/the) | ❌ Don't exist |
| Drop filler (just/really/basically) | ⚠️ Chinese has fewer, different fillers |
| Abbreviations (DB/auth/config) | ❌ Chinese is already compact per-character |

But Chinese LLMs have their own massive verbosity sources:

- **客套話 (Pleasantries)**: 好的，讓我來幫你 / 希望這對你有幫助！
- **填充詞 (Filler)**: 需要注意的是 / 值得一提的是 / 簡單來說
- **避險語 (Hedging)**: 從某種程度上來說 / 可能需要根據實際情況
- **重複解釋 (Repetition)**: Saying the same thing 2-3 ways (換句話說... = repeat)
- **過度結構化 (Over-structuring)**: 首先...其次...最後...總結 for 2-point answers
- **空洞宣稱 (Hollow claims)**: 具有重要意義 / 至關重要的 / 不可或缺的
- **模糊引用 (Phantom attribution)**: 研究表明... / 根據最佳實踐... (no source)

### Behavioral patterns (not in SKILL.md, but worth noting)

Chinese LLMs also exhibit unique behavioral verbosity:
- **Scope deflection**: 這是之前就知道的問題，不在這次範圍之內 (avoiding work)
- **Conversation escape**: 可以 commit 了嗎？/ 目前的修改已經可以正常運作了 (rushing to end)
- **Upselling**: 如果你願意，我可以幫你做一件更有價值的事 (expanding scope unprompted)

These are behavioral, not textual, so they stay out of the compression rules — but they illustrate how Chinese LLM verbosity goes beyond word choice.

## Intensity levels

| Level | Strategy |
|---|---|
| **zh-tw-lite** | Drop pleasantries/filler/hedging. Keep complete sentences. Professional but concise |
| **zh-tw-full** | Drop template openers, hollow claims, repetition. Fragments OK. One point = one sentence |
| **zh-tw-ultra** | Language-agnostic maximum compression. English when shorter (pool not 連接池). Arrows, abbreviations |

Key design decision: `zh-tw-ultra` is **language-agnostic** — it uses whichever language is shorter for each concept. This is practical for bilingual developers and maximizes token savings, since Chinese characters cost 2-4x more tokens than equivalent English words in most tokenizers.

## Before/after (tested)

**Prompt**: "Why does my TypeScript project show 'Type X is not assignable to type Y' on build but not in VS Code?"

**Verbose** (~2,500 chars):
> 您好，這是一個在 TypeScript 開發中相當常見的問題。我來為您詳細解釋原因和解決方案。首先，最常見的原因是 VS Code 使用的 TypeScript 版本與 build 工具使用的版本不同。需要注意的是，不同版本的型別檢查規則和嚴格程度不同...（後面還有 5 個方案 + 檢查清單 + 「希望這個解答對您有幫助！」）

**zh-tw-full** (~800 chars):
> IDE 和 CLI 用不同的 TypeScript 版本或配置。VS Code 用 workspace TS 版本，tsc CLI 用全域或 node_modules 裡的版本。tsconfig.json 中 skipLibCheck 或 noImplicitAny 設定只在 CLI 有效。快速檢查：npx tsc --version 看 CLI 版本。統一版本：npm ls typescript 確認只有一份。重啟 TS server：Cmd+Shift+P → "TypeScript: Restart TS Server"。

**Compression: ~68%** — comparable to English caveman's 65-75%.

## Test results across 3 real scenarios

| Scenario | Verbose | zh-tw-full | Compression |
|---|---|---|---|
| Obsidian plugin lifecycle | ~1,500 chars | ~600 chars | 60% |
| TypeScript build vs IDE | ~2,500 chars | ~800 chars | 68% |
| Git rebase conflicts | ~2,800 chars | ~800 chars | 71% |
| **Average** | | | **~66%** |

Information completeness: all technical points preserved in compressed versions. Zero semantic loss.

## Diff

- `+44 −2`, one file (`skills/caveman/SKILL.md`)
- Per CONTRIBUTING.md, only the source copy is edited; CI auto-syncs the rest