### PR TITLE
Ultra: add density benchmark and optional 🪨 anchor

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -31,7 +31,7 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 |-------|------------|
 | **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
 | **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
-| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
+| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough. **Density benchmark — match this:** `"Inline obj prop → new ref → re-render. useMemo."` Optional: start every response with 🪨 as slippage detector — missing stone = caveman slipped |
 | **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
 | **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |


### PR DESCRIPTION
Closes #235

Adds two small things to the ultra intensity row in `SKILL.md`:

1. **Density benchmark** — promotes the existing ultra example (`"Inline obj prop → new ref → re-render. useMemo."`) from illustration to explicit target. Models drift verbose over long sessions; a concrete benchmark gives them a measurable floor.

2. **Optional visual anchor (🪨)** — one emoji per response as a slippage canary. Costs 1–2 tokens. Missing stone = caveman slipped. Opt-in, not mandatory.

## Before

```
| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
```

## After

```
| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough. **Density benchmark — match this:** `"Inline obj prop → new ref → re-render. useMemo."` Optional: start every response with 🪨 as slippage detector — missing stone = caveman slipped |
```

Benchmark turns a vague instruction into a measurable target. Anchor makes drift visible at a glance.

*Verbose model forget. Rock remind. 🪨*