### PR TITLE
refactor(hooks): dedup INDEPENDENT_MODES into caveman-config

### DIFF
--- a/hooks/caveman-activate.js
+++ b/hooks/caveman-activate.js
@@ -9,7 +9,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { getDefaultMode, safeWriteFlag } = require('./caveman-config');
+const { getDefaultMode, safeWriteFlag, INDEPENDENT_MODES } = require('./caveman-config');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');
@@ -34,10 +34,6 @@ safeWriteFlag(flagPath, mode);
 //
 //    Reads SKILL.md at runtime so edits to the source of truth propagate
 //    automatically — no hardcoded duplication to go stale.
-
-// Modes that have their own independent skill files — not caveman intensity levels.
-// For these, emit a short activation line; the skill itself handles behavior.
-const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
 
 if (INDEPENDENT_MODES.has(mode)) {
   process.stdout.write('CAVEMAN MODE ACTIVE — level: ' + mode + '. Behavior defined by /caveman-' + mode + ' skill.');

--- a/hooks/caveman-config.js
+++ b/hooks/caveman-config.js
@@ -19,6 +19,11 @@ const VALID_MODES = [
   'commit', 'review', 'compress'
 ];
 
+// Modes that have their own independent skill files — not caveman intensity
+// levels. For these, hooks emit a short activation line and skip intensity
+// ruleset injection; the skill itself defines behavior.
+const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
+
 function getConfigDir() {
   if (process.env.XDG_CONFIG_HOME) {
     return path.join(process.env.XDG_CONFIG_HOME, 'caveman');
@@ -151,4 +156,4 @@ function readFlag(flagPath) {
   }
 }
 
-module.exports = { getDefaultMode, getConfigDir, getConfigPath, VALID_MODES, safeWriteFlag, readFlag };
+module.exports = { getDefaultMode, getConfigDir, getConfigPath, VALID_MODES, INDEPENDENT_MODES, safeWriteFlag, readFlag };

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -5,7 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { getDefaultMode, safeWriteFlag, readFlag } = require('./caveman-config');
+const { getDefaultMode, safeWriteFlag, readFlag, INDEPENDENT_MODES } = require('./caveman-config');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');
@@ -78,7 +78,6 @@ process.stdin.on('end', () => {
     // If the flag is missing, corrupted, oversized, or a symlink pointing at
     // something like ~/.ssh/id_rsa, readFlag returns null and we emit nothing
     // — never inject untrusted bytes into model context.
-    const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
     const activeMode = readFlag(flagPath);
     if (activeMode && !INDEPENDENT_MODES.has(activeMode)) {
       process.stdout.write(JSON.stringify({


### PR DESCRIPTION
## Problem

\`const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress'])\` is defined identically in two places:

- \`hooks/caveman-activate.js:40\`
- \`hooks/caveman-mode-tracker.js:81\`

Adding a new independent mode (or removing one) requires editing both files; one will inevitably drift.

## Fix

Export \`INDEPENDENT_MODES\` from \`hooks/caveman-config.js\` alongside the existing \`VALID_MODES\` export. Import where needed.

## Diff summary

\`\`\`
 hooks/caveman-activate.js     | 6 +-----
 hooks/caveman-config.js       | 7 ++++++-
 hooks/caveman-mode-tracker.js | 3 +--
 3 files changed, 8 insertions(+), 8 deletions(-)
\`\`\`

## Verify

\`\`\`
node --check hooks/caveman-config.js
node --check hooks/caveman-activate.js
node --check hooks/caveman-mode-tracker.js
node -e \"const {INDEPENDENT_MODES}=require('./hooks/caveman-config'); console.log([...INDEPENDENT_MODES]);\"
# → [ 'commit', 'review', 'compress' ]
\`\`\`

All pass. No behavior change.