### PR TITLE
docs: refresh README banner artwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://em-content.zobj.net/source/apple/391/rock_1faa8.png" width="120" />
+  <img src="assets/readme-banner.png" alt="caveman banner" width="100%" />
 </p>
 
 <h1 align="center">caveman</h1>


### PR DESCRIPTION
## Summary
- replace the top README image with updated in-repo banner artwork
- add the banner asset as `assets/readme-banner.png` so the README stays self-contained

## Why
This is a very beautiful banner image that gives the project a much stronger first impression. It helps improve the README's visual polish and makes the project more compelling for sharing, discovery, and overall promotion.

## Testing
- verified the branch README now starts with the new banner image block
- verified the new banner asset is accessible from the branch
