### PR TITLE
feat(hooks): add /caveman status command to report active mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Overwritten by CI on push to main when sources change. Edits here lost.
 `.github/workflows/sync-skill.yml` triggers on main push when `skills/caveman/SKILL.md` or `rules/caveman-activate.md` changes.
 
 What it does:
+
 1. Copies `skills/caveman/SKILL.md` to all agent-specific SKILL.md locations
 2. Rebuilds `caveman.skill` as a ZIP of `skills/caveman/`
 3. Rebuilds all agent rule files from `rules/caveman-activate.md`, prepending agent-specific frontmatter (Cursor needs `alwaysApply: true`, Windsurf needs `trigger: always_on`)
@@ -88,12 +89,14 @@ All hooks honor `CLAUDE_CONFIG_DIR` for non-default Claude Code config locations
 ### `hooks/caveman-config.js` — shared module
 
 Exports:
+
 - `getDefaultMode()` — resolves default mode from `CAVEMAN_DEFAULT_MODE` env var, then `$XDG_CONFIG_HOME/caveman/config.json` / `~/.config/caveman/config.json` / `%APPDATA%\caveman\config.json`, then `'full'`
 - `safeWriteFlag(flagPath, content)` — symlink-safe flag write. Refuses if flag target or its immediate parent is a symlink. Opens with `O_NOFOLLOW` where supported. Atomic temp + rename. Creates with `0600`. Protects against local attackers replacing the predictable flag path with a symlink to clobber files writable by the user. Used by both write hooks. Silent-fails on all filesystem errors.
 
 ### `hooks/caveman-activate.js` — SessionStart hook
 
 Runs once per Claude Code session start. Three things:
+
 1. Writes the active mode to `$CLAUDE_CONFIG_DIR/.caveman-active` via `safeWriteFlag` (creates if missing)
 2. Emits caveman ruleset as hidden stdout — Claude Code injects SessionStart hook stdout as system context, invisible to user
 3. Checks `settings.json` for statusline config; if missing, appends nudge to offer setup on first interaction
@@ -105,7 +108,9 @@ Silent-fails on all filesystem errors — never blocks session start.
 Reads JSON from stdin. Three responsibilities:
 
 **1. Slash-command activation.** If prompt starts with `/caveman`, writes mode to flag file via `safeWriteFlag`:
+
 - `/caveman` → configured default (see `caveman-config.js`, defaults to `full`)
+- `/caveman status` → read-only query, emits current mode via `hookSpecificOutput`, no flag write
 - `/caveman lite` → `lite`
 - `/caveman ultra` → `ultra`
 - `/caveman wenyan` or `/caveman wenyan-full` → `wenyan`
@@ -122,6 +127,7 @@ Reads JSON from stdin. Three responsibilities:
 ### `hooks/caveman-statusline.sh` — Statusline badge
 
 Reads flag file at `$CLAUDE_CONFIG_DIR/.caveman-active`. Outputs colored badge string for Claude Code statusline:
+
 - `full` or empty → `[CAVEMAN]` (orange)
 - anything else → `[CAVEMAN:<MODE_UPPERCASED>]` (orange)
 
@@ -181,6 +187,7 @@ For agents without hook systems, minimal always-on snippet lives in README under
 ## Evals
 
 `evals/` has three-arm harness:
+
 - `__baseline__` — no system prompt
 - `__terse__` — `Answer concisely.`
 - `<skill>` — `Answer concisely.\n\n{SKILL.md}`

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -45,7 +45,20 @@ process.stdin.on('end', () => {
       } else if (cmd === '/caveman-compress' || cmd === '/caveman:caveman-compress') {
         mode = 'compress';
       } else if (cmd === '/caveman' || cmd === '/caveman:caveman') {
-        if (arg === 'lite') mode = 'lite';
+        if (arg === 'status') {
+          // Status query — don't change mode, just report current state
+          const current = readFlag(flagPath);
+          const statusMsg = current
+            ? 'CAVEMAN STATUS: Active mode is "' + current + '". Tell the user their current caveman mode is: ' + current
+            : 'CAVEMAN STATUS: Caveman is not active. Tell the user caveman mode is currently off.';
+          process.stdout.write(JSON.stringify({
+            hookSpecificOutput: {
+              hookEventName: "UserPromptSubmit",
+              additionalContext: statusMsg
+            }
+          }));
+          return; // skip all other processing — status is read-only
+        } else if (arg === 'lite') mode = 'lite';
         else if (arg === 'ultra') mode = 'ultra';
         else if (arg === 'wenyan-lite') mode = 'wenyan-lite';
         else if (arg === 'wenyan' || arg === 'wenyan-full') mode = 'wenyan';

--- a/skills/caveman-help/SKILL.md
+++ b/skills/caveman-help/SKILL.md
@@ -32,6 +32,10 @@ Mode stick until changed or session end.
 | **caveman-compress** | `/caveman:compress <file>` | Compress .md files to caveman prose. Saves ~46% input tokens. |
 | **caveman-help** | `/caveman-help` | This card. |
 
+## Check Active Mode
+
+`/caveman status` — show which mode active right now (lite/full/ultra/wenyan-*/off).
+
 ## Deactivate
 
 Say "stop caveman" or "normal mode". Resume anytime with `/caveman`.

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -14,7 +14,7 @@ Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
 ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
 
-Default: **full**. Switch: `/caveman lite|full|ultra`.
+Default: **full**. Switch: `/caveman lite|full|ultra`. Check: `/caveman status`.
 
 ## Rules
 


### PR DESCRIPTION
# Feat - Add /caveman status

## PR Description

Before: No way to check which caveman mode is active. User switches to ultra, forgets,
has no command to verify.

After: /caveman status reports current active mode:

```bash
# When ultra is active:
> /caveman status
→ "Current caveman mode: ultra"

# When inactive:
> /caveman status
→ "Caveman mode is currently off"
```

New feature — read-only status query via hook. No flag writes, no mode changes.

Why: Users switching between modes (lite/full/ultra/wenyan) need a way to check what's
currently active without guessing from output style.

Files changed

- hooks/caveman-mode-tracker.js — add status branch, emit mode via hookSpecificOutput
- skills/caveman/SKILL.md — document /caveman status
- skills/caveman-help/SKILL.md — add "Check Active Mode" section
- CLAUDE.md — document status command in hook reference

## Test

Case 1 inactive:

```bash
echo '{"prompt":"/caveman status"}' | CLAUDE_CONFIG_DIR="$(mktemp -d)" node
hooks/caveman-mode-tracker.js
```

Case 2 active (ultra):

```bash
D=$(mktemp -d) && echo "ultra" > "$D/.caveman-active" && echo '{"prompt":"/caveman
status"}' | CLAUDE_CONFIG_DIR="$D" node hooks/caveman-mode-tracker.js
```