### PR TITLE
feat: add French language mode (fr-lite/fr-full/fr-ultra)

### DIFF
--- a/commands/caveman.toml
+++ b/commands/caveman.toml
@@ -1,2 +1,2 @@
-description = "Switch caveman intensity level (lite/full/ultra/wenyan)"
+description = "Switch caveman intensity level (lite/full/ultra/wenyan/fr)"
 prompt = "Switch to caveman {{args}} mode. If no level specified, use full. Respond terse like smart caveman — drop articles, filler, pleasantries. Fragments OK. Technical terms exact. Code unchanged. Pattern: [thing] [action] [reason]. [next step]."

--- a/hooks/caveman-config.js
+++ b/hooks/caveman-config.js
@@ -16,6 +16,7 @@ const os = require('os');
 const VALID_MODES = [
   'off', 'lite', 'full', 'ultra',
   'wenyan-lite', 'wenyan', 'wenyan-full', 'wenyan-ultra',
+  'fr-lite', 'fr', 'fr-full', 'fr-ultra',
   'commit', 'review', 'compress'
 ];
 

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -50,6 +50,9 @@ process.stdin.on('end', () => {
         else if (arg === 'wenyan-lite') mode = 'wenyan-lite';
         else if (arg === 'wenyan' || arg === 'wenyan-full') mode = 'wenyan';
         else if (arg === 'wenyan-ultra') mode = 'wenyan-ultra';
+        else if (arg === 'fr-lite') mode = 'fr-lite';
+        else if (arg === 'fr' || arg === 'fr-full') mode = 'fr';
+        else if (arg === 'fr-ultra') mode = 'fr-ultra';
         else mode = getDefaultMode();
       }
 

--- a/skills/caveman-help/SKILL.md
+++ b/skills/caveman-help/SKILL.md
@@ -20,6 +20,9 @@ Display this reference card when invoked. One-shot — do NOT change mode, write
 | **Wenyan-Lite** | `/caveman wenyan-lite` | Classical Chinese style, light compression. |
 | **Wenyan-Full** | `/caveman wenyan` | Full 文言文. Maximum classical terseness. |
 | **Wenyan-Ultra** | `/caveman wenyan-ultra` | Extreme. Ancient scholar on a budget. |
+| **Fr-Lite** | `/caveman fr-lite` | French. Professional but tight. |
+| **Fr-Full** | `/caveman fr` | French caveman. Fragments, no articles. |
+| **Fr-Ultra** | `/caveman fr-ultra` | Extreme French compression. Abbreviations + arrows. |
 
 Mode stick until changed or session end.
 

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -3,7 +3,7 @@ name: caveman
 description: >
   Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
   while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
-  wenyan-lite, wenyan-full, wenyan-ultra.
+  wenyan-lite, wenyan-full, wenyan-ultra, fr-lite, fr-full, fr-ultra.
   Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
   "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
 ---
@@ -35,6 +35,9 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 | **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
 | **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+| **fr-lite** | French. Drop filler/hedging but keep grammar, professional register |
+| **fr-full** | French caveman. Fragments, no articles, short synonyms. Telegraphic but French |
+| **fr-ultra** | Extreme French compression. Abbreviations (BDD/auth/config/req/res/fn/impl), arrows, bare fragments |
 
 Example — "Why React component re-render?"
 - lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
@@ -43,6 +46,9 @@ Example — "Why React component re-render?"
 - wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
 - wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
 - wenyan-ultra: "新參照→重繪。useMemo Wrap。"
+- fr-lite: "Le composant re-rend car nouvelle ref objet a chaque rendu. Envelopper avec `useMemo`."
+- fr-full: "Nouvelle ref objet chaque rendu. Prop inline = nouvelle ref = re-rendu. `useMemo`."
+- fr-ultra: "Prop inline → nouvelle ref → re-rendu. `useMemo`."
 
 Example — "Explain database connection pooling."
 - lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
@@ -50,6 +56,9 @@ Example — "Explain database connection pooling."
 - ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
 - wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
 - wenyan-ultra: "池reuse conn。skip handshake → fast。"
+- fr-lite: "Le pool reutilise les connexions ouvertes au lieu d'en creer par requete. Evite le cout du handshake."
+- fr-full: "Pool reutilise connexions BDD ouvertes. Pas nouvelle connexion par requete. Evite handshake."
+- fr-ultra: "Pool = reutilise conn BDD. Skip handshake → rapide sous charge."
 
 ## Auto-Clarity
 


### PR DESCRIPTION
## French language mode

Adds French as a new language variant, following the existing wenyan (Classical Chinese) pattern.

### Before

Caveman only supports English (`lite`/`full`/`ultra`) and Classical Chinese (`wenyan-lite`/`wenyan`/`wenyan-ultra`) modes.

### After

French speakers can use `/caveman fr` for telegraphic French with 3 intensity levels:

**Example — "Why React component re-render?"**
- **fr-lite:** "Le composant re-rend car nouvelle ref objet a chaque rendu. Envelopper avec `useMemo`."
- **fr-full:** "Nouvelle ref objet chaque rendu. Prop inline = nouvelle ref = re-rendu. `useMemo`."
- **fr-ultra:** "Prop inline → nouvelle ref → re-rendu. `useMemo`."

**Example — "Explain database connection pooling."**
- **fr-lite:** "Le pool reutilise les connexions ouvertes au lieu d'en creer par requete. Evite le cout du handshake."
- **fr-full:** "Pool reutilise connexions BDD ouvertes. Pas nouvelle connexion par requete. Evite handshake."
- **fr-ultra:** "Pool = reutilise conn BDD. Skip handshake → rapide sous charge."

### Why

French is the 5th most spoken language worldwide. This follows the exact same pattern as wenyan — 3 intensity levels defined in the SKILL.md intensity table, modes registered in `caveman-config.js`, and command routing in `caveman-mode-tracker.js`.

### Changes (5 files, 18 additions)

- `skills/caveman/SKILL.md` — intensity table rows + examples
- `hooks/caveman-config.js` — `VALID_MODES` list
- `hooks/caveman-mode-tracker.js` — `/caveman fr` command routing
- `skills/caveman-help/SKILL.md` — help card table
- `commands/caveman.toml` — description update

Synced copies (`caveman/SKILL.md`, `.cursor/`, `.windsurf/`, `plugins/`, `caveman.skill`) left untouched per CONTRIBUTING.md — CI handles sync after merge.