### PR TITLE
fix: isolate hooks as CommonJS so they survive ESM parent package.json

### DIFF
--- a/hooks/install.ps1
+++ b/hooks/install.ps1
@@ -24,7 +24,7 @@ $HooksDir = Join-Path $ClaudeDir "hooks"
 $Settings = Join-Path $ClaudeDir "settings.json"
 $RepoUrl = "https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks"
 
-$HookFiles = @("caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-statusline.sh", "caveman-statusline.ps1")
+$HookFiles = @("package.json", "caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-statusline.sh", "caveman-statusline.ps1")
 
 # Resolve source — works from repo clone or remote
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { $null }

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -37,7 +37,7 @@ HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS="$CLAUDE_DIR/settings.json"
 REPO_URL="https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks"
 
-HOOK_FILES=("caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-statusline.sh")
+HOOK_FILES=("package.json" "caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-statusline.sh")
 
 # Resolve source — works from repo clone or curl pipe
 SCRIPT_DIR=""

--- a/hooks/package.json
+++ b/hooks/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/hooks/uninstall.ps1
+++ b/hooks/uninstall.ps1
@@ -11,7 +11,7 @@ $HooksDir = Join-Path $ClaudeDir "hooks"
 $Settings = Join-Path $ClaudeDir "settings.json"
 $FlagFile = Join-Path $ClaudeDir ".caveman-active"
 
-$HookFiles = @("caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-statusline.sh", "caveman-statusline.ps1")
+$HookFiles = @("package.json", "caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-statusline.sh", "caveman-statusline.ps1")
 
 # Detect if caveman is installed as a plugin
 $PluginInstalled = $false

--- a/hooks/uninstall.sh
+++ b/hooks/uninstall.sh
@@ -10,7 +10,7 @@ HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS="$CLAUDE_DIR/settings.json"
 FLAG_FILE="$CLAUDE_DIR/.caveman-active"
 
-HOOK_FILES=("caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-statusline.sh")
+HOOK_FILES=("package.json" "caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-statusline.sh")
 
 # Detect if caveman is installed as a plugin (check plugin cache)
 PLUGIN_INSTALLED=0


### PR DESCRIPTION
## What

Adds `hooks/package.json` with `{ "type": "commonjs" }` so the caveman hooks resolve as CJS regardless of what the user's `~/.claude/package.json` declares. Also registers the new file in `install.{sh,ps1}` and `uninstall.{sh,ps1}` so standalone installs (`curl | bash` / PowerShell) copy it into `~/.claude/hooks/`.

## Why

When `~/.claude/package.json` (or any ancestor) contains `"type": "module"`, Node treats every `.js` file under that tree as an ES module. The caveman hooks are CommonJS (`require('fs')`), so they crash immediately:

```
ReferenceError: require is not defined in ES module scope
    at file:///.../hooks/caveman-activate.js:9:12
```

surfaced to the user as:

```
SessionStart:clear hook error
Failed with non-blocking status code: file:///.../caveman-activate.js:9
UserPromptSubmit hook error
Failed with non-blocking status code: file:///.../caveman-mode-tracker.js:5
```

Repros on any user who has `{ "type": "module" }` in `~/.claude/package.json` — which several Claude Code plugins/skills set up. On my machine this stopped both hooks from firing (flag file not written, ruleset never injected, statusline badge missing).

The ESM sub-case is flagged in [@mrx-arafat's comment on #167](https://github.com/JuliusBrussee/caveman/issues/167#issuecomment-4249634684) — recommending exactly this workaround but applied by the user, not shipped by the plugin. Shipping it here means the fix survives plugin updates and reaches every install without user action.

## How the fix works

Node's module-type resolution walks up looking for the nearest `package.json`. By dropping one into `hooks/` itself, we pin the directory to CJS regardless of any ancestor settings. Zero code changes to the hooks themselves.

Resolution order:
- Before: `~/.claude/package.json` → `"type": "module"` → `.js` treated as ESM → `require` undefined → crash.
- After: `hooks/package.json` (nearer ancestor) → `"type": "commonjs"` → `.js` treated as CJS → hook runs.

## Scope note

This does not fix the Windows `${CLAUDE_PLUGIN_ROOT}` path-expansion issues with spaces/umlauts in #167 / #78 / #72 — those have a separate root cause (unquoted variable in `plugin.json`) and need their own patch.

## Verification

Simulated ESM-parent environment:

```bash
mkdir -p /tmp/esm-test/.claude/plugins/hooks
echo '{"type":"module"}' > /tmp/esm-test/.claude/package.json
cp hooks/{package.json,caveman-config.js,caveman-activate.js,caveman-mode-tracker.js} \
   /tmp/esm-test/.claude/plugins/hooks/

HOME=/tmp/esm-test node /tmp/esm-test/.claude/plugins/hooks/caveman-activate.js
# → exit 0, emits "CAVEMAN MODE ACTIVE — level: full" + ruleset

echo '{"prompt":"hi"}' | HOME=/tmp/esm-test \
  node /tmp/esm-test/.claude/plugins/hooks/caveman-mode-tracker.js
# → exit 0
```

Without the fix both commands fail with `ReferenceError: require is not defined in ES module scope`.

## Files changed

- `hooks/package.json` (new) — `{ "type": "commonjs" }`
- `hooks/install.sh` — add `package.json` to `HOOK_FILES`
- `hooks/install.ps1` — add `package.json` to `$HookFiles`
- `hooks/uninstall.sh` — add `package.json` to `HOOK_FILES`
- `hooks/uninstall.ps1` — add `package.json` to `$HookFiles`