### PR TITLE
fix(windows): write node script to temp file instead of node -e

### DIFF
--- a/hooks/install.ps1
+++ b/hooks/install.ps1
@@ -180,7 +180,13 @@ fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
 console.log('  Hooks wired in settings.json');
 '@
 
-node -e $nodeScript
+$tmpScript = Join-Path $env:TEMP "caveman-install-$([System.Diagnostics.Process]::GetCurrentProcess().Id).js"
+try {
+    [System.IO.File]::WriteAllText($tmpScript, $nodeScript, [System.Text.Encoding]::UTF8)
+    node $tmpScript
+} finally {
+    if (Test-Path $tmpScript) { Remove-Item $tmpScript -Force }
+}
 
 Write-Host ""
 Write-Host "Done! Restart Claude Code to activate." -ForegroundColor Green


### PR DESCRIPTION
Fixes #249

## What broke

`install.ps1` failed on Windows PowerShell 5.1 with a `SyntaxError` mid-script:

```
[eval]:17
      command: 'node '
SyntaxError: Unexpected end of input
```

Hook files were copied but `settings.json` was never updated, leaving caveman non-functional.

## Root cause

`node -e $nodeScript` on Windows passes the multiline string through the Windows command processor, which **terminates the argument at the first `"` character**. The JS string contains `'node "' + hooksDir + ...` — the `"` after `node ` ends the argument early.

## Fix

Write the script to a temp `.js` file and run `node tempfile.js`. Temp file is cleaned up in a `finally` block regardless of success or failure.

```powershell
$tmpScript = Join-Path $env:TEMP "caveman-install-$([System.Diagnostics.Process]::GetCurrentProcess().Id).js"
try {
    [System.IO.File]::WriteAllText($tmpScript, $nodeScript, [System.Text.Encoding]::UTF8)
    node $tmpScript
} finally {
    if (Test-Path $tmpScript) { Remove-Item $tmpScript -Force }
}
```

Verified clean install output on Windows 11 / PowerShell 5.1 / Node v24.14.0.