### PR TITLE
Align caveman Codex auto-start with current settings hooks

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,0 @@
-[features]
-codex_hooks = true

--- a/.codex/settings.json
+++ b/.codex/settings.json
@@ -2,12 +2,10 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume",
         "hooks": [
           {
             "type": "command",
             "command": "echo 'CAVEMAN MODE ACTIVE. Rules: Drop articles/filler/pleasantries/hedging. Fragments OK. Short synonyms. Pattern: [thing] [action] [reason]. [next step]. Not: Sure! I would be happy to help you with that. Yes: Bug in auth middleware. Fix: Code/commits/security: write normal. User says stop caveman or normal mode to deactivate.'",
-            "timeout": 5,
             "statusMessage": "Loading caveman mode"
           }
         ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ How caveman reaches each agent type:
 | Agent | Mechanism | Auto-activates? |
 |-------|-----------|----------------|
 | Claude Code | Plugin (hooks + skills) or standalone hooks | Yes — SessionStart hook injects rules |
-| Codex | Plugin in `plugins/caveman/` plus repo `.codex/hooks.json` and `.codex/config.toml` | Yes on macOS/Linux — SessionStart hook |
+| Codex | Plugin in `plugins/caveman/` plus repo `.codex/settings.json` SessionStart hook | Yes — repo-local SessionStart hook |
 | Gemini CLI | Extension with `GEMINI.md` context file | Yes — context file loads every session |
 | Cursor | `.cursor/rules/caveman.mdc` with `alwaysApply: true` | Yes — always-on rule |
 | Windsurf | `.windsurf/rules/caveman.md` with `trigger: always_on` | Yes — always-on rule |

--- a/CLAUDE.original.md
+++ b/CLAUDE.original.md
@@ -151,7 +151,7 @@ How caveman reaches each agent type:
 | Agent | Mechanism | Auto-activates? |
 |-------|-----------|----------------|
 | Claude Code | Plugin (hooks + skills) or standalone hooks | Yes — SessionStart hook injects rules |
-| Codex | Plugin in `plugins/caveman/` with `hooks.json` | Yes — SessionStart hook |
+| Codex | Plugin in `plugins/caveman/` plus repo `.codex/settings.json` SessionStart hook | Yes — repo-local SessionStart hook |
 | Gemini CLI | Extension with `GEMINI.md` context file | Yes — context file loads every session |
 | Cursor | `.cursor/rules/caveman.mdc` with `alwaysApply: true` | Yes — always-on rule |
 | Windsurf | `.windsurf/rules/caveman.md` with `trigger: always_on` | Yes — always-on rule |

--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ Auto-activation is built in for Claude Code, Gemini CLI, and the repo-local Code
 | caveman-help | Y | — | Y | Y | Y | Y | Y |
 
 > [!NOTE]
-> Auto-activation works differently per agent: Claude Code uses SessionStart hooks, this repo's Codex dogfood setup uses `.codex/hooks.json`, Gemini uses context files. Cursor/Windsurf/Cline/Copilot can be made always-on, but `npx skills add` installs only the skill, not the repo rule/instruction files.
+> Auto-activation works differently per agent: Claude Code uses SessionStart hooks, this repo's current Codex/OMX setup uses `.codex/settings.json`, Gemini uses context files. Cursor/Windsurf/Cline/Copilot can be made always-on, but `npx skills add` installs only the skill, not the repo rule/instruction files.
 >
-> ¹ Codex uses `$caveman` syntax, not `/caveman`. This repo ships `.codex/hooks.json`, so caveman auto-starts when you run Codex inside this repo. The installed plugin itself gives you `$caveman`; copy the same hook into another repo if you want always-on behavior there too. caveman-commit and caveman-review are not in the Codex plugin bundle — use the SKILL.md files directly.
+> ¹ Codex uses `$caveman` syntax, not `/caveman`. This repo ships `.codex/settings.json` with a `SessionStart` hook, so caveman auto-starts when you run Codex/OMX inside this repo. The installed plugin itself gives you `$caveman`; copy the same hook into another repo if you want always-on behavior there too. caveman-commit and caveman-review are not in the Codex plugin bundle — use the SKILL.md files directly.
 > ² Add the "Want it always on?" snippet below to those agents' system prompt or rule file if you want session-start activation.
 > ³ Cursor and Windsurf receive the full SKILL.md with all intensity levels. Mode switching works on-demand via the skill; no slash command.
 > ⁴ Available in Claude Code, but plugin install only nudges setup. Standalone `install.sh` / `install.ps1` configures it automatically when no custom `statusLine` exists.
@@ -204,18 +204,31 @@ Uninstall: `bash hooks/uninstall.sh` or `powershell -File hooks\uninstall.ps1`
 
 **macOS / Linux:**
 1. Clone repo → Open Codex in the repo directory → `/plugins` → Search "Caveman" → Install
-2. Repo-local auto-start is already wired by `.codex/hooks.json` + `.codex/config.toml`
+2. Repo-local auto-start is already wired by `.codex/settings.json`
 
 **Windows:**
 1. Enable symlinks first: `git config --global core.symlinks true` (requires Developer Mode or admin)
 2. Clone repo → Open VS Code → Codex Settings → Plugins → find "Caveman" under local marketplace → Install → Reload Window
-3. Codex hooks are currently disabled on Windows, so use `$caveman` to start manually
+3. If your Codex build does not apply repo-local `SessionStart` hooks on Windows yet, use `$caveman` to start manually
 
-This repo also ships `.codex/hooks.json` and enables hooks in `.codex/config.toml`, so caveman auto-activates while you run Codex inside this repo on macOS/Linux. The installed plugin gives you `$caveman`; if you want always-on behavior in other repos too, copy the same `SessionStart` hook there and enable:
+This repo also ships `.codex/settings.json`, so caveman auto-activates while you run Codex/OMX inside this repo. The installed plugin gives you `$caveman`; if you want always-on behavior in other repos too, copy the same `SessionStart` hook into that repo's `.codex/settings.json`:
 
-```toml
-[features]
-codex_hooks = true
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'CAVEMAN MODE ACTIVE. Rules: Drop articles/filler/pleasantries/hedging. Fragments OK. Short synonyms. Pattern: [thing] [action] [reason]. [next step]. Not: Sure! I would be happy to help you with that. Yes: Bug in auth middleware. Fix: Code/commits/security: write normal. User says stop caveman or normal mode to deactivate.'",
+            "statusMessage": "Loading caveman mode"
+          }
+        ]
+      }
+    ]
+  }
+}
 ```
 
 </details>

--- a/tests/verify_repo.py
+++ b/tests/verify_repo.py
@@ -98,12 +98,26 @@ def verify_manifests_and_syntax() -> None:
         ROOT / ".agents/plugins/marketplace.json",
         ROOT / ".claude-plugin/plugin.json",
         ROOT / ".claude-plugin/marketplace.json",
-        ROOT / ".codex/hooks.json",
+        ROOT / ".codex/settings.json",
         ROOT / "gemini-extension.json",
         ROOT / "plugins/caveman/.codex-plugin/plugin.json",
     ]
     for path in manifest_paths:
         read_json(path)
+
+    codex_settings = read_json(ROOT / ".codex/settings.json")
+    ensure(not (ROOT / ".codex/hooks.json").exists(), "legacy .codex/hooks.json should be removed")
+    ensure(not (ROOT / ".codex/config.toml").exists(), "legacy .codex/config.toml should be removed")
+    session_entries = codex_settings.get("hooks", {}).get("SessionStart", [])
+    ensure(session_entries, ".codex/settings.json missing SessionStart hook")
+    session_hooks = session_entries[0].get("hooks", [])
+    ensure(session_hooks, ".codex/settings.json missing SessionStart command")
+    first_hook = session_hooks[0]
+    ensure(first_hook.get("type") == "command", "Codex SessionStart hook should stay command-based")
+    ensure(
+        "CAVEMAN MODE ACTIVE" in first_hook.get("command", ""),
+        "Codex SessionStart hook missing caveman activation banner",
+    )
 
     run(["node", "--check", "hooks/caveman-config.js"])
     run(["node", "--check", "hooks/caveman-activate.js"])
@@ -225,7 +239,7 @@ def verify_hook_install_flow() -> None:
             ["node", "hooks/caveman-activate.js"],
             env={"HOME": str(home)},
         )
-        ensure("CAVEMAN MODE ACTIVE." in activate.stdout, "activation output missing caveman banner")
+        ensure("CAVEMAN MODE ACTIVE" in activate.stdout, "activation output missing caveman banner")
         ensure("STATUSLINE SETUP NEEDED" not in activate.stdout, "activation should stay quiet when custom statusline exists")
         ensure((claude_dir / ".caveman-active").read_text() == "full", "activation flag should default to full")
 
@@ -234,14 +248,14 @@ def verify_hook_install_flow() -> None:
             ["node", "hooks/caveman-activate.js"],
             env={"HOME": str(home), "CAVEMAN_DEFAULT_MODE": "ultra"},
         )
-        ensure("CAVEMAN MODE ACTIVE." in activate_custom.stdout, "activation with custom default missing banner")
+        ensure("CAVEMAN MODE ACTIVE" in activate_custom.stdout, "activation with custom default missing banner")
         ensure((claude_dir / ".caveman-active").read_text() == "ultra", "CAVEMAN_DEFAULT_MODE=ultra should set flag to ultra")
         # Test "off" mode — activation skipped, flag removed
         activate_off = run(
             ["node", "hooks/caveman-activate.js"],
             env={"HOME": str(home), "CAVEMAN_DEFAULT_MODE": "off"},
         )
-        ensure("CAVEMAN MODE ACTIVE." not in activate_off.stdout, "off mode should not emit caveman banner")
+        ensure("CAVEMAN MODE ACTIVE" not in activate_off.stdout, "off mode should not emit caveman banner")
         ensure(not (claude_dir / ".caveman-active").exists(), "off mode should remove flag file")
 
         # Test mode tracker with /caveman when default is off — should NOT write flag
@@ -274,7 +288,15 @@ def verify_hook_install_flow() -> None:
             capture_output=True,
             check=True,
         )
-        ensure(ultra_prompt.stdout == "", "mode tracker should stay silent")
+        reinforcement = json.loads(ultra_prompt.stdout)
+        ensure(
+            reinforcement.get("hookSpecificOutput", {}).get("hookEventName") == "UserPromptSubmit",
+            "mode tracker should emit UserPromptSubmit reinforcement JSON",
+        )
+        ensure(
+            "CAVEMAN MODE ACTIVE (ultra)." in reinforcement.get("hookSpecificOutput", {}).get("additionalContext", ""),
+            "mode tracker reinforcement missing active ultra reminder",
+        )
         ensure((claude_dir / ".caveman-active").read_text() == "ultra", "mode tracker did not record ultra")
 
         subprocess.run(


### PR DESCRIPTION
## Summary
- switch repo-local Codex auto-start wiring from deprecated .codex/hooks.json and .codex/config.toml to .codex/settings.json
- update the repo docs to the current OMX and Codex workflow
- extend repository verification for the new hook surface and hook-output shapes

## Verification
- python3 tests/verify_repo.py
- python3 -m unittest tests.test_hooks