### PR TITLE
fix: treat Typst and LaTeX files as natural language

### DIFF
--- a/caveman-compress/README.md
+++ b/caveman-compress/README.md
@@ -98,7 +98,7 @@ Examples:
 
 | Type | Compress? |
 |------|-----------|
-| `.md`, `.txt`, `.rst` | ✅ Yes |
+| `.md`, `.txt`, `.rst`, `.typ`, `.typst`, `.tex` | ✅ Yes |
 | Extensionless natural language | ✅ Yes |
 | `.py`, `.js`, `.ts`, `.json`, `.yaml` | ❌ Skip (code/config) |
 | `*.original.md` | ❌ Skip (backup files) |

--- a/caveman-compress/SKILL.md
+++ b/caveman-compress/SKILL.md
@@ -103,7 +103,7 @@ Compressed:
 
 ## Boundaries
 
-- ONLY compress natural language files (.md, .txt, extensionless)
+- ONLY compress natural language files (.md, .txt, .typ, .typst, .tex, extensionless)
 - NEVER modify: .py, .js, .ts, .json, .yaml, .yml, .toml, .env, .lock, .css, .html, .xml, .sql, .sh
 - If file has mixed content (prose + code), compress ONLY the prose sections
 - If unsure whether something is code or prose, leave it unchanged

--- a/caveman-compress/scripts/detect.py
+++ b/caveman-compress/scripts/detect.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path
 
 # Extensions that are natural language and compressible
-COMPRESSIBLE_EXTENSIONS = {".md", ".txt", ".markdown", ".rst"}
+COMPRESSIBLE_EXTENSIONS = {".md", ".txt", ".markdown", ".rst", ".typ", ".typst", ".tex"}
 
 # Extensions that are code/config and should be skipped
 SKIP_EXTENSIONS = {


### PR DESCRIPTION
I ran into this issue where I couldn't use caveman or compress to compress documents written in Typst or LaTeX. This fixes that problem.

If people find it helpful, give it a thumbs up and consider merging!