### PR TITLE
feat(hooks): opt-in SessionStart ruleset dump via env var

### DIFF
--- a/hooks/caveman-activate.js
+++ b/hooks/caveman-activate.js
@@ -44,6 +44,17 @@ if (INDEPENDENT_MODES.has(mode)) {
   process.exit(0);
 }
 
+// Opt-in SessionStart ruleset dump.
+// The full ruleset (~60 lines) is valuable for first-time users but heavy for
+// power users who already know caveman and just want the flag written + the
+// statusline active. Set CAVEMAN_SESSIONSTART_DUMP=1 to restore the full dump;
+// default off emits a 3-line acknowledgment so the ruleset isn't re-injected
+// into every session's context window.
+if (!process.env.CAVEMAN_SESSIONSTART_DUMP) {
+  process.stdout.write('CAVEMAN ACTIVE — level: ' + mode + '. Short mode. Set CAVEMAN_SESSIONSTART_DUMP=1 for full ruleset.');
+  process.exit(0);
+}
+
 // Resolve the canonical label for wenyan alias
 const modeLabel = mode === 'wenyan' ? 'wenyan-full' : mode;
 


### PR DESCRIPTION
## What

Make the SessionStart ruleset dump in `hooks/caveman-activate.js` opt-in via an environment variable.

## Why

The hook currently emits the full ~60-line filtered ruleset on every new session. After the first few sessions, that content is redundant context — it anchors behavior the user already has, but eats the session's context window on every restart.

## Change

One insertion right after the existing `INDEPENDENT_MODES` early-exit block. The flag file still writes, the statusline still reads it, the plugin remains active.

**Before:** every session → full ~60-line filtered ruleset dump.

**After, default (env var unset):**
```
CAVEMAN ACTIVE — level: full. Short mode. Set CAVEMAN_SESSIONSTART_DUMP=1 for full ruleset.
```

**After, `CAVEMAN_SESSIONSTART_DUMP=1`:** current behavior restored — full filtered ruleset emitted.

## Compatibility

- First-time users see no change — the env var is absent by default.

  Wait, this is a semantic change. Let me be more precise: **this PR ships short mode as the new default.** Power users benefit immediately; first-time users lose the anchoring ruleset on session start. If you'd prefer the default stay full-dump (env var to OPT OUT instead of OPT IN), flip the condition's sense — I'm happy to rework the PR that way.

- Existing users who rely on the ruleset dump set `CAVEMAN_SESSIONSTART_DUMP=1` in their shell profile; everything else is unchanged.

## One ask

Please keep the env var named `CAVEMAN_SESSIONSTART_DUMP` on merge — downstream tooling (a local fallback hook we'd like to retire in favor of this flag) matches on the exact name.

## Testing

```bash
# Short mode (default):
$ node hooks/caveman-activate.js
CAVEMAN ACTIVE — level: full. Short mode. Set CAVEMAN_SESSIONSTART_DUMP=1 for full ruleset.

# Full mode (opt-in):
$ CAVEMAN_SESSIONSTART_DUMP=1 node hooks/caveman-activate.js
CAVEMAN MODE ACTIVE — level: full
[... full ruleset ...]
```

Both exit 0, flag file is written in both modes, statusline unaffected.