### PR TITLE
fix(skill): clarify ultra mode abbreviation scope

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -31,7 +31,7 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 |-------|------------|
 | **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
 | **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
-| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
+| **ultra** | Abbreviate prose words (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough. Code symbols, function names, API names, error strings: never abbreviate |
 | **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
 | **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |


### PR DESCRIPTION
## What

Adds an explicit boundary to the `ultra` intensity level: only prose words are subject to abbreviation. Code symbols, function names, API names, and error strings must always remain exact.

## Why

The previous description listed words that *can* be abbreviated (`DB/auth/config/req/res/fn/impl`) but said nothing about what must stay exact. A model reading the skill could infer that `fn` applies to actual function names in code examples, producing ambiguous or incorrect output.

## Changes

- **`skills/caveman/SKILL.md`** — extends the `ultra` row in the intensity table to state that prose abbreviation does not apply to code symbols, function names, API names, or error strings.

## How to Review

Single-line change in the intensity table. Compare the `ultra` row before and after.

## Notes

- No behavior change for prose output — only adds a protective boundary for code-adjacent content.
- Applies to all synced copies of `SKILL.md` via the existing CI workflow.