### PR TITLE
feat(compress): add <!-- nocompress --> escape to bypass Claude reformatting

### DIFF
--- a/caveman-compress/scripts/compress.py
+++ b/caveman-compress/scripts/compress.py
@@ -103,12 +103,14 @@ Compress this markdown into caveman format.
 STRICT RULES:
 - Do NOT modify anything inside ``` code blocks
 - Do NOT modify anything inside inline backticks
+- Do NOT add new ``` fences around content that is not already fenced — even if it looks like code or JSON
+- Do NOT create or promote text to markdown headings — only preserve existing # headings exactly as-is
 - Preserve ALL URLs exactly
-- Preserve ALL headings exactly
+- Preserve ALL headings exactly (do not add, remove, or reword any heading)
 - Preserve file paths and commands
 - Return ONLY the compressed markdown body — do NOT wrap the entire output in a ```markdown fence or any other fence. Inner code blocks from the original stay as-is; do not add a new outer fence around the whole file.
 
-Only compress natural language.
+Only compress natural language prose. Never restructure, add formatting, or improve organization.
 
 TEXT:
 {original}

--- a/caveman-compress/scripts/compress.py
+++ b/caveman-compress/scripts/compress.py
@@ -17,6 +17,14 @@ OUTER_FENCE_REGEX = re.compile(
 )
 
 
+NOCOMPRESS_REGEX = re.compile(
+    r"<!--\s*nocompress\s*-->(.*?)<!--\s*/nocompress\s*-->",
+    re.DOTALL | re.IGNORECASE,
+)
+
+PLACEHOLDER = "<!--NOCOMPRESS_{index}-->"
+
+
 def strip_llm_wrapper(text: str) -> str:
     """Strip outer ```markdown ... ``` fence when it wraps the entire output."""
     m = OUTER_FENCE_REGEX.match(text)
@@ -28,6 +36,32 @@ from .detect import should_compress
 from .validate import validate
 
 MAX_RETRIES = 2
+
+
+# ---------- Nocompress Helpers ----------
+
+
+def extract_nocompress(text: str) -> tuple[str, list[str]]:
+    """Replace <!-- nocompress -->...<!-- /nocompress --> blocks with placeholders.
+
+    Returns (text_with_placeholders, list_of_extracted_regions).
+    The extracted regions are spliced back verbatim after compression so Claude
+    never sees them — guaranteeing exact preservation regardless of content.
+    """
+    regions: list[str] = []
+
+    def replace(m: re.Match) -> str:
+        regions.append(m.group(0))
+        return PLACEHOLDER.format(index=len(regions) - 1)
+
+    return NOCOMPRESS_REGEX.sub(replace, text), regions
+
+
+def restore_nocompress(text: str, regions: list[str]) -> str:
+    """Splice extracted nocompress regions back by placeholder index."""
+    for i, region in enumerate(regions):
+        text = text.replace(PLACEHOLDER.format(index=i), region)
+    return text
 
 
 # ---------- Claude Calls ----------
@@ -138,9 +172,13 @@ def compress_file(filepath: Path) -> bool:
         print("Aborting to prevent data loss. Please remove or rename the backup file if you want to proceed.")
         return False
 
-    # Step 1: Compress
+    # Step 1: Extract nocompress regions, compress the rest
+    sendable, nocompress_regions = extract_nocompress(original_text)
+    if nocompress_regions:
+        print(f"  ({len(nocompress_regions)} nocompress region(s) preserved verbatim)")
     print("Compressing with Claude...")
-    compressed = call_claude(build_compress_prompt(original_text))
+    compressed_partial = call_claude(build_compress_prompt(sendable))
+    compressed = restore_nocompress(compressed_partial, nocompress_regions)
 
     # Save original as backup, write compressed to original path
     backup_path.write_text(original_text)
@@ -168,9 +206,11 @@ def compress_file(filepath: Path) -> bool:
             return False
 
         print("Fixing with Claude...")
-        compressed = call_claude(
-            build_fix_prompt(original_text, compressed, result.errors)
+        fixed_partial = call_claude(
+            build_fix_prompt(sendable, compressed_partial, result.errors)
         )
+        compressed_partial = fixed_partial
+        compressed = restore_nocompress(compressed_partial, nocompress_regions)
         filepath.write_text(compressed)
 
     return True

--- a/caveman-compress/scripts/compress.py
+++ b/caveman-compress/scripts/compress.py
@@ -105,6 +105,7 @@ STRICT RULES:
 - Do NOT modify anything inside inline backticks
 - Do NOT add new ``` fences around content that is not already fenced — even if it looks like code or JSON
 - Do NOT create or promote text to markdown headings — only preserve existing # headings exactly as-is
+- Do NOT convert XML-like tags (e.g. <section>, <foo>) into headings or any other markdown structure — leave them as plain text
 - Preserve ALL URLs exactly
 - Preserve ALL headings exactly (do not add, remove, or reword any heading)
 - Preserve file paths and commands

--- a/caveman-compress/scripts/validate.py
+++ b/caveman-compress/scripts/validate.py
@@ -6,6 +6,10 @@ URL_REGEX = re.compile(r"https?://[^\s)]+")
 FENCE_OPEN_REGEX = re.compile(r"^(\s{0,3})(`{3,}|~{3,})(.*)$")
 HEADING_REGEX = re.compile(r"^(#{1,6})\s+(.*)", re.MULTILINE)
 BULLET_REGEX = re.compile(r"^\s*[-*+]\s+", re.MULTILINE)
+NOCOMPRESS_REGEX = re.compile(
+    r"<!--\s*nocompress\s*-->.*?<!--\s*/nocompress\s*-->",
+    re.DOTALL | re.IGNORECASE,
+)
 
 # crude but effective path detection
 # Requires either a path prefix (./ ../ / or drive letter) or a slash/backslash within the match
@@ -28,6 +32,11 @@ class ValidationResult:
 
 def read_file(path: Path) -> str:
     return path.read_text(errors="ignore")
+
+
+def strip_nocompress(text: str) -> str:
+    """Remove nocompress regions before validation so they don't skew checks."""
+    return NOCOMPRESS_REGEX.sub("", text)
 
 
 # ---------- Extractors ----------
@@ -150,8 +159,8 @@ def validate_bullets(orig, comp, result):
 def validate(original_path: Path, compressed_path: Path) -> ValidationResult:
     result = ValidationResult()
 
-    orig = read_file(original_path)
-    comp = read_file(compressed_path)
+    orig = strip_nocompress(read_file(original_path))
+    comp = strip_nocompress(read_file(compressed_path))
 
     validate_headings(orig, comp, result)
     validate_code_blocks(orig, comp, result)

--- a/caveman-compress/scripts/validate.py
+++ b/caveman-compress/scripts/validate.py
@@ -2,7 +2,7 @@
 import re
 from pathlib import Path
 
-URL_REGEX = re.compile(r"https?://[^\s)]+")
+URL_REGEX = re.compile(r"https?://[^\s)`]+")
 FENCE_OPEN_REGEX = re.compile(r"^(\s{0,3})(`{3,}|~{3,})(.*)$")
 HEADING_REGEX = re.compile(r"^(#{1,6})\s+(.*)", re.MULTILINE)
 BULLET_REGEX = re.compile(r"^\s*[-*+]\s+", re.MULTILINE)

--- a/tests/test_nocompress.py
+++ b/tests/test_nocompress.py
@@ -70,6 +70,37 @@ class TestRestoreNocompress(unittest.TestCase):
         self.assertEqual(result, text)
 
 
+class TestUrlRegex(unittest.TestCase):
+    """URL_REGEX should not capture trailing backticks from inline code wrapping."""
+
+    def test_url_stops_at_trailing_backtick(self):
+        from scripts.validate import extract_urls
+        # Claude sometimes wraps URLs in inline code: `http://example.com/`
+        text = "See `http://example.com/` for details."
+        urls = extract_urls(text)
+        self.assertIn("http://example.com/", urls)
+        self.assertNotIn("http://example.com/`", urls)
+
+    def test_url_stops_at_trailing_paren(self):
+        from scripts.validate import extract_urls
+        text = "See (http://example.com/) for details."
+        urls = extract_urls(text)
+        self.assertIn("http://example.com/", urls)
+
+    def test_backtick_wrapped_url_matches_plain_url(self):
+        """Validation: original has plain URL, compressed wraps in backticks — should still match."""
+        import tempfile
+        from pathlib import Path
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            original = "See http://example.com/ for details."
+            compressed = "See `http://example.com/` for details."
+            (d / "orig.md").write_text(original)
+            (d / "comp.md").write_text(compressed)
+            result = validate(d / "orig.md", d / "comp.md")
+            self.assertTrue(result.is_valid, f"URL mismatch false positive: {result.errors}")
+
+
 class TestStripNocompressForValidation(unittest.TestCase):
     def test_strips_region(self):
         text = "Before\n<!-- nocompress -->\n```json\n{}\n```\n<!-- /nocompress -->\nAfter"

--- a/tests/test_nocompress.py
+++ b/tests/test_nocompress.py
@@ -1,0 +1,152 @@
+"""Tests for <!-- nocompress --> / <!-- /nocompress --> escape in caveman-compress."""
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "caveman-compress"))
+
+from scripts.compress import extract_nocompress, restore_nocompress, PLACEHOLDER
+from scripts.validate import strip_nocompress, validate, ValidationResult
+
+
+class TestExtractNocompress(unittest.TestCase):
+    def test_no_regions(self):
+        text = "Normal **caveman** text."
+        out, regions = extract_nocompress(text)
+        self.assertEqual(out, text)
+        self.assertEqual(regions, [])
+
+    def test_single_region_replaced(self):
+        text = 'Before\n<!-- nocompress -->\n{"key": "value"}\n<!-- /nocompress -->\nAfter'
+        out, regions = extract_nocompress(text)
+        self.assertIn(PLACEHOLDER.format(index=0), out)
+        self.assertNotIn('"key"', out)
+        self.assertEqual(len(regions), 1)
+        self.assertIn('"key": "value"', regions[0])
+
+    def test_multiple_regions(self):
+        text = (
+            "<!-- nocompress -->block1<!-- /nocompress -->"
+            " middle "
+            "<!-- nocompress -->block2<!-- /nocompress -->"
+        )
+        out, regions = extract_nocompress(text)
+        self.assertEqual(len(regions), 2)
+        self.assertIn(PLACEHOLDER.format(index=0), out)
+        self.assertIn(PLACEHOLDER.format(index=1), out)
+        self.assertNotIn("block1", out)
+        self.assertNotIn("block2", out)
+
+    def test_case_insensitive_tags(self):
+        text = "<!-- NOCOMPRESS -->secret<!-- /NOCOMPRESS -->"
+        out, regions = extract_nocompress(text)
+        self.assertEqual(len(regions), 1)
+        self.assertNotIn("secret", out)
+
+    def test_whitespace_in_tags(self):
+        text = "<!--  nocompress  -->data<!--  /nocompress  -->"
+        out, regions = extract_nocompress(text)
+        self.assertEqual(len(regions), 1)
+
+
+class TestRestoreNocompress(unittest.TestCase):
+    def test_roundtrip(self):
+        original = 'Prose\n<!-- nocompress -->\n{"exact": true}\n<!-- /nocompress -->\nMore prose.'
+        extracted, regions = extract_nocompress(original)
+        restored = restore_nocompress(extracted, regions)
+        self.assertEqual(restored, original)
+
+    def test_multiple_roundtrip(self):
+        original = "<!-- nocompress -->A<!-- /nocompress --> mid <!-- nocompress -->B<!-- /nocompress -->"
+        extracted, regions = extract_nocompress(original)
+        restored = restore_nocompress(extracted, regions)
+        self.assertEqual(restored, original)
+
+    def test_no_regions_unchanged(self):
+        text = "Plain text, no regions."
+        _, regions = extract_nocompress(text)
+        result = restore_nocompress(text, regions)
+        self.assertEqual(result, text)
+
+
+class TestStripNocompressForValidation(unittest.TestCase):
+    def test_strips_region(self):
+        text = "Before\n<!-- nocompress -->\n```json\n{}\n```\n<!-- /nocompress -->\nAfter"
+        stripped = strip_nocompress(text)
+        self.assertNotIn("```json", stripped)
+        self.assertIn("Before", stripped)
+        self.assertIn("After", stripped)
+
+    def test_no_regions_unchanged(self):
+        text = "# Heading\n\nSome text."
+        self.assertEqual(strip_nocompress(text), text)
+
+
+class TestValidateIgnoresNocompressRegions(unittest.TestCase):
+    """Validation should pass when nocompress regions differ between original and compressed."""
+
+    def _write_tmp(self, tmp_dir: Path, name: str, content: str) -> Path:
+        p = tmp_dir / name
+        p.write_text(content)
+        return p
+
+    def test_nocompress_region_not_flagged_as_code_block_mismatch(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            original = (
+                "# Doc\n\n"
+                "<!-- nocompress -->\n"
+                "```json\n{\"key\": \"original\"}\n```\n"
+                "<!-- /nocompress -->\n\n"
+                "Some prose here."
+            )
+            # Compressed version has caveman prose but nocompress region intact
+            compressed = (
+                "# Doc\n\n"
+                "<!-- nocompress -->\n"
+                "```json\n{\"key\": \"original\"}\n```\n"
+                "<!-- /nocompress -->\n\n"
+                "Prose here."
+            )
+            orig_path = self._write_tmp(d, "orig.md", original)
+            comp_path = self._write_tmp(d, "comp.md", compressed)
+            result = validate(orig_path, comp_path)
+            self.assertTrue(result.is_valid, f"Unexpected errors: {result.errors}")
+
+    def test_nocompress_region_preserved_verbatim_after_roundtrip(self):
+        """extract → simulate Claude compression → restore → validate passes."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            original = (
+                "# Title\n\n"
+                "The system is a very big and important platform that does lots of things.\n\n"
+                "<!-- nocompress -->\n"
+                "```yaml\nexact:\n  - preserved: true\n```\n"
+                "<!-- /nocompress -->\n\n"
+                "Please make sure to always run the tests before committing."
+            )
+            # Simulate what Claude returns: prose compressed, placeholder intact
+            sendable, regions = extract_nocompress(original)
+            # Claude would compress sendable; we simulate that here
+            simulated_claude_output = sendable.replace(
+                "The system is a very big and important platform that does lots of things.",
+                "System: big platform, many things.",
+            ).replace(
+                "Please make sure to always run the tests before committing.",
+                "Run tests before commit.",
+            )
+            compressed = restore_nocompress(simulated_claude_output, regions)
+
+            orig_path = self._write_tmp(d, "orig.md", original)
+            comp_path = self._write_tmp(d, "comp.md", compressed)
+            result = validate(orig_path, comp_path)
+            self.assertTrue(result.is_valid, f"Unexpected errors: {result.errors}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nocompress.py
+++ b/tests/test_nocompress.py
@@ -179,5 +179,54 @@ class TestValidateIgnoresNocompressRegions(unittest.TestCase):
             self.assertTrue(result.is_valid, f"Unexpected errors: {result.errors}")
 
 
+class TestXmlTagHeadingPrevention(unittest.TestCase):
+    """Validator must catch when Claude converts XML tags to markdown headings."""
+
+    def test_xml_tag_promoted_to_heading_fails_validation(self):
+        """Original has XML tags + no headings; compressed invents a heading → fail."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            original = (
+                "<section_intro>\n\n"
+                "This is the introduction text.\n\n"
+                "</section_intro>\n"
+            )
+            # Claude converts <section_intro> to a markdown heading
+            compressed = (
+                "# Introduction\n\n"
+                "This is intro text.\n"
+            )
+            (d / "orig.md").write_text(original)
+            (d / "comp.md").write_text(compressed)
+            result = validate(d / "orig.md", d / "comp.md")
+            self.assertFalse(result.is_valid, "Should fail: Claude added a heading that wasn't in original")
+            self.assertTrue(
+                any("Heading count mismatch" in e for e in result.errors),
+                f"Expected heading count error, got: {result.errors}",
+            )
+
+    def test_xml_tags_preserved_as_plain_text_passes_validation(self):
+        """Original has XML tags + no headings; compressed keeps XML tags as plain text → pass."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            original = (
+                "<section_intro>\n\n"
+                "This is the introduction text with lots of extra filler words.\n\n"
+                "</section_intro>\n"
+            )
+            # Claude compresses prose but leaves XML tags intact, no headings added
+            compressed = (
+                "<section_intro>\n\n"
+                "Introduction text.\n\n"
+                "</section_intro>\n"
+            )
+            (d / "orig.md").write_text(original)
+            (d / "comp.md").write_text(compressed)
+            result = validate(d / "orig.md", d / "comp.md")
+            self.assertTrue(result.is_valid, f"Unexpected errors: {result.errors}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Some files contain example code blocks (JSON, YAML, tool-call templates) that repeatedly fail validation because Claude reformats them despite the \"preserve code blocks exactly\" rule. The validator does byte-exact comparison of fenced blocks, so even cosmetic changes (key reordering, whitespace) fail.

Claude will also sometimes insert its own headers after encountering an xml tag, e.g <example-1>.  Improve prompts to prevent inadvertent changes like this.

## Solution

Add `<!-- nocompress -->` / `<!-- /nocompress -->` tags to exclude regions from compression entirely. The script — not Claude — handles extraction and restoration, so preservation is guaranteed regardless of content complexity.

**Before:**
```
<!-- nocompress tag did not exist, files with tricky example blocks failed -->
❌ Compression failed after retries — original restored
```

**After:**
```markdown
Use guide agent like this:

<!-- nocompress -->
```json
{"tool": "guide_agent", "args": {"query": "exact example"}}
```
<!-- /nocompress -->

Other prose compressed normally.
```
```
✅ Compression completed successfully
```

## Changes

- `caveman-compress/scripts/compress.py`: `extract_nocompress()` strips tagged regions to placeholders before Claude call; `restore_nocompress()` splices them back after. Fix loop operates on placeholder text so validation errors remain accurate.
- `caveman-compress/scripts/validate.py`: `strip_nocompress()` removes tagged regions from both sides before all checks (heading counts, code block diffs, URL sets).
- `tests/test_nocompress.py`: 12 unit tests — extract/restore roundtrip, case-insensitive tags, multi-region, validation bypass, full simulate-Claude roundtrip.

## Why one sentence better

Fenced blocks not always escape, Claude name things or shuffle.  If Claude disobey, take away toys until Claude done.