### PR TITLE
Clarify Codex plugin install steps for Caveman

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Pick your agent. One command. Done.
 | Agent | Install |
 |-------|---------|
 | **Claude Code** | `claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman` |
-| **Codex** | Clone repo → `/plugins` → Search "Caveman" → Install |
+| **Codex** | Clone repo → Open Codex in repo → `/plugins` → Search "Caveman" → Install |
 | **Gemini CLI** | `gemini extensions install https://github.com/JuliusBrussee/caveman` |
 | **Cursor** | `npx skills add JuliusBrussee/caveman -a cursor` |
 | **Windsurf** | `npx skills add JuliusBrussee/caveman -a windsurf` |


### PR DESCRIPTION
### PR Title
Clarify Codex plugin installation steps

---

### Description
The current installation instructions are intentionally concise:

> Clone repo → /plugins → Search "Caveman" → Install

However, this creates ambiguity around **where `/plugins` should be executed**.  
It’s not immediately clear that Codex must be opened *inside the cloned repository* before running the command.

This PR updates the instructions to:

> Clone repo → Open Codex in repo → /plugins → Search "Caveman" → Install

---

### Why this change
- Removes a point of confusion for first-time users  
- Makes the flow explicit without adding verbosity  
- Preserves the concise, caveman-style tone of the project  
- Reduces friction during onboarding / first install

---

### Scope
- Docs-only change  
- No functional impact  