### PR TITLE
fix(compress): avoid XML-like trigger placeholder

### DIFF
--- a/caveman-compress/SKILL.md
+++ b/caveman-compress/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Compress natural language memory files (CLAUDE.md, todos, preferences) into caveman format
   to save input tokens. Preserves all technical substance, code, URLs, and structure.
   Compressed version overwrites the original file. Human-readable backup saved as FILE.original.md.
-  Trigger: /caveman:compress <filepath> or "compress memory file"
+  Trigger: /caveman:compress FILEPATH or "compress memory file"
 ---
 
 # Caveman Compress

--- a/tests/verify_repo.py
+++ b/tests/verify_repo.py
@@ -73,21 +73,32 @@ def _frontmatter_description(path: Path) -> str:
 
     description_lines: list[str] = []
     collecting = False
+    block_indent: int | None = None
     for line in lines[1:]:
         if line == "---":
             break
         if collecting:
-            if line.startswith((" ", "\t")):
-                description_lines.append(line.strip())
+            stripped = line.strip()
+            if not stripped:
+                description_lines.append("")
                 continue
-            break
+            indent = len(line) - len(line.lstrip(" \t"))
+            if block_indent is None:
+                if indent == 0:
+                    break
+                block_indent = indent
+            elif indent < block_indent:
+                break
+            description_lines.append(stripped)
+            continue
         if line.startswith("description:"):
             value = line.split(":", 1)[1].strip()
-            if value in {">", "|"}:
+            # Folded (>) and literal (|) block scalars, with optional chomping (-/+).
+            if value and value[0] in ("|", ">"):
                 collecting = True
                 continue
             return value.strip("'\"")
-    return " ".join(description_lines)
+    return " ".join(part for part in description_lines if part)
 
 
 def verify_skill_frontmatter_upload_compatibility() -> None:

--- a/tests/verify_repo.py
+++ b/tests/verify_repo.py
@@ -37,6 +37,8 @@ def run(
     check: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     merged_env = os.environ.copy()
+    # Keep Python subprocess output decodable on Windows when the CLI prints Unicode.
+    merged_env.setdefault("PYTHONIOENCODING", "utf-8")
     if env:
         merged_env.update(env)
     result = subprocess.run(
@@ -44,6 +46,7 @@ def run(
         cwd=cwd,
         env=merged_env,
         text=True,
+        encoding="utf-8",
         capture_output=True,
         check=False,
     )
@@ -57,7 +60,54 @@ def run(
 
 
 def read_json(path: Path) -> object:
-    return json.loads(path.read_text())
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def shell_path(path: Path) -> str:
+    return str(path).replace("\\", "/") if os.name == "nt" else str(path)
+
+
+def _frontmatter_description(path: Path) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    ensure(lines and lines[0] == "---", f"{path} missing YAML frontmatter")
+
+    description_lines: list[str] = []
+    collecting = False
+    for line in lines[1:]:
+        if line == "---":
+            break
+        if collecting:
+            if line.startswith((" ", "\t")):
+                description_lines.append(line.strip())
+                continue
+            break
+        if line.startswith("description:"):
+            value = line.split(":", 1)[1].strip()
+            if value in {">", "|"}:
+                collecting = True
+                continue
+            return value.strip("'\"")
+    return " ".join(description_lines)
+
+
+def verify_skill_frontmatter_upload_compatibility() -> None:
+    section("Skill Frontmatter Upload Compatibility")
+
+    skill_paths = [
+        ROOT / "skills/caveman/SKILL.md",
+        ROOT / "skills/caveman-commit/SKILL.md",
+        ROOT / "skills/caveman-help/SKILL.md",
+        ROOT / "skills/caveman-review/SKILL.md",
+        ROOT / "caveman-compress/SKILL.md",
+    ]
+    for path in skill_paths:
+        description = _frontmatter_description(path)
+        ensure(
+            "<" not in description and ">" not in description,
+            f"{path} description contains XML-like angle brackets",
+        )
+
+    print("Skill frontmatter descriptions avoid XML-like tags")
 
 
 def verify_synced_files() -> None:
@@ -72,19 +122,26 @@ def verify_synced_files() -> None:
         ROOT / ".windsurf/skills/caveman/SKILL.md",
     ]
     for copy in skill_copies:
-        ensure(copy.read_text() == skill_source.read_text(), f"Skill copy mismatch: {copy}")
+        ensure(
+            copy.read_text(encoding="utf-8") == skill_source.read_text(encoding="utf-8"),
+            f"Skill copy mismatch: {copy}",
+        )
 
     rule_copies = [
         ROOT / ".clinerules/caveman.md",
         ROOT / ".github/copilot-instructions.md",
     ]
     for copy in rule_copies:
-        ensure(copy.read_text() == rule_source.read_text(), f"Rule copy mismatch: {copy}")
+        ensure(
+            copy.read_text(encoding="utf-8") == rule_source.read_text(encoding="utf-8"),
+            f"Rule copy mismatch: {copy}",
+        )
 
     with zipfile.ZipFile(ROOT / "caveman.skill") as archive:
         ensure("caveman/SKILL.md" in archive.namelist(), "caveman.skill missing caveman/SKILL.md")
         ensure(
-            archive.read("caveman/SKILL.md").decode("utf-8") == skill_source.read_text(),
+            archive.read("caveman/SKILL.md").decode("utf-8")
+            == skill_source.read_text(encoding="utf-8"),
             "caveman.skill payload mismatch",
         )
 
@@ -113,8 +170,8 @@ def verify_manifests_and_syntax() -> None:
     run(["bash", "-n", "hooks/caveman-statusline.sh"])
 
     # Ensure install/uninstall scripts include caveman-config.js
-    install_sh = (ROOT / "hooks/install.sh").read_text()
-    uninstall_sh = (ROOT / "hooks/uninstall.sh").read_text()
+    install_sh = (ROOT / "hooks/install.sh").read_text(encoding="utf-8")
+    uninstall_sh = (ROOT / "hooks/uninstall.sh").read_text(encoding="utf-8")
     ensure("caveman-config.js" in install_sh, "install.sh missing caveman-config.js")
     ensure("caveman-config.js" in uninstall_sh, "uninstall.sh missing caveman-config.js")
 
@@ -123,9 +180,9 @@ def verify_manifests_and_syntax() -> None:
 
 def verify_powershell_static() -> None:
     section("PowerShell Static Checks")
-    install_text = (ROOT / "hooks/install.ps1").read_text()
-    uninstall_text = (ROOT / "hooks/uninstall.ps1").read_text()
-    statusline_text = (ROOT / "hooks/caveman-statusline.ps1").read_text()
+    install_text = (ROOT / "hooks/install.ps1").read_text(encoding="utf-8")
+    uninstall_text = (ROOT / "hooks/uninstall.ps1").read_text(encoding="utf-8")
+    statusline_text = (ROOT / "hooks/caveman-statusline.ps1").read_text(encoding="utf-8")
 
     ensure("caveman-config.js" in install_text, "install.ps1 missing caveman-config.js")
     ensure("caveman-config.js" in uninstall_text, "uninstall.ps1 missing caveman-config.js")
@@ -212,8 +269,9 @@ def verify_hook_install_flow() -> None:
             "hooks": {"Notification": [{"hooks": [{"type": "command", "command": "echo keep-me"}]}]},
         }
         (claude_dir / "settings.json").write_text(json.dumps(existing_settings, indent=2) + "\n")
+        hook_env = {"HOME": shell_path(home), "CLAUDE_CONFIG_DIR": shell_path(claude_dir)}
 
-        run(["bash", "hooks/install.sh"], env={"HOME": str(home)})
+        run(["bash", "hooks/install.sh"], env=hook_env)
 
         settings = read_json(claude_dir / "settings.json")
         hooks = settings["hooks"]
@@ -223,33 +281,37 @@ def verify_hook_install_flow() -> None:
 
         activate = run(
             ["node", "hooks/caveman-activate.js"],
-            env={"HOME": str(home)},
+            env=hook_env,
         )
-        ensure("CAVEMAN MODE ACTIVE." in activate.stdout, "activation output missing caveman banner")
+        ensure("CAVEMAN MODE ACTIVE" in activate.stdout, "activation output missing caveman banner")
         ensure("STATUSLINE SETUP NEEDED" not in activate.stdout, "activation should stay quiet when custom statusline exists")
-        ensure((claude_dir / ".caveman-active").read_text() == "full", "activation flag should default to full")
+        ensure((claude_dir / ".caveman-active").read_text(encoding="utf-8") == "full", "activation flag should default to full")
 
         # Test configurable default mode via CAVEMAN_DEFAULT_MODE env var
         activate_custom = run(
             ["node", "hooks/caveman-activate.js"],
-            env={"HOME": str(home), "CAVEMAN_DEFAULT_MODE": "ultra"},
+            env={**hook_env, "CAVEMAN_DEFAULT_MODE": "ultra"},
         )
-        ensure("CAVEMAN MODE ACTIVE." in activate_custom.stdout, "activation with custom default missing banner")
-        ensure((claude_dir / ".caveman-active").read_text() == "ultra", "CAVEMAN_DEFAULT_MODE=ultra should set flag to ultra")
+        ensure("CAVEMAN MODE ACTIVE" in activate_custom.stdout, "activation with custom default missing banner")
+        ensure(
+            (claude_dir / ".caveman-active").read_text(encoding="utf-8") == "ultra",
+            "CAVEMAN_DEFAULT_MODE=ultra should set flag to ultra",
+        )
         # Test "off" mode — activation skipped, flag removed
         activate_off = run(
             ["node", "hooks/caveman-activate.js"],
-            env={"HOME": str(home), "CAVEMAN_DEFAULT_MODE": "off"},
+            env={**hook_env, "CAVEMAN_DEFAULT_MODE": "off"},
         )
-        ensure("CAVEMAN MODE ACTIVE." not in activate_off.stdout, "off mode should not emit caveman banner")
+        ensure("CAVEMAN MODE ACTIVE" not in activate_off.stdout, "off mode should not emit caveman banner")
         ensure(not (claude_dir / ".caveman-active").exists(), "off mode should remove flag file")
 
         # Test mode tracker with /caveman when default is off — should NOT write flag
         subprocess.run(
             ["node", "hooks/caveman-mode-tracker.js"],
             cwd=ROOT,
-            env={**os.environ, "HOME": str(home), "CAVEMAN_DEFAULT_MODE": "off"},
+            env={**os.environ, **hook_env, "CAVEMAN_DEFAULT_MODE": "off"},
             text=True,
+            encoding="utf-8",
             input='{"prompt":"/caveman"}',
             capture_output=True,
             check=True,
@@ -261,27 +323,32 @@ def verify_hook_install_flow() -> None:
 
         run(
             ["node", "hooks/caveman-mode-tracker.js"],
-            env={"HOME": str(home)},
+            env=hook_env,
             check=True,
         )
 
         ultra_prompt = subprocess.run(
             ["node", "hooks/caveman-mode-tracker.js"],
             cwd=ROOT,
-            env={**os.environ, "HOME": str(home)},
+            env={**os.environ, **hook_env},
             text=True,
+            encoding="utf-8",
             input='{"prompt":"/caveman ultra"}',
             capture_output=True,
             check=True,
         )
-        ensure(ultra_prompt.stdout == "", "mode tracker should stay silent")
-        ensure((claude_dir / ".caveman-active").read_text() == "ultra", "mode tracker did not record ultra")
+        ensure(
+            "CAVEMAN MODE ACTIVE (ultra)" in ultra_prompt.stdout,
+            "mode tracker should emit active-mode reinforcement",
+        )
+        ensure((claude_dir / ".caveman-active").read_text(encoding="utf-8") == "ultra", "mode tracker did not record ultra")
 
         subprocess.run(
             ["node", "hooks/caveman-mode-tracker.js"],
             cwd=ROOT,
-            env={**os.environ, "HOME": str(home)},
+            env={**os.environ, **hook_env},
             text=True,
+            encoding="utf-8",
             input='{"prompt":"normal mode"}',
             capture_output=True,
             check=True,
@@ -291,27 +358,28 @@ def verify_hook_install_flow() -> None:
         (claude_dir / ".caveman-active").write_text("wenyan-ultra")
         statusline = run(
             ["bash", "hooks/caveman-statusline.sh"],
-            env={"HOME": str(home)},
+            env=hook_env,
         )
         ensure("[CAVEMAN:WENYAN-ULTRA]" in statusline.stdout, "statusline badge output mismatch")
 
-        reinstall = run(["bash", "hooks/install.sh"], env={"HOME": str(home)})
+        reinstall = run(["bash", "hooks/install.sh"], env=hook_env)
         ensure("Nothing to do" in reinstall.stdout, "install.sh should be idempotent")
 
-        run(["bash", "hooks/uninstall.sh"], env={"HOME": str(home)})
+        run(["bash", "hooks/uninstall.sh"], env=hook_env)
         settings_after = read_json(claude_dir / "settings.json")
         ensure(settings_after == existing_settings, "uninstall.sh did not restore non-caveman settings")
         ensure(not (claude_dir / ".caveman-active").exists(), "uninstall.sh should remove flag file")
 
     with tempfile.TemporaryDirectory(prefix="caveman-verify-fresh-") as temp_root:
         home = Path(temp_root) / "home"
-        run(["bash", "hooks/install.sh"], env={"HOME": str(home)})
         claude_dir = home / ".claude"
+        hook_env = {"HOME": shell_path(home), "CLAUDE_CONFIG_DIR": shell_path(claude_dir)}
+        run(["bash", "hooks/install.sh"], env=hook_env)
         settings = read_json(claude_dir / "settings.json")
         ensure("statusLine" in settings, "fresh install should configure statusline")
-        activate = run(["node", "hooks/caveman-activate.js"], env={"HOME": str(home)})
+        activate = run(["node", "hooks/caveman-activate.js"], env=hook_env)
         ensure("STATUSLINE SETUP NEEDED" not in activate.stdout, "fresh install should not nudge for statusline")
-        run(["bash", "hooks/uninstall.sh"], env={"HOME": str(home)})
+        run(["bash", "hooks/uninstall.sh"], env=hook_env)
         ensure(read_json(claude_dir / "settings.json") == {}, "fresh uninstall should leave empty settings")
 
     print("Claude hook install/uninstall flow OK")
@@ -319,6 +387,7 @@ def verify_hook_install_flow() -> None:
 
 def main() -> int:
     checks = [
+        verify_skill_frontmatter_upload_compatibility,
         verify_synced_files,
         verify_manifests_and_syntax,
         verify_powershell_static,


### PR DESCRIPTION
## Summary
- Replace the compress skill trigger placeholder in canonical frontmatter with `FILEPATH` so the description no longer looks like an XML tag.
- Add verifier coverage to reject XML-like angle brackets in canonical skill descriptions.
- Make the verifier consistently read UTF-8 text and align hook-flow assertions with current hook behavior.

Fixes #266.

## Verification
- `python -m py_compile tests/verify_repo.py`
- `git diff --check --cached`
- Full verifier passed from an LF-normalized staged snapshot under WSL: `python3 tests/verify_repo.py`