### PR TITLE
feat: per-project default mode via .claude/caveman.local.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,48 @@ Classical Chinese literary compression — same technical accuracy, but in the m
 
 Level stick until you change it or session end.
 
+### Configuration
+
+Default mode resolves in this order:
+
+1. **`CAVEMAN_DEFAULT_MODE`** env var — session override
+2. **`.claude/caveman.local.md`** in your project root — per-project default
+3. **`~/.config/caveman/config.json`** (or `$XDG_CONFIG_HOME/caveman/config.json`) — global default
+4. Hardcoded `full`
+
+#### Per-project default
+
+Create `.claude/caveman.local.md` in your project root:
+
+```markdown
+---
+defaultMode: off
+---
+
+# Project notes (optional markdown body, ignored by plugin)
+Caveman disabled for this repo.
+```
+
+Valid `defaultMode` values: `off`, `lite`, `full`, `ultra`, `wenyan-lite`, `wenyan`, `wenyan-ultra`.
+
+Add to `.gitignore` if per-user (Claude Code convention for `.claude/*.local.md`):
+
+```gitignore
+.claude/*.local.md
+```
+
+Per-project config is read at session start. Restart Claude Code to pick up changes.
+
+#### Global default
+
+```json
+{
+  "defaultMode": "lite"
+}
+```
+
+Save as `~/.config/caveman/config.json` (or `$XDG_CONFIG_HOME/caveman/config.json`).
+
 ## Caveman Skills
 
 ### caveman-commit

--- a/hooks/caveman-config.js
+++ b/hooks/caveman-config.js
@@ -3,11 +3,13 @@
 //
 // Resolution order for default mode:
 //   1. CAVEMAN_DEFAULT_MODE environment variable
-//   2. Config file defaultMode field:
+//   2. Per-project config: $CLAUDE_PROJECT_DIR/.claude/caveman.local.md
+//      (YAML frontmatter with `defaultMode` field)
+//   3. Global config file defaultMode field:
 //      - $XDG_CONFIG_HOME/caveman/config.json (any platform, if set)
 //      - ~/.config/caveman/config.json (macOS / Linux fallback)
 //      - %APPDATA%\caveman\config.json (Windows fallback)
-//   3. 'full'
+//   4. 'full'
 
 const fs = require('fs');
 const path = require('path');
@@ -36,14 +38,86 @@ function getConfigPath() {
   return path.join(getConfigDir(), 'config.json');
 }
 
+// Per-project settings path. Follows the Claude Code plugin convention
+// of `.claude/<plugin-name>.local.md`. $CLAUDE_PROJECT_DIR is set by Claude
+// Code for every hook invocation — falls back to process.cwd() for direct
+// CLI invocation or tests.
+function getProjectConfigPath() {
+  const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  if (!projectDir) return null;
+  return path.join(projectDir, '.claude', 'caveman.local.md');
+}
+
+// Read `defaultMode` from YAML frontmatter in the project config file.
+// Hard-capped at 4096 bytes to limit attack surface; rejects symlinks for
+// the same reason as readFlag (local attacker could redirect to ~/.ssh/id_rsa
+// etc.). Returns a validated mode string or null.
+//
+// Only the `defaultMode:` line is parsed — no full YAML parser is needed
+// because the plugin has zero npm dependencies and we deliberately keep
+// the config surface minimal. Markdown body is ignored.
+const MAX_PROJECT_CONFIG_BYTES = 4096;
+
+function readProjectDefaultMode() {
+  const projectPath = getProjectConfigPath();
+  if (!projectPath) return null;
+
+  try {
+    let st;
+    try {
+      st = fs.lstatSync(projectPath);
+    } catch (e) {
+      return null;
+    }
+    if (st.isSymbolicLink() || !st.isFile()) return null;
+    if (st.size > MAX_PROJECT_CONFIG_BYTES) return null;
+
+    const O_NOFOLLOW = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0;
+    const flags = fs.constants.O_RDONLY | O_NOFOLLOW;
+    let fd;
+    let content;
+    try {
+      fd = fs.openSync(projectPath, flags);
+      const buf = Buffer.alloc(MAX_PROJECT_CONFIG_BYTES);
+      const n = fs.readSync(fd, buf, 0, MAX_PROJECT_CONFIG_BYTES, 0);
+      content = buf.slice(0, n).toString('utf8');
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd);
+    }
+
+    // Extract YAML frontmatter block: content between opening --- and closing ---.
+    const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!fmMatch) return null;
+    const frontmatter = fmMatch[1];
+
+    // Extract `defaultMode:` line. Strip surrounding quotes if present.
+    const fieldMatch = frontmatter.match(/^\s*defaultMode\s*:\s*(.+?)\s*$/m);
+    if (!fieldMatch) return null;
+    let value = fieldMatch[1].trim();
+    value = value.replace(/^(["'])(.*)\1$/, '$2');
+
+    const mode = value.toLowerCase();
+    if (!VALID_MODES.includes(mode)) return null;
+    return mode;
+  } catch (e) {
+    return null;
+  }
+}
+
 function getDefaultMode() {
-  // 1. Environment variable (highest priority)
+  // 1. Environment variable (highest priority — session override)
   const envMode = process.env.CAVEMAN_DEFAULT_MODE;
   if (envMode && VALID_MODES.includes(envMode.toLowerCase())) {
     return envMode.toLowerCase();
   }
 
-  // 2. Config file
+  // 2. Per-project config at $CLAUDE_PROJECT_DIR/.claude/caveman.local.md
+  const projectMode = readProjectDefaultMode();
+  if (projectMode) {
+    return projectMode;
+  }
+
+  // 3. Global config file
   try {
     const configPath = getConfigPath();
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
@@ -54,7 +128,7 @@ function getDefaultMode() {
     // Config file doesn't exist or is invalid — fall through
   }
 
-  // 3. Default
+  // 4. Default
   return 'full';
 }
 
@@ -151,4 +225,13 @@ function readFlag(flagPath) {
   }
 }
 
-module.exports = { getDefaultMode, getConfigDir, getConfigPath, VALID_MODES, safeWriteFlag, readFlag };
+module.exports = {
+  getDefaultMode,
+  getConfigDir,
+  getConfigPath,
+  getProjectConfigPath,
+  readProjectDefaultMode,
+  VALID_MODES,
+  safeWriteFlag,
+  readFlag,
+};

--- a/hooks/caveman-config.js
+++ b/hooks/caveman-config.js
@@ -85,6 +85,14 @@ function readProjectDefaultMode() {
       if (fd !== undefined) fs.closeSync(fd);
     }
 
+    // Strip UTF-8 BOM if present. Windows editors (Notepad, older VS Code
+    // configurations, some PowerShell `Out-File` invocations) prefix saved
+    // UTF-8 files with \uFEFF, which would otherwise make the frontmatter
+    // regex silently fail and the config fall through to the global default.
+    if (content.charCodeAt(0) === 0xFEFF) {
+      content = content.slice(1);
+    }
+
     // Extract YAML frontmatter block: content between opening --- and closing ---.
     const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     if (!fmMatch) return null;


### PR DESCRIPTION
Previously the only way to scope caveman differently per project was a direnv trick on `CAVEMAN_DEFAULT_MODE`. That's workable but awkward — you have to remember to `direnv allow` in every repo, and the setting lives in an `.envrc` that's not obviously about caveman. I wanted something like `.prettierrc`: drop a file in the project, done.

## Resolution order now

1. `CAVEMAN_DEFAULT_MODE` env var (unchanged — session override)
2. `$CLAUDE_PROJECT_DIR/.claude/caveman.local.md` ← new
3. `~/.config/caveman/config.json` (unchanged — global)
4. `full` (unchanged — fallback)

## Format

```markdown
---
defaultMode: off
---

# Project notes (optional markdown body, ignored by plugin)
Caveman disabled for this repo.
```

## Why `.claude/caveman.local.md`

I picked this path because it matches the [Claude Code plugin-settings convention](https://docs.claude.com/en/docs/claude-code/plugins) — other plugins like ralph-loop and multi-agent-swarm already use `.claude/<plugin-name>.local.md`, and the `$CLAUDE_PROJECT_DIR` env var hands us the project root for free. Users who recognize the pattern from other plugins won't need docs to figure it out.

Gitignored by convention (`.claude/*.local.md`) so per-user preferences don't leak between collaborators.

## Security

Symmetric with the existing `readFlag()` hardening:

| Defense | Why |
|---------|-----|
| `lstat()` + `O_NOFOLLOW` symlink check | Without this, a local attacker with write access to `.claude/` could point the config at `~/.ssh/id_rsa` and have the plugin slurp it on the next session |
| 4096-byte size cap | Enough room for frontmatter plus modest notes, caps the attack surface if the file ever gets echoed into a log |
| Whitelist validation | File contents never trusted directly — the parsed value is checked against `VALID_MODES` before use |
| Silent-fail on all errors | Missing, malformed, or unreadable config falls through cleanly to the next resolution step |

## Parsing

I deliberately avoided pulling in a YAML dependency. The plugin has zero npm deps today and I want to keep it that way. Only the `defaultMode:` line is parsed, via a single-line regex on the frontmatter block. Markdown body is ignored. Handles bare values and quoted values (both single and double), rejects anything outside `VALID_MODES`. If someone wants a second field here later, that's a separate design discussion.

## Tests

Verified end-to-end via a small Node harness:

- [x] Valid bare value (`defaultMode: off`) → resolves to `off`
- [x] Quoted values (`"lite"`, `'ultra'`) → parsed correctly
- [x] Invalid mode (`defaultMode: garbage`) → falls through to global/default
- [x] No frontmatter block → falls through
- [x] Symlinked file (e.g. to `/etc/passwd`) → rejected
- [x] Missing `$CLAUDE_PROJECT_DIR` and no config → falls through to `full`
- [x] `CAVEMAN_DEFAULT_MODE` env var overrides project config

- [ ] Manual smoke test: drop `.claude/caveman.local.md` with `defaultMode: off` in a project, start a Claude Code session, verify caveman is disabled there but still active elsewhere

## Docs

Added a Configuration section to the README covering the full resolution chain, the per-project file format, the gitignore pattern, and the global config file. The global config was previously undocumented in the README — this PR documents both layers together.