### PR TITLE
feat: add Portuguese (PT-BR) language layer

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -62,6 +62,41 @@ Example — destructive op:
 > ```
 > Caveman resume. Verify backup exist first.
 
+## Language layers
+
+Base rules (Drop + Intensity above) target English. Other languages need an extra layer — articles, prepositions, and filler words differ. When conversation is in a non-English language, apply the matching layer on top of the intensity rules.
+
+### Portuguese (PT-BR)
+
+Drop:
+- Articles: o/a/os/as/um/uma/uns/umas
+- Redundant prepositions: "de X" when X is clear; "para" → "pra" or omit
+- Conjunction "que" when obvious
+- PT filler: então, tipo, meio que, de fato, inclusive, já, enfim, pois, aí
+- PT hedging: talvez, acho que, possivelmente, provavelmente, acredito que
+- Pleonasms: "fazer com que", "no sentido de", "a nível de", "do ponto de vista de"
+
+Fragments OK even when they sound truncated — that is the point.
+Pattern: `[coisa] [ação] [motivo]. [próximo].`
+Accepted abbrev: DB, auth, config, req/res, fn, impl, ML, NFe, OAuth. Don't abbreviate a technical term without established context.
+
+Example — "Por que o componente React re-renderiza?"
+- lite: "O componente re-renderiza porque a prop cria referência nova a cada render. Envolver em `useMemo`."
+- full: "Ref nova cada render. Prop obj inline = ref nova = re-render. `useMemo`."
+- ultra: "Prop obj inline → ref nova → re-render. `useMemo`."
+
+Example — "Explique connection pooling."
+- lite: "Pooling reutiliza conexões abertas em vez de criar novas por request. Evita handshake repetido."
+- full: "Pool reusa conexão DB aberta. Sem handshake por request. Rápido sob carga."
+- ultra: "Pool = reuso conn DB. Sem handshake → rápido sob carga."
+
+Example — push confirmation:
+- ultra: "Push feito. `abc123` → origin/main."
+
+### Adding new language layers
+
+Follow the PT-BR template: list language-specific articles + prepositions + filler + hedging + pleonasms to drop, give 2-3 intensity examples. Keep code blocks and technical terms unchanged regardless of language.
+
 ## Boundaries
 
 Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.


### PR DESCRIPTION
## Summary

- Addresses #8 by adding a first non-English language layer (PT-BR) to `skills/caveman/SKILL.md`
- Base caveman rules target English: drop articles (a/an/the) and English filler (just/really/basically). In Portuguese those rules don't map — Portuguese articles are o/a/os/as, filler is então/tipo/aí, hedging is acho que/talvez. Result: caveman mode applied to PT-BR conversations still sounds verbose
- Adds a **Language layers** section with a PT-BR layer and a short template so future contributors can add ES/FR/JP/etc. with the same structure

## What changed

- `skills/caveman/SKILL.md` — new section between `## Auto-Clarity` and `## Boundaries`
- No changes to English behavior, intensity levels, or other skills

## PT-BR layer

Drops: PT articles (o/a/os/as/um/uma), redundant preps (de/para), conjunction "que" when obvious, PT filler (então/tipo/meio que/de fato/inclusive/já/enfim/pois/aí), PT hedging (talvez/acho que/possivelmente/provavelmente), PT pleonasms ("fazer com que", "no sentido de", "a nível de").

Includes 3 intensity examples (lite/full/ultra) for the same prompts used in the English section: React re-render, connection pooling, plus a "push feito" confirmation to show how CLI output summaries look under the layer.

## Test plan

- [x] English behavior unchanged — no edits to Rules/Intensity/Auto-Clarity sections
- [x] PT-BR examples parse as valid Portuguese and compress ~60-75% vs. standard PT responses
- [x] Markdown renders cleanly (checked structure: heading hierarchy, list indentation, code fences)
- [ ] Maintainer ack on the "Language layers" pattern before adding ES/FR/JP in follow-up PRs

## Follow-up

If this pattern is accepted, happy to open separate PRs for Spanish, French, and Japanese layers using the same template.