### PR TITLE
fix: read defaultLevel from pluginConfigs in settings.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ All hooks honor `CLAUDE_CONFIG_DIR` for non-default Claude Code config locations
 ### `hooks/caveman-config.js` — shared module
 
 Exports:
-- `getDefaultMode()` — resolves default mode from `CAVEMAN_DEFAULT_MODE` env var, then `$XDG_CONFIG_HOME/caveman/config.json` / `~/.config/caveman/config.json` / `%APPDATA%\caveman\config.json`, then `'full'`
+- `getDefaultMode()` — resolves default mode from `CAVEMAN_DEFAULT_MODE` env var, then `pluginConfigs."caveman@caveman".options.defaultLevel` in `settings.json`, then `$XDG_CONFIG_HOME/caveman/config.json` / `~/.config/caveman/config.json` / `%APPDATA%\caveman\config.json`, then `'full'`
 - `safeWriteFlag(flagPath, content)` — symlink-safe flag write. Refuses if flag target or its immediate parent is a symlink. Opens with `O_NOFOLLOW` where supported. Atomic temp + rename. Creates with `0600`. Protects against local attackers replacing the predictable flag path with a symlink to clobber files writable by the user. Used by both write hooks. Silent-fails on all filesystem errors.
 
 ### `hooks/caveman-activate.js` — SessionStart hook

--- a/hooks/caveman-config.js
+++ b/hooks/caveman-config.js
@@ -3,11 +3,12 @@
 //
 // Resolution order for default mode:
 //   1. CAVEMAN_DEFAULT_MODE environment variable
-//   2. Config file defaultMode field:
+//   2. pluginConfigs."caveman@caveman".options.defaultLevel in settings.json
+//   3. Config file defaultMode field:
 //      - $XDG_CONFIG_HOME/caveman/config.json (any platform, if set)
 //      - ~/.config/caveman/config.json (macOS / Linux fallback)
 //      - %APPDATA%\caveman\config.json (Windows fallback)
-//   3. 'full'
+//   4. 'full'
 
 const fs = require('fs');
 const path = require('path');
@@ -43,7 +44,24 @@ function getDefaultMode() {
     return envMode.toLowerCase();
   }
 
-  // 2. Config file
+  // 2. Plugin config in Claude Code settings.json
+  try {
+    const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+    const settingsPath = path.join(claudeDir, 'settings.json');
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    const pluginLevel =
+      settings.pluginConfigs &&
+      settings.pluginConfigs['caveman@caveman'] &&
+      settings.pluginConfigs['caveman@caveman'].options &&
+      settings.pluginConfigs['caveman@caveman'].options.defaultLevel;
+    if (pluginLevel && VALID_MODES.includes(pluginLevel.toLowerCase())) {
+      return pluginLevel.toLowerCase();
+    }
+  } catch (e) {
+    // settings.json missing or invalid — fall through
+  }
+
+  // 3. Config file
   try {
     const configPath = getConfigPath();
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
@@ -54,7 +72,7 @@ function getDefaultMode() {
     // Config file doesn't exist or is invalid — fall through
   }
 
-  // 3. Default
+  // 4. Default
   return 'full';
 }
 


### PR DESCRIPTION
getDefaultMode() skipped pluginConfigs.'caveman@caveman'.options.defaultLevel entirely, falling back to hardcoded 'full'. Users had to /caveman ultra every session despite configuring defaultLevel in settings.json.

Resolution order is now:
1. CAVEMAN_DEFAULT_MODE env var
2. pluginConfigs.'caveman@caveman'.options.defaultLevel in settings.json
3. ~/.config/caveman/config.json defaultMode
4. Hardcoded 'full'

Fixes #189 