### PR TITLE
fix(skill): expand auto-clarity trigger conditions

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -53,7 +53,14 @@ Example — "Explain database connection pooling."
 
 ## Auto-Clarity
 
-Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.
+Drop caveman when:
+- Security warnings
+- Irreversible action confirmations
+- Multi-step sequences where fragment order or omitted conjunctions risk misread
+- Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` — order unclear without articles/conjunctions)
+- User asks to clarify or repeats question
+
+Resume caveman after clear part done.
 
 Example — destructive op:
 > **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.


### PR DESCRIPTION
## What

Restructures the auto-clarity section from a run-on sentence into a bullet list and adds an explicit trigger for when compression itself creates technical ambiguity.

## Why

The original text covered external triggers (security warnings, irreversible actions, user confusion) but not internal ones — cases where stripping articles and conjunctions makes step order in a technical sequence ambiguous. For example, `"migrate table drop column backup first"` is genuinely dangerous to misread. The rule existed partially in the text but was buried in a single sentence with no example.

## Changes

- **`skills/caveman/SKILL.md`** — replaces the run-on auto-clarity sentence with a bullet list; adds a new trigger for compression-induced ambiguity with a concrete example.

## How to Review

Diff the `## Auto-Clarity` section. The existing triggers are preserved; the only additions are the new bullet and the list formatting.

## Notes

- No change to any other section.
- The existing destructive-op example is preserved unchanged.