### PR TITLE
docs: add Windows manual install fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,18 +189,24 @@ irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks/install.p
 
 Or from a local clone: `bash hooks/install.sh` / `powershell -File hooks\install.ps1`
 
-**Windows Installation (Manual Fallback):** In some Windows environments, automated install can fail in edge cases (#249, #199, #72; #150 is historical related context). If that happens, use this manual fallback for plugin-skill activation (not standalone hooks install):
+**Windows Installation (Manual Fallback):** In some Windows environments, automated install can fail in edge cases (#249, #199, #72; #150 is historical related context).
+
+Use this fallback only for plugin-skill activation. It does **not** install standalone hooks/statusline.
+
+1. Open PowerShell in your repo root.
+2. Run this setup block:
 
 ```powershell
-# Run from repo root
 $ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
 $PluginSkillDir = Join-Path $ClaudeDir ".agents\plugins\caveman\skills\caveman"
 $MarketplaceDir = Join-Path $ClaudeDir ".agents\plugins"
 $MarketplaceFile = Join-Path $MarketplaceDir "marketplace.json"
 
+# Step A: Copy skill file into Claude plugin path
 New-Item -ItemType Directory -Path $PluginSkillDir -Force | Out-Null
 Copy-Item ".\skills\caveman\SKILL.md" "$PluginSkillDir\SKILL.md" -Force
 
+# Step B: Create or update marketplace.json with caveman plugin entry
 New-Item -ItemType Directory -Path $MarketplaceDir -Force | Out-Null
 if (Test-Path $MarketplaceFile) {
   $marketplace = Get-Content $MarketplaceFile -Raw | ConvertFrom-Json
@@ -223,13 +229,18 @@ $plugins["caveman"] = [ordered]@{
 }
 $marketplace.plugins = [pscustomobject]$plugins
 $marketplace | ConvertTo-Json -Depth 10 | Set-Content -Path $MarketplaceFile -Encoding UTF8
+```
 
-# Verify files
+3. Verify install:
+
+```powershell
 Test-Path "$PluginSkillDir\SKILL.md"
 Get-Content $MarketplaceFile
 ```
 
-Restart Claude Code, then run `/caveman` to confirm mode activates.
+`Test-Path` should print `True`, and `Get-Content` should show a `caveman` plugin entry.
+
+4. Restart Claude Code, then run `/caveman` to confirm mode activates.
 
 Uninstall: `bash hooks/uninstall.sh` or `powershell -File hooks\uninstall.ps1`
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,48 @@ irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks/install.p
 
 Or from a local clone: `bash hooks/install.sh` / `powershell -File hooks\install.ps1`
 
+**Windows Installation (Manual Fallback):** In some Windows environments, automated install can fail in edge cases (#249, #199, #72; #150 is historical related context). If that happens, use this manual fallback for plugin-skill activation (not standalone hooks install):
+
+```powershell
+# Run from repo root
+$ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
+$PluginSkillDir = Join-Path $ClaudeDir ".agents\plugins\caveman\skills\caveman"
+$MarketplaceDir = Join-Path $ClaudeDir ".agents\plugins"
+$MarketplaceFile = Join-Path $MarketplaceDir "marketplace.json"
+
+New-Item -ItemType Directory -Path $PluginSkillDir -Force | Out-Null
+Copy-Item ".\skills\caveman\SKILL.md" "$PluginSkillDir\SKILL.md" -Force
+
+New-Item -ItemType Directory -Path $MarketplaceDir -Force | Out-Null
+if (Test-Path $MarketplaceFile) {
+  $marketplace = Get-Content $MarketplaceFile -Raw | ConvertFrom-Json
+} else {
+  $marketplace = [pscustomobject]@{}
+}
+
+if (-not ($marketplace.PSObject.Properties.Name -contains "plugins")) {
+  $marketplace | Add-Member -NotePropertyName plugins -NotePropertyValue ([pscustomobject]@{})
+}
+
+$plugins = [ordered]@{}
+foreach ($p in $marketplace.plugins.PSObject.Properties) {
+  $plugins[$p.Name] = $p.Value
+}
+$plugins["caveman"] = [ordered]@{
+  name = "caveman"
+  source = "JuliusBrussee/caveman"
+  version = "main"
+}
+$marketplace.plugins = [pscustomobject]$plugins
+$marketplace | ConvertTo-Json -Depth 10 | Set-Content -Path $MarketplaceFile -Encoding UTF8
+
+# Verify files
+Test-Path "$PluginSkillDir\SKILL.md"
+Get-Content $MarketplaceFile
+```
+
+Restart Claude Code, then run `/caveman` to confirm mode activates.
+
 Uninstall: `bash hooks/uninstall.sh` or `powershell -File hooks\uninstall.ps1`
 
 **Statusline badge:** Shows `[CAVEMAN]`, `[CAVEMAN:ULTRA]`, etc. in your Claude Code status bar.


### PR DESCRIPTION
## What
- Adds a new **Windows Installation (Manual Fallback)** subsection in the Claude Code details block of README.
- Places the section after the local-clone install line and before the Uninstall line.
- Adds copy/paste PowerShell commands to:
  - create the plugin skill path,
  - copy `skills/caveman/SKILL.md` into the Claude plugin path,
  - create/update `.agents/plugins/marketplace.json` with a `caveman` entry.
- Adds verification commands (`Test-Path`, `Get-Content`) and expected result guidance.
- Adds final runtime validation step: restart Claude Code and run `/caveman`.

## Why
- Automated install can fail in specific Windows edge cases.
- This gives users a reliable manual fallback without changing installer behavior in this PR.
- Wording is intentionally scoped and does **not** claim universal Windows failure.

## Tested
- Environment: **Windows 11 + Claude Code**
- Verified README placement and markdown rendering.
- Executed documented PowerShell flow against a temporary `CLAUDE_CONFIG_DIR`.
- Confirmed:
  - `SKILL.md` exists in plugin skill path,
  - `marketplace.json` contains `caveman` plugin entry.
- Confirmed contribution remains docs-focused (README-only change).

## Related
- Edge cases: #249, #199, #72
- Historical related context: #150
