### PR TITLE
fix: allow safeWriteFlag through symlinked parent directories

### DIFF
--- a/hooks/caveman-config.js
+++ b/hooks/caveman-config.js
@@ -59,37 +59,80 @@ function getDefaultMode() {
 }
 
 // Symlink-safe flag file write.
-// Refuses symlinks at the target file and at the immediate parent directory,
-// uses O_NOFOLLOW where available, writes atomically via temp + rename with
+// Uses O_NOFOLLOW where available, writes atomically via temp + rename with
 // 0600 permissions. Protects against local attackers replacing the predictable
 // flag path (~/.claude/.caveman-active) with a symlink to clobber other files.
 //
-// Does NOT walk the full ancestor chain — macOS has /tmp -> /private/tmp and
-// many legitimate setups route through symlinked home dirs, so a full walk
-// produces false positives. The attack surface requires write access to the
-// immediate parent, which is what we check.
+// When the parent directory is a symlink (legitimate pattern: ~/.claude symlinked
+// to another drive or shared config dir), resolves through to the real path and
+// verifies ownership on Unix (uid match). This allows e.g.
+//   ln -s /opt/shared-claude-config ~/.claude
+// while still refusing attacker-planted symlinks pointing to dirs owned by
+// another user.
+//
+// On Windows, uid checks are unavailable — falls back to verifying the resolved
+// path lives under the user's home directory.
+//
+// The flag file itself must never be a symlink (that's the actual clobber vector).
+//
+// Set CAVEMAN_DEBUG=1 to emit stderr diagnostics when flag writes are refused.
 //
 // Silent-fails on any filesystem error — the flag is best-effort.
 function safeWriteFlag(flagPath, content) {
+  const debug = process.env.CAVEMAN_DEBUG === '1';
   try {
     const flagDir = path.dirname(flagPath);
     fs.mkdirSync(flagDir, { recursive: true });
 
-    // Refuse if the parent directory itself is a symlink (attacker redirect).
+    // When the parent directory is a symlink, resolve it and verify ownership.
+    // This allows legitimate symlinked ~/.claude dirs while still refusing
+    // attacker-planted symlinks pointing at dirs owned by another user.
+    let realFlagDir;
     try {
-      if (fs.lstatSync(flagDir).isSymbolicLink()) return;
+      const lstat = fs.lstatSync(flagDir);
+      if (lstat.isSymbolicLink()) {
+        realFlagDir = fs.realpathSync(flagDir);
+        // Verify the resolved target is a directory
+        const realStat = fs.statSync(realFlagDir);
+        if (!realStat.isDirectory()) {
+          if (debug) process.stderr.write(`[caveman] safeWriteFlag: symlink target ${realFlagDir} is not a directory\n`);
+          return;
+        }
+        // On Unix: verify ownership (resolved dir must be owned by current user)
+        if (typeof process.getuid === 'function') {
+          if (realStat.uid !== process.getuid()) {
+            if (debug) process.stderr.write(`[caveman] safeWriteFlag: symlink target ${realFlagDir} owned by uid ${realStat.uid}, not current user ${process.getuid()}\n`);
+            return;
+          }
+        } else {
+          // On Windows: verify resolved path is under user's home directory
+          const home = os.homedir();
+          const normalizedReal = path.resolve(realFlagDir);
+          const normalizedHome = path.resolve(home);
+          if (!normalizedReal.toLowerCase().startsWith(normalizedHome.toLowerCase() + path.sep) &&
+              normalizedReal.toLowerCase() !== normalizedHome.toLowerCase()) {
+            if (debug) process.stderr.write(`[caveman] safeWriteFlag: symlink target ${normalizedReal} is outside home directory ${normalizedHome}\n`);
+            return;
+          }
+        }
+      } else {
+        realFlagDir = flagDir;
+      }
     } catch (e) {
       return;
     }
 
     // Refuse if the target already exists as a symlink.
+    // Use the real directory path for the actual flag file check.
+    const realFlagPath = path.join(realFlagDir, path.basename(flagPath));
     try {
-      if (fs.lstatSync(flagPath).isSymbolicLink()) return;
+      if (fs.lstatSync(realFlagPath).isSymbolicLink()) return;
     } catch (e) {
       if (e.code !== 'ENOENT') return;
     }
 
-    const tempPath = path.join(flagDir, `.caveman-active.${process.pid}.${Date.now()}`);
+    // Write atomically via temp + rename in the resolved directory.
+    const tempPath = path.join(realFlagDir, `.caveman-active.${process.pid}.${Date.now()}`);
     const O_NOFOLLOW = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0;
     const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | O_NOFOLLOW;
     let fd;
@@ -100,7 +143,7 @@ function safeWriteFlag(flagPath, content) {
     } finally {
       if (fd !== undefined) fs.closeSync(fd);
     }
-    fs.renameSync(tempPath, flagPath);
+    fs.renameSync(tempPath, realFlagPath);
   } catch (e) {
     // Silent fail — flag is best-effort
   }

--- a/tests/test_symlink_flag.js
+++ b/tests/test_symlink_flag.js
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+// Tests for safeWriteFlag / readFlag behavior with symlinked parent directories.
+// Covers fix for issue #207: safeWriteFlag refuses flag writes when ~/.claude
+// is a symlink.
+//
+// Run: node tests/test_symlink_flag.js
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+
+const { safeWriteFlag, readFlag, VALID_MODES } = require('../hooks/caveman-config');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-symlink-test-'));
+  try {
+    fn(tmpBase);
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${e.message}`);
+  } finally {
+    fs.rmSync(tmpBase, { recursive: true, force: true });
+  }
+}
+
+console.log('safeWriteFlag + readFlag symlink tests\n');
+
+// ---------- safeWriteFlag ----------
+
+test('writes flag in normal (non-symlinked) directory', (tmp) => {
+  const flagDir = path.join(tmp, 'claude-config');
+  fs.mkdirSync(flagDir, { recursive: true });
+  const flagPath = path.join(flagDir, '.caveman-active');
+
+  safeWriteFlag(flagPath, 'full');
+
+  assert.strictEqual(fs.readFileSync(flagPath, 'utf8'), 'full');
+});
+
+test('writes flag when parent directory is a symlink owned by current user', (tmp) => {
+  // Create real directory and symlink to it (simulating ~/.claude -> /real/path)
+  const realDir = path.join(tmp, 'real-claude-config');
+  fs.mkdirSync(realDir, { recursive: true });
+  const symlinkDir = path.join(tmp, 'claude-symlink');
+  fs.symlinkSync(realDir, symlinkDir);
+
+  const flagPath = path.join(symlinkDir, '.caveman-active');
+  safeWriteFlag(flagPath, 'ultra');
+
+  // Flag should exist in the real directory
+  const realFlagPath = path.join(realDir, '.caveman-active');
+  assert.strictEqual(fs.existsSync(realFlagPath), true, 'flag file should exist in resolved dir');
+  assert.strictEqual(fs.readFileSync(realFlagPath, 'utf8'), 'ultra');
+});
+
+test('readFlag works through symlinked parent directory', (tmp) => {
+  const realDir = path.join(tmp, 'real-claude-config');
+  fs.mkdirSync(realDir, { recursive: true });
+  const symlinkDir = path.join(tmp, 'claude-symlink');
+  fs.symlinkSync(realDir, symlinkDir);
+
+  // Write directly to real path, then read through symlink path
+  const realFlagPath = path.join(realDir, '.caveman-active');
+  fs.writeFileSync(realFlagPath, 'lite', { mode: 0o600 });
+
+  const result = readFlag(path.join(symlinkDir, '.caveman-active'));
+  assert.strictEqual(result, 'lite');
+});
+
+test('safeWriteFlag then readFlag round-trip through symlink', (tmp) => {
+  const realDir = path.join(tmp, 'real-config');
+  fs.mkdirSync(realDir, { recursive: true });
+  const symlinkDir = path.join(tmp, 'link-config');
+  fs.symlinkSync(realDir, symlinkDir);
+
+  const flagPath = path.join(symlinkDir, '.caveman-active');
+  safeWriteFlag(flagPath, 'wenyan-ultra');
+
+  // Read back through the same symlink path
+  const result = readFlag(flagPath);
+  assert.strictEqual(result, 'wenyan-ultra');
+});
+
+test('refuses flag file that is itself a symlink (even through symlinked parent)', (tmp) => {
+  const realDir = path.join(tmp, 'real-config');
+  fs.mkdirSync(realDir, { recursive: true });
+  const symlinkDir = path.join(tmp, 'link-config');
+  fs.symlinkSync(realDir, symlinkDir);
+
+  // Create a symlink at the flag file location pointing to some other file
+  const decoyFile = path.join(tmp, 'decoy.txt');
+  fs.writeFileSync(decoyFile, 'ATTACK');
+  const realFlagPath = path.join(realDir, '.caveman-active');
+  fs.symlinkSync(decoyFile, realFlagPath);
+
+  // safeWriteFlag should refuse (flag file is a symlink)
+  safeWriteFlag(path.join(symlinkDir, '.caveman-active'), 'full');
+  // The decoy should NOT have been overwritten
+  assert.strictEqual(fs.readFileSync(decoyFile, 'utf8'), 'ATTACK');
+});
+
+test('readFlag refuses flag file that is a symlink', (tmp) => {
+  const realDir = path.join(tmp, 'real-config');
+  fs.mkdirSync(realDir, { recursive: true });
+
+  const secretFile = path.join(tmp, 'secret.txt');
+  fs.writeFileSync(secretFile, 'SSH_PRIVATE_KEY_CONTENT');
+  fs.symlinkSync(secretFile, path.join(realDir, '.caveman-active'));
+
+  const result = readFlag(path.join(realDir, '.caveman-active'));
+  assert.strictEqual(result, null, 'should refuse symlinked flag file');
+});
+
+test('flag file permissions are 0600 when written through symlink', (tmp) => {
+  if (process.platform === 'win32') return; // skip on Windows
+
+  const realDir = path.join(tmp, 'real-config');
+  fs.mkdirSync(realDir, { recursive: true });
+  const symlinkDir = path.join(tmp, 'link-config');
+  fs.symlinkSync(realDir, symlinkDir);
+
+  safeWriteFlag(path.join(symlinkDir, '.caveman-active'), 'full');
+
+  const realFlagPath = path.join(realDir, '.caveman-active');
+  const stat = fs.statSync(realFlagPath);
+  const mode = stat.mode & 0o777;
+  assert.strictEqual(mode, 0o600, `expected 0600, got 0${mode.toString(8)}`);
+});
+
+test('overwrites existing flag through symlinked parent', (tmp) => {
+  const realDir = path.join(tmp, 'real-config');
+  fs.mkdirSync(realDir, { recursive: true });
+  const symlinkDir = path.join(tmp, 'link-config');
+  fs.symlinkSync(realDir, symlinkDir);
+
+  const flagPath = path.join(symlinkDir, '.caveman-active');
+
+  safeWriteFlag(flagPath, 'lite');
+  assert.strictEqual(readFlag(flagPath), 'lite');
+
+  safeWriteFlag(flagPath, 'ultra');
+  assert.strictEqual(readFlag(flagPath), 'ultra');
+});
+
+test('creates parent directory via mkdirSync even when it does not exist yet', (tmp) => {
+  const flagDir = path.join(tmp, 'nonexistent', 'nested');
+  const flagPath = path.join(flagDir, '.caveman-active');
+
+  safeWriteFlag(flagPath, 'full');
+
+  assert.strictEqual(fs.existsSync(flagPath), true);
+  assert.strictEqual(fs.readFileSync(flagPath, 'utf8'), 'full');
+});
+
+test('symlink to nonexistent target silently fails', (tmp) => {
+  const symlinkDir = path.join(tmp, 'broken-link');
+  try {
+    fs.symlinkSync('/nonexistent/path/that/does/not/exist', symlinkDir);
+  } catch (e) {
+    // Can't create symlink — skip
+    return;
+  }
+
+  const flagPath = path.join(symlinkDir, '.caveman-active');
+  // Should not throw
+  safeWriteFlag(flagPath, 'full');
+  // Flag should not exist (target doesn't exist)
+  assert.strictEqual(fs.existsSync(path.join(symlinkDir, '.caveman-active')), false);
+});
+
+test('all valid modes round-trip through symlinked parent', (tmp) => {
+  const realDir = path.join(tmp, 'real-config');
+  fs.mkdirSync(realDir, { recursive: true });
+  const symlinkDir = path.join(tmp, 'link-config');
+  fs.symlinkSync(realDir, symlinkDir);
+
+  const flagPath = path.join(symlinkDir, '.caveman-active');
+
+  for (const mode of VALID_MODES) {
+    safeWriteFlag(flagPath, mode);
+    const read = readFlag(flagPath);
+    assert.strictEqual(read, mode, `mode '${mode}' did not round-trip`);
+  }
+});
+
+// ---------- Source code audit ----------
+
+test('safeWriteFlag no longer has blanket symlink parent refusal', (tmp) => {
+  // Verify the old pattern "if (fs.lstatSync(flagDir).isSymbolicLink()) return;"
+  // without ownership check is no longer present
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', 'hooks', 'caveman-config.js'), 'utf8'
+  );
+
+  // The old pattern: check isSymbolicLink on flagDir and immediately return
+  // New pattern: check isSymbolicLink, then realpathSync + ownership verification
+  const lines = source.split('\n');
+  let foundSymlinkCheck = false;
+  let foundOwnershipCheck = false;
+  for (const line of lines) {
+    if (line.includes('isSymbolicLink()') && line.includes('flagDir')) {
+      // This is the lstat check on the parent dir — should NOT be a blanket return
+      foundSymlinkCheck = true;
+    }
+    if (line.includes('realpathSync') || line.includes('getuid') || line.includes('normalizedHome')) {
+      foundOwnershipCheck = true;
+    }
+  }
+
+  assert.ok(foundOwnershipCheck, 'safeWriteFlag should include ownership/home-dir verification');
+});
+
+// ---------- Summary ----------
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Problem

When `~/.claude` is a symlink (common pattern on Windows with config on a separate drive, or Linux with XDG shared config dirs), `safeWriteFlag` silently refuses all writes. The blanket `isSymbolicLink()` check on the parent directory treats legitimate user-created symlinks the same as attacker-planted ones.

Consequences:
- Statusline badge never renders
- `/caveman lite|full|ultra` slash commands cannot update mode
- Natural-language activation/deactivation is a no-op
- SessionStart stdout injection still works, so caveman behavior is active — but mode-switching and statusline are broken

## Root cause

```js
// hooks/caveman-config.js:80-83 (before this PR)
try {
  if (fs.lstatSync(flagDir).isSymbolicLink()) return;
} catch (e) {
  return;
}
```

This security check refuses **any** symlinked parent to prevent symlink-clobber attacks. But legitimate symlinked `~/.claude` directories hit the same check.

## Fix

Replace the blanket refusal with symlink resolution + ownership verification:

1. When `flagDir` is a symlink, resolve it via `fs.realpathSync()`
2. **Unix**: verify the resolved target is owned by the current user (`stat.uid === process.getuid()`)
3. **Windows**: verify the resolved path is under the user's home directory (no `uid` available)
4. The flag **file** itself is still never allowed to be a symlink (the actual clobber vector)

This preserves the security guarantee (attacker-owned symlink targets are rejected) while allowing legitimate `~/.claude` symlinks.

## Debug mode

Adds `CAVEMAN_DEBUG=1` env var — when set, `safeWriteFlag` emits stderr diagnostics explaining why a write was refused. Helps users diagnose the otherwise completely silent failure.

## Tests

12 regression tests in `tests/test_symlink_flag.js`:
- Normal (non-symlinked) directory write
- Symlinked parent owned by current user — write succeeds
- `readFlag` works through symlinked parent
- `safeWriteFlag` → `readFlag` round-trip through symlink
- Flag file as symlink — refused (even through symlinked parent)
- `readFlag` refuses symlinked flag file (exfil protection)
- Permissions 0600 preserved through symlink write
- Overwrite existing flag through symlinked parent
- `mkdirSync` creates parent when it doesn't exist
- Broken symlink target — silent fail
- All valid modes round-trip through symlink
- Source code audit: no blanket symlink refusal remains

Existing tests unaffected: `python3 tests/test_hooks.py` (4 passed).

Fixes #207