### PR TITLE
fix: reduce false positives in natural language activation/deactivation

### DIFF
--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -28,7 +28,7 @@ process.stdin.on('end', () => {
         /\btalk like\b.*\bcaveman\b/i.test(prompt) ||
         /\bstart caveman\b/i.test(prompt) ||
         /\bcaveman\b.*\b(mode|activate|enable|turn on)\b/i.test(prompt)) {
-      if (!/\b(stop|disable|turn off|deactivate|don't|do not|no)\b/i.test(prompt)) {
+      if (!/\b(stop|disable|turn off|deactivate|don't|do not)\b/i.test(prompt)) {
         const mode = getDefaultMode();
         if (mode !== 'off') {
           safeWriteFlag(flagPath, mode);
@@ -67,11 +67,13 @@ process.stdin.on('end', () => {
     }
 
     // Detect deactivation — natural language and slash commands.
-    // "normal mode" requires "caveman" in the same prompt to avoid false
-    // deactivation when users discuss unrelated "normal mode" topics.
+    // "normal mode" works standalone when caveman is already active (flag
+    // exists), preserving the documented stop phrase. When caveman is not
+    // active, require "caveman" in the prompt to avoid false deactivation
+    // from unrelated "normal mode" discussion.
     if (/\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/i.test(prompt) ||
         /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/i.test(prompt) ||
-        (/\bnormal mode\b/i.test(prompt) && /\bcaveman\b/i.test(prompt))) {
+        (/\bnormal mode\b/i.test(prompt) && (readFlag(flagPath) !== null || /\bcaveman\b/i.test(prompt)))) {
       try { fs.unlinkSync(flagPath); } catch (e) {}
     }
 

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -20,9 +20,15 @@ process.stdin.on('end', () => {
     // Natural language activation (e.g. "activate caveman", "turn on caveman mode",
     // "talk like caveman"). README tells users they can say these, but the hook
     // only matched /caveman commands — flag file and statusline stayed out of sync.
-    if (/\b(activate|enable|turn on|start|talk like)\b.*\bcaveman\b/i.test(prompt) ||
-        /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt)) {
-      if (!/\b(stop|disable|turn off|deactivate)\b/i.test(prompt)) {
+    //
+    // Guard: require "caveman" to appear as a direct object of the action verb,
+    // not as a modifier in an unrelated clause ("start a caveman fire" should NOT
+    // activate). Also reject prompts containing negation words before the trigger.
+    if (/\b(activate|enable|turn on)\b.*\bcaveman\b/i.test(prompt) ||
+        /\btalk like\b.*\bcaveman\b/i.test(prompt) ||
+        /\bstart caveman\b/i.test(prompt) ||
+        /\bcaveman\b.*\b(mode|activate|enable|turn on)\b/i.test(prompt)) {
+      if (!/\b(stop|disable|turn off|deactivate|don't|do not|no)\b/i.test(prompt)) {
         const mode = getDefaultMode();
         if (mode !== 'off') {
           safeWriteFlag(flagPath, mode);
@@ -60,10 +66,12 @@ process.stdin.on('end', () => {
       }
     }
 
-    // Detect deactivation — natural language and slash commands
+    // Detect deactivation — natural language and slash commands.
+    // "normal mode" requires "caveman" in the same prompt to avoid false
+    // deactivation when users discuss unrelated "normal mode" topics.
     if (/\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/i.test(prompt) ||
         /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/i.test(prompt) ||
-        /\bnormal mode\b/i.test(prompt)) {
+        (/\bnormal mode\b/i.test(prompt) && /\bcaveman\b/i.test(prompt))) {
       try { fs.unlinkSync(flagPath); } catch (e) {}
     }
 

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -67,13 +67,13 @@ process.stdin.on('end', () => {
     }
 
     // Detect deactivation — natural language and slash commands.
-    // "normal mode" works standalone when caveman is already active (flag
-    // exists), preserving the documented stop phrase. When caveman is not
-    // active, require "caveman" in the prompt to avoid false deactivation
-    // from unrelated "normal mode" discussion.
+    // Keep the documented stop phrase "normal mode", but only as an exact
+    // standalone command. Broad /\bnormal mode\b/ matching still deactivates
+    // on incidental discussion such as "switch from normal mode to debug mode"
+    // or "is this normal mode behavior?".
     if (/\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/i.test(prompt) ||
         /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/i.test(prompt) ||
-        (/\bnormal mode\b/i.test(prompt) && (readFlag(flagPath) !== null || /\bcaveman\b/i.test(prompt)))) {
+        prompt === 'normal mode') {
       try { fs.unlinkSync(flagPath); } catch (e) {}
     }
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -10,7 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 class HookScriptTests(unittest.TestCase):
-    def run_cmd(self, cmd, home):
+    def run_cmd(self, cmd, home, input_text=None):
         env = os.environ.copy()
         env["HOME"] = str(home)
         env["USERPROFILE"] = str(home)
@@ -19,6 +19,7 @@ class HookScriptTests(unittest.TestCase):
             cwd=REPO_ROOT,
             env=env,
             text=True,
+            input=input_text,
             capture_output=True,
             check=True,
         )
@@ -155,6 +156,83 @@ class HookScriptTests(unittest.TestCase):
 
             self.assertNotIn("STATUSLINE SETUP NEEDED", result.stdout)
             self.assertEqual((claude_dir / ".caveman-active").read_text(), "full")
+
+    def test_mode_tracker_preserves_exact_normal_mode_only(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-normal-mode-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+            flag = claude_dir / ".caveman-active"
+
+            for prompt in (
+                "switch from normal mode to debug mode",
+                "use normal mode for this task",
+                "is this normal mode behavior?",
+            ):
+                flag.write_text("full")
+                self.run_cmd(
+                    ["node", "hooks/caveman-mode-tracker.js"],
+                    home,
+                    input_text=json.dumps({"prompt": prompt}),
+                )
+                self.assertTrue(flag.exists(), f"{prompt!r} should not deactivate caveman")
+
+            flag.write_text("full")
+            self.run_cmd(
+                ["node", "hooks/caveman-mode-tracker.js"],
+                home,
+                input_text=json.dumps({"prompt": "normal mode"}),
+            )
+            self.assertFalse(flag.exists(), '"normal mode" should still deactivate caveman')
+
+    def test_mode_tracker_allows_activate_caveman_no_markdown(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-no-markdown-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+
+            self.run_cmd(
+                ["node", "hooks/caveman-mode-tracker.js"],
+                home,
+                input_text=json.dumps({"prompt": "activate caveman, no markdown"}),
+            )
+
+            self.assertEqual((claude_dir / ".caveman-active").read_text(), "full")
+
+    def test_mode_tracker_ignores_dont_activate_caveman(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-dont-activate-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+
+            self.run_cmd(
+                ["node", "hooks/caveman-mode-tracker.js"],
+                home,
+                input_text=json.dumps({"prompt": "don't activate caveman"}),
+            )
+
+            self.assertFalse((claude_dir / ".caveman-active").exists())
+
+    def test_mode_tracker_only_activates_exact_start_caveman(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-start-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+            flag = claude_dir / ".caveman-active"
+
+            self.run_cmd(
+                ["node", "hooks/caveman-mode-tracker.js"],
+                home,
+                input_text=json.dumps({"prompt": "How do I start a caveman fire?"}),
+            )
+            self.assertFalse(flag.exists())
+
+            self.run_cmd(
+                ["node", "hooks/caveman-mode-tracker.js"],
+                home,
+                input_text=json.dumps({"prompt": "start caveman"}),
+            )
+            self.assertEqual(flag.read_text(), "full")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The problem

The natural-language mode tracker in `hooks/caveman-mode-tracker.js` still matched too broadly around activation and deactivation phrases.

Three concrete failure modes prompted this PR:

1. **`start.*caveman` was too broad.** Prompts like `How do I start a caveman fire?` activated caveman even though `caveman` was not the action target.
2. **Negated activation still slipped through.** Phrases like `don't activate caveman` should not enable caveman.
3. **`normal mode` discussion caused false deactivation.** The tracker treated incidental mentions of `normal mode` as a stop command, so prompts like `switch from normal mode to debug mode` could silently disable caveman.

## What this PR changes

- Narrow activation matching so `start caveman` still works, but broader `start ... caveman` phrases do not.
- Keep negated activation blocked while allowing valid prompts such as `activate caveman, no markdown`.
- Preserve the documented stop phrase `normal mode`, but only as the exact standalone command instead of any incidental mention.
- Add regression tests for:
  - exact `start caveman` activation
  - no activation for `How do I start a caveman fire?`
  - no activation for `don't activate caveman`
  - valid activation for `activate caveman, no markdown`
  - no deactivation for incidental `normal mode` discussion
  - deactivation for exact `normal mode`

## Verification

- `python -m unittest discover -s tests -p 'test_*.py'`
- Targeted local hook repros for:
  - `How do I start a caveman fire?`
  - `start caveman`
  - `don't activate caveman`
  - `activate caveman, no markdown`
  - `switch from normal mode to debug mode`
  - `normal mode`

## Note

`tests/verify_repo.py` still fails on an existing activation-banner string expectation unrelated to this PR.

Closes #187
