### PR TITLE
Quote ${CLAUDE_PLUGIN_ROOT} so hooks work on paths with spaces

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/caveman-activate.js",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/caveman-activate.js\"",
             "timeout": 5,
             "statusMessage": "Loading caveman mode..."
           }
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/caveman-mode-tracker.js",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/caveman-mode-tracker.js\"",
             "timeout": 5,
             "statusMessage": "Tracking caveman mode..."
           }


### PR DESCRIPTION
## Summary
- Fixes #157 — both hook commands in `.claude-plugin/plugin.json` passed `${CLAUDE_PLUGIN_ROOT}` unquoted to the shell. On any system where the plugin root contains a space (e.g. `/Users/Tyler Laprade/...` on macOS), the shell split the expansion on whitespace and Node received a truncated path:

  ```
  Error: Cannot find module '/Users/Tyler'
  ```

  Both `SessionStart` and `UserPromptSubmit` hooks errored on every session start and every prompt submit, effectively disabling the plugin for those users.
- Wrapping `${CLAUDE_PLUGIN_ROOT}` in double quotes preserves the full path on any POSIX-style shell and is a no-op on paths without spaces.

## Changes
- `.claude-plugin/plugin.json` — quoted `${CLAUDE_PLUGIN_ROOT}` in the `caveman-activate.js` and `caveman-mode-tracker.js` hook command strings.

## Test plan
- [x] Verify diff is minimal (only the two hook command strings changed).
- [ ] Reproduce bug: `mkdir "/tmp/plugin root with space"`, copy the plugin in, run a hook → pre-fix errors with `Cannot find module '/tmp/plugin'`, post-fix loads correctly.
- [ ] Confirm hooks still work on plugin roots without spaces (unchanged behavior).