### PR TITLE
fix(hooks): validate statusLine against schema, not truthy

### DIFF
--- a/hooks/caveman-activate.js
+++ b/hooks/caveman-activate.js
@@ -115,7 +115,12 @@ try {
   let hasStatusline = false;
   if (fs.existsSync(settingsPath)) {
     const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-    if (settings.statusLine) {
+    // Validate against the actual statusLine schema rather than a generic
+    // truthy check. A plain `if (settings.statusLine)` passes on strings,
+    // numbers, arrays, and partial/malformed objects — all of which suppress
+    // the nudge even though no working statusline is configured.
+    const sl = settings && settings.statusLine;
+    if (sl && sl.type === 'command' && typeof sl.command === 'string' && sl.command.length > 0) {
       hasStatusline = true;
     }
   }


### PR DESCRIPTION
## Problem

\`hooks/caveman-activate.js:118\`:

\`\`\`js
if (settings.statusLine) {
  hasStatusline = true;
}
\`\`\`

Plain truthy check. Passes on any non-falsy value — strings (\`\"todo\"\`, \`\"true\"\`), numbers, arrays, partial objects (e.g. \`{\"type\": \"command\"}\` with no \`command\`), malformed shapes.

Consequence: user edits \`settings.json\`, types something wrong, the statusline doesn't actually work, but the nudge is suppressed — so the user gets no feedback about why their badge is broken.

## Fix

Validate against the real schema:

\`\`\`js
const sl = settings && settings.statusLine;
if (sl && sl.type === 'command' && typeof sl.command === 'string' && sl.command.length > 0) {
  hasStatusline = true;
}
\`\`\`

- \`sl.type === 'command'\` — Claude Code statusline type
- \`typeof sl.command === 'string' && sl.command.length > 0\` — must have a non-empty command to actually run

## Backward compat

Correctly-configured \`statusLine\` still passes (unchanged behavior). Malformed/partial \`statusLine\` now correctly triggers the setup nudge.

## Verify

\`\`\`
node --check hooks/caveman-activate.js
\`\`\`

Passes.