### PR TITLE
fix(validate): URL_REGEX no longer captures trailing prose punctuation

### DIFF
--- a/caveman-compress/scripts/validate.py
+++ b/caveman-compress/scripts/validate.py
@@ -2,7 +2,17 @@
 import re
 from pathlib import Path
 
-URL_REGEX = re.compile(r"https?://[^\s)]+")
+# Match URL but do NOT consume trailing prose punctuation (. , ; : ! ? >).
+# Without this lookahead, "see https://example.com." captures the trailing
+# period; when the LLM correctly strips prose punctuation during compression,
+# the validator flags URL-missing (expected 'example.com.' not found, even
+# though 'example.com' is present).
+#
+# Non-greedy body + lookahead that permits zero-or-more prose-punct chars
+# followed by whitespace, closing paren, or end-of-string. Internal '.' in
+# domains and paths is preserved because the lookahead requires a terminator
+# after any stripped punctuation.
+URL_REGEX = re.compile(r"https?://[^\s)]+?(?=[\.,;:!?>]*(?:[\s)]|\Z))")
 FENCE_OPEN_REGEX = re.compile(r"^(\s{0,3})(`{3,}|~{3,})(.*)$")
 HEADING_REGEX = re.compile(r"^(#{1,6})\s+(.*)", re.MULTILINE)
 BULLET_REGEX = re.compile(r"^\s*[-*+]\s+", re.MULTILINE)


### PR DESCRIPTION
## Problem

\`validate.py:5\` pattern \`https?://[^\s)]+\` greedily consumes trailing prose punctuation:

\`\`\`python
>>> re.search(r'https?://[^\s)]+', 'See https://example.com. Next sentence.').group()
'https://example.com.'  # includes period
\`\`\`

When the LLM correctly strips trailing prose punctuation during compression, the validator flags \`URL missing\` because the extracted URL-with-period no longer matches:

\`\`\`
Compressing with Claude...
Validation failed:
   - URL missing: https://example.com.
\`\`\`

This triggers unnecessary retries (and sometimes unrecoverable failures when the LLM doesn't reinsert the period because it's not part of the URL).

## Fix

Non-greedy body + lookahead that permits zero-or-more prose-punctuation chars followed by whitespace, closing paren, or end-of-string:

\`\`\`python
URL_REGEX = re.compile(r\"https?://[^\s)]+?(?=[\.,;:!?>]*(?:[\s)]|\Z))\")
\`\`\`

Internal \`.\` in domains and paths preserved (lookahead requires a terminator after any stripped punctuation).

## Test cases

| Input | Before | After |
|-------|--------|-------|
| \`see https://example.com.\` | \`https://example.com.\` | \`https://example.com\` |
| \`visit https://a.co/path, then\` | \`https://a.co/path,\` | \`https://a.co/path\` |
| \`docs: https://foo.bar/x?q=1; more\` | \`https://foo.bar/x?q=1;\` | \`https://foo.bar/x?q=1\` |
| \`(see https://example.com)\` | \`https://example.com\` | \`https://example.com\` (unchanged) |
| \`https://github.com/org/repo/issues/42\` | full match | full match (unchanged) |
| \`http://localhost:8080/api?a=1&b=2 works\` | full match | full match (unchanged) |
| \`path file https://a.co/b.html\` | full match | full match (internal . kept) |
| \`https://api/v1\` (end of string) | full match | full match (unchanged) |

All URLs without trailing prose punctuation are unchanged. Only the prose-punctuation cases improve.

## Verify

\`\`\`
python -m py_compile caveman-compress/scripts/validate.py
\`\`\`

Passes.