### PR TITLE
[codex] fix verifier for current hook output

### DIFF
--- a/tests/verify_repo.py
+++ b/tests/verify_repo.py
@@ -225,7 +225,7 @@ def verify_hook_install_flow() -> None:
             ["node", "hooks/caveman-activate.js"],
             env={"HOME": str(home)},
         )
-        ensure("CAVEMAN MODE ACTIVE." in activate.stdout, "activation output missing caveman banner")
+        ensure("CAVEMAN MODE ACTIVE" in activate.stdout, "activation output missing caveman banner")
         ensure("STATUSLINE SETUP NEEDED" not in activate.stdout, "activation should stay quiet when custom statusline exists")
         ensure((claude_dir / ".caveman-active").read_text() == "full", "activation flag should default to full")
 
@@ -234,7 +234,7 @@ def verify_hook_install_flow() -> None:
             ["node", "hooks/caveman-activate.js"],
             env={"HOME": str(home), "CAVEMAN_DEFAULT_MODE": "ultra"},
         )
-        ensure("CAVEMAN MODE ACTIVE." in activate_custom.stdout, "activation with custom default missing banner")
+        ensure("CAVEMAN MODE ACTIVE" in activate_custom.stdout, "activation with custom default missing banner")
         ensure((claude_dir / ".caveman-active").read_text() == "ultra", "CAVEMAN_DEFAULT_MODE=ultra should set flag to ultra")
         # Test "off" mode — activation skipped, flag removed
         activate_off = run(
@@ -274,7 +274,15 @@ def verify_hook_install_flow() -> None:
             capture_output=True,
             check=True,
         )
-        ensure(ultra_prompt.stdout == "", "mode tracker should stay silent")
+        ultra_context = json.loads(ultra_prompt.stdout)
+        ensure(
+            ultra_context.get("hookSpecificOutput", {}).get("hookEventName") == "UserPromptSubmit",
+            "mode tracker should emit UserPromptSubmit context",
+        )
+        ensure(
+            "CAVEMAN MODE ACTIVE (ultra)" in ultra_context.get("hookSpecificOutput", {}).get("additionalContext", ""),
+            "mode tracker reinforcement context missing ultra mode",
+        )
         ensure((claude_dir / ".caveman-active").read_text() == "ultra", "mode tracker did not record ultra")
 
         subprocess.run(


### PR DESCRIPTION
## Summary
- update verifier banner assertions for the current activation hook output
- validate mode tracker reinforcement JSON instead of expecting silence
- keep the fix scoped to tests/verify_repo.py

## Root Cause
The verifier still expected older hook behavior: an activation banner with a period and a silent mode tracker. The current hook emits a level-aware activation banner and structured UserPromptSubmit reinforcement context.

## Verification
- python3 tests/verify_repo.py
- python3 -m unittest tests/test_hooks.py