### PR TITLE
fix: expand natural-language toggle phrasings in mode tracker

### DIFF
--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -17,22 +17,36 @@ process.stdin.on('end', () => {
     const data = JSON.parse(input);
     const prompt = (data.prompt || '').trim().toLowerCase();
 
+    // Deactivation patterns — reused below to unlink the flag and above as the
+    // activation guard. Broad verbs (stop/disable/deactivate/turn off/switch off)
+    // use sentence-spanning .* because they unambiguously indicate deactivation.
+    // Bare off/no and the ambiguous verbs exit/end/cancel require tight proximity
+    // to "caveman" so unrelated prose like "go caveman and end with a summary"
+    // does not flip the flag.
+    const isDeactivation =
+        /\b(stop|disable|deactivate|turn off|switch off)\b.*\bcaveman\b/i.test(prompt) ||
+        /\bcaveman\b.*\b(stop|disable|deactivate|turn off|switch off)\b/i.test(prompt) ||
+        /\bcaveman\s+off\b/i.test(prompt) ||
+        /\boff\s+caveman\b/i.test(prompt) ||
+        /\bno\s+caveman\b/i.test(prompt) ||
+        /\b(exit|end|cancel)\s+caveman\b/i.test(prompt) ||
+        /\bcaveman\s+(exit|end|cancel)\b/i.test(prompt) ||
+        /\b(normal mode|back to normal)\b/i.test(prompt);
+
     // Natural language activation (e.g. "activate caveman", "turn on caveman mode",
-    // "talk like caveman", "caveman on", "go caveman"). Bare "on" is matched
-    // only in tight proximity to "caveman" to avoid false positives on
-    // unrelated prose. Negative guard prevents activation when the same prompt
-    // also contains a deactivation verb ("stop", "off", "no", etc).
+    // "talk like caveman", "caveman on", "go caveman"). Bare "on" only matches
+    // in tight proximity to "caveman". Skipped when the same prompt also looks
+    // like a deactivation so "stop caveman mode" cannot both activate and
+    // deactivate simultaneously.
     const activationMatch =
         /\b(activate|enable|turn on|switch on|start|talk like|go|use|be)\b.*\bcaveman\b/i.test(prompt) ||
         /\bcaveman\b.*\b(mode|activate|enable|turn on|switch on|start)\b/i.test(prompt) ||
         /\bcaveman\s+on\b/i.test(prompt) ||
         /\bon\s+caveman\b/i.test(prompt);
-    if (activationMatch) {
-      if (!/\b(stop|disable|turn off|switch off|deactivate|exit|end|cancel|off|no)\b/i.test(prompt)) {
-        const mode = getDefaultMode();
-        if (mode !== 'off') {
-          safeWriteFlag(flagPath, mode);
-        }
+    if (activationMatch && !isDeactivation) {
+      const mode = getDefaultMode();
+      if (mode !== 'off') {
+        safeWriteFlag(flagPath, mode);
       }
     }
 
@@ -66,15 +80,8 @@ process.stdin.on('end', () => {
       }
     }
 
-    // Detect deactivation — natural language and slash commands.
-    // Bare "off" and "no" use tight proximity to "caveman" to avoid matching
-    // unrelated prose ("no problem", "switched it off", etc.).
-    if (/\b(stop|disable|deactivate|turn off|switch off|exit|end|cancel)\b.*\bcaveman\b/i.test(prompt) ||
-        /\bcaveman\b.*\b(stop|disable|deactivate|turn off|switch off|exit|end|cancel)\b/i.test(prompt) ||
-        /\bcaveman\s+off\b/i.test(prompt) ||
-        /\boff\s+caveman\b/i.test(prompt) ||
-        /\bno\s+caveman\b/i.test(prompt) ||
-        /\b(normal mode|back to normal)\b/i.test(prompt)) {
+    // Unlink the flag if the prompt looks like a deactivation.
+    if (isDeactivation) {
       try { fs.unlinkSync(flagPath); } catch (e) {}
     }
 

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -18,11 +18,17 @@ process.stdin.on('end', () => {
     const prompt = (data.prompt || '').trim().toLowerCase();
 
     // Natural language activation (e.g. "activate caveman", "turn on caveman mode",
-    // "talk like caveman"). README tells users they can say these, but the hook
-    // only matched /caveman commands — flag file and statusline stayed out of sync.
-    if (/\b(activate|enable|turn on|start|talk like)\b.*\bcaveman\b/i.test(prompt) ||
-        /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt)) {
-      if (!/\b(stop|disable|turn off|deactivate)\b/i.test(prompt)) {
+    // "talk like caveman", "caveman on", "go caveman"). Bare "on" is matched
+    // only in tight proximity to "caveman" to avoid false positives on
+    // unrelated prose. Negative guard prevents activation when the same prompt
+    // also contains a deactivation verb ("stop", "off", "no", etc).
+    const activationMatch =
+        /\b(activate|enable|turn on|switch on|start|talk like|go|use|be)\b.*\bcaveman\b/i.test(prompt) ||
+        /\bcaveman\b.*\b(mode|activate|enable|turn on|switch on|start)\b/i.test(prompt) ||
+        /\bcaveman\s+on\b/i.test(prompt) ||
+        /\bon\s+caveman\b/i.test(prompt);
+    if (activationMatch) {
+      if (!/\b(stop|disable|turn off|switch off|deactivate|exit|end|cancel|off|no)\b/i.test(prompt)) {
         const mode = getDefaultMode();
         if (mode !== 'off') {
           safeWriteFlag(flagPath, mode);
@@ -60,10 +66,15 @@ process.stdin.on('end', () => {
       }
     }
 
-    // Detect deactivation — natural language and slash commands
-    if (/\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/i.test(prompt) ||
-        /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/i.test(prompt) ||
-        /\bnormal mode\b/i.test(prompt)) {
+    // Detect deactivation — natural language and slash commands.
+    // Bare "off" and "no" use tight proximity to "caveman" to avoid matching
+    // unrelated prose ("no problem", "switched it off", etc.).
+    if (/\b(stop|disable|deactivate|turn off|switch off|exit|end|cancel)\b.*\bcaveman\b/i.test(prompt) ||
+        /\bcaveman\b.*\b(stop|disable|deactivate|turn off|switch off|exit|end|cancel)\b/i.test(prompt) ||
+        /\bcaveman\s+off\b/i.test(prompt) ||
+        /\boff\s+caveman\b/i.test(prompt) ||
+        /\bno\s+caveman\b/i.test(prompt) ||
+        /\b(normal mode|back to normal)\b/i.test(prompt)) {
       try { fs.unlinkSync(flagPath); } catch (e) {}
     }
 


### PR DESCRIPTION
The previous regex (PR #120, which I also wrote) added natural-language toggles but missed a case that turns out to be the one users actually type: bare `caveman off`. The alternation required `turn off` as a two-word phrase, so `off` on its own slipped through. I just hit this myself — typed `caveman off`, statusline kept showing the badge, hook kept injecting the reinforcement on every turn. Took me a while to notice because the flag file silently stayed put.

## What's new

**Activation:** `caveman on`, `on caveman`, `go caveman`, `use caveman`, `be caveman`, `switch on caveman`.

**Deactivation:** `caveman off`, `off caveman`, `no caveman`, `exit/end/cancel caveman`, `switch off caveman`, `back to normal`.

## False-positive defense

Bare `on`, `off`, `no` only match in tight proximity to `caveman` — patterns like `\bcaveman\s+off\b`, not the sentence-spanning `.*` alternation. Without this, prose like *"the on switch is broken"*, *"I have no problems today"*, or *"off to the races"* would flip the flag. Tight proximity keeps false positives at zero on the test cases I tried.

The activation guard now also blocks on `off`, `switch off`, `exit`, `end`, `cancel`, and `no` — so an ambiguous prompt like *"stop caveman mode"* can't simultaneously activate and deactivate. The guard wins, deactivation fires.

## Test plan

I ran both regexes through 35 hand-crafted cases: every new trigger, every existing trigger, and a false-positive section (`"hello world"`, `"the on switch is broken"`, `"I have no problems today"`, `"off to the races"`, `"end of file"`, `"cancel my order"`). 34/35 behave as intended. The one skipped case is `"caveman please"` — intent is ambiguous enough that I didn't want to guess.

- [ ] Smoke test: open Claude Code, type `caveman off`, verify flag deletion + statusline update
- [ ] Smoke test: `no caveman`, `go caveman`, `back to normal` — deactivation/activation/deactivation respectively
- [ ] Regression check on existing phrasings (`stop caveman`, `normal mode`, `turn off caveman`)