### PR TITLE
Codex installers macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ caveman-compress.md
 .claude/worktrees/
 evals/snapshots/*.html
 evals/snapshots/*.png
+/.idea/

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Auto-activation is built in for Claude Code, Gemini CLI, and the repo-local Code
 > [!NOTE]
 > Auto-activation works differently per agent: Claude Code uses SessionStart hooks, this repo's Codex dogfood setup uses `.codex/hooks.json`, Gemini uses context files. Cursor/Windsurf/Cline/Copilot can be made always-on, but `npx skills add` installs only the skill, not the repo rule/instruction files.
 >
-> ¹ Codex uses `$caveman` syntax, not `/caveman`. This repo ships `.codex/hooks.json`, so caveman auto-starts when you run Codex inside this repo. The installed plugin itself gives you `$caveman`; copy the same hook into another repo if you want always-on behavior there too. caveman-commit and caveman-review are not in the Codex plugin bundle — use the SKILL.md files directly.
+> ¹ Codex uses `$caveman` syntax, not `/caveman`. This repo ships `.codex/hooks.json`, so caveman auto-starts when you run Codex inside this repo. The installed plugin itself gives you `$caveman`; copy the same hook into another repo if you want always-on behavior there too. caveman-commit and caveman-review are not in the Codex plugin bundle itself, though the macOS local-plugin installer below also installs those companion skills for convenience.
 > ² Add the "Want it always on?" snippet below to those agents' system prompt or rule file if you want session-start activation.
 > ³ Cursor and Windsurf receive the full SKILL.md with all intensity levels. Mode switching works on-demand via the skill; no slash command.
 > ⁴ Available in Claude Code, but plugin install only nudges setup. Standalone `install.sh` / `install.ps1` configures it automatically when no custom `statusLine` exists.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Auto-activation is built in for Claude Code, Gemini CLI, and the repo-local Code
 > [!NOTE]
 > Auto-activation works differently per agent: Claude Code uses SessionStart hooks, this repo's Codex dogfood setup uses `.codex/hooks.json`, Gemini uses context files. Cursor/Windsurf/Cline/Copilot can be made always-on, but `npx skills add` installs only the skill, not the repo rule/instruction files.
 >
-> ¹ Codex uses `$caveman` syntax, not `/caveman`. This repo ships `.codex/hooks.json`, so caveman auto-starts when you run Codex inside this repo. The installed plugin itself gives you `$caveman`; copy the same hook into another repo if you want always-on behavior there too. caveman-commit and caveman-review are not in the Codex plugin bundle itself, though the macOS local-plugin installer below also installs those companion skills for convenience.
+> ¹ Codex uses `$caveman` syntax, not `/caveman`. This repo ships `.codex/hooks.json`, so caveman auto-starts when you run Codex inside this repo. The installed plugin itself gives you `$caveman`; copy the same hook into another repo if you want always-on behavior there too. caveman-commit, caveman-review, and caveman-help are not in the Codex plugin bundle itself, though the macOS local-plugin installer below also installs those companion skills for convenience.
 > ² Add the "Want it always on?" snippet below to those agents' system prompt or rule file if you want session-start activation.
 > ³ Cursor and Windsurf receive the full SKILL.md with all intensity levels. Mode switching works on-demand via the skill; no slash command.
 > ⁴ Available in Claude Code, but plugin install only nudges setup. Standalone `install.sh` / `install.ps1` configures it automatically when no custom `statusLine` exists.

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Uninstall: `bash hooks/uninstall.sh` or `powershell -File hooks\uninstall.ps1`
 
 - Skills-only install: `curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/installers/codex/macos/skills-only/install.sh | bash`
 - Codex Desktop local-plugin install: `curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/installers/codex/macos/plugin-with-all-skills/install.sh | bash`
+- Skills-only uninstall (no prompt): `curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/installers/codex/macos/skills-only/uninstall.sh | bash -s -- --yes`
+- Codex Desktop local-plugin uninstall (no prompt): `curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/installers/codex/macos/plugin-with-all-skills/uninstall.sh | bash -s -- --yes`
 
 These direct-run installer scripts are for macOS. If you prefer manual steps, or if you are on Linux/Windows, use the instructions below.
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,13 @@ Uninstall: `bash hooks/uninstall.sh` or `powershell -File hooks\uninstall.ps1`
 <details>
 <summary><strong>Codex — full details</strong></summary>
 
+**macOS shortcut (no manual clone/download):**
+
+- Skills-only install: `curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/installers/codex/macos/skills-only/install.sh | bash`
+- Codex Desktop local-plugin install: `curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/installers/codex/macos/plugin-with-all-skills/install.sh | bash`
+
+These direct-run installer scripts are for macOS. If you prefer manual steps, or if you are on Linux/Windows, use the instructions below.
+
 **macOS / Linux:**
 1. Clone repo → Open Codex in the repo directory → `/plugins` → Search "Caveman" → Install
 2. Repo-local auto-start is already wired by `.codex/hooks.json` + `.codex/config.toml`

--- a/installers/codex/macos/README.md
+++ b/installers/codex/macos/README.md
@@ -14,7 +14,7 @@ Choose one. Most users should not install both.
 - you use Codex Desktop
 - you want Caveman to appear in Codex's local plugin marketplace
 - you want one plugin entry that contains all Caveman skills
-- you want plugin uninstall to remove plugin-managed skills together
+- you want plugin uninstall to remove plugin files cleanly
 
 ### Use `skills-only` if:
 
@@ -224,22 +224,16 @@ Behavior:
 - removes `caveman` entry from `~/.agents/plugins/marketplace.json`
 - deletes `~/.agents/plugins/marketplace.json` entirely if file becomes empty and still matches default local-marketplace shape
 - removes config section `[plugins."caveman@local-plugins"]` from `~/.codex/config.toml` if present
+- does not remove standalone skills under `~/.codex/skills`
 - removes empty parent dirs like `~/.agents/plugins`, `~/.codex/plugins/cache/local-plugins`, and `~/.agents` when they become empty
 
-## Important caveat about plugin uninstall
-
-`plugin-with-all-skills/uninstall.sh` also removes these standalone skill directories from `~/.codex/skills` if they exist:
-
-- `~/.codex/skills/caveman-commit`
-- `~/.codex/skills/caveman-help`
-- `~/.codex/skills/caveman-review`
-
-Script labels these as legacy standalone skills. If you intentionally installed those three outside plugin flow, uninstall will still delete them. README calls this out because behavior is easy to miss.
-
-It does **not** remove standalone:
+It leaves standalone installs untouched, including:
 
 - `~/.codex/skills/caveman`
 - `~/.codex/skills/compress`
+- `~/.codex/skills/caveman-commit`
+- `~/.codex/skills/caveman-help`
+- `~/.codex/skills/caveman-review`
 
 ## Recommended path
 

--- a/installers/codex/macos/README.md
+++ b/installers/codex/macos/README.md
@@ -4,6 +4,7 @@ This folder contains two macOS installer flows for Caveman:
 
 - `plugin-with-all-skills/`: installs Caveman as a local Codex plugin, with all shipped skills bundled under that plugin.
 - `skills-only/`: installs Caveman skills directly into your Codex skills directory, with no plugin marketplace integration.
+- `expunge-all-caveman-files.sh`: runs both uninstall flows with `--yes` so users can clear installer-managed Caveman files before a fresh install.
 
 Choose one. Most users should not install both.
 
@@ -178,6 +179,29 @@ Important differences:
 
 ## Uninstall
 
+### Full expunge
+
+Use this when you want highest-confidence cleanup before reinstalling.
+
+```sh
+chmod +x installers/codex/macos/expunge-all-caveman-files.sh
+installers/codex/macos/expunge-all-caveman-files.sh
+```
+
+Behavior:
+
+- runs `skills-only/uninstall.sh --yes`
+- runs `plugin-with-all-skills/uninstall.sh --yes`
+- removes anything those uninstallers manage, in one pass
+- prints `Nothing to do` where one install type is not present
+- tells you to restart Codex before fresh install
+
+Recommended use:
+
+- switching from one install mode to another
+- cleaning up partial installs
+- resetting machine before testing install docs
+
 ### Skills-only uninstall
 
 ```sh
@@ -301,6 +325,7 @@ Use one method per target. Running prompt flow after script flow usually hits ex
 
 ```text
 installers/codex/macos/
+├── expunge-all-caveman-files.sh
 ├── README.md
 ├── plugin-with-all-skills/
 │   ├── install.sh

--- a/installers/codex/macos/README.md
+++ b/installers/codex/macos/README.md
@@ -71,13 +71,14 @@ Needs:
 - `git`
 - `mv`
 - `mkdir`
+- `mktemp`
+- `rm`
 
 ### `skills-only/uninstall.sh`
 
 Needs:
 
 - `rm`
-- `rmdir`
 
 ### `plugin-with-all-skills/install.sh`
 
@@ -87,6 +88,8 @@ Needs:
 - `python3`
 - `mv`
 - `mkdir`
+- `mktemp`
+- `rm`
 
 ### `plugin-with-all-skills/uninstall.sh`
 

--- a/installers/codex/macos/README.md
+++ b/installers/codex/macos/README.md
@@ -1,12 +1,319 @@
+# Caveman Installers for Codex on macOS
 
+This folder contains two macOS installer flows for Caveman:
 
-# Install instructions for Codex Desktop and Codex CLI on macOS
+- `plugin-with-all-skills/`: installs Caveman as a local Codex plugin, with all shipped skills bundled under that plugin.
+- `skills-only/`: installs Caveman skills directly into your Codex skills directory, with no plugin marketplace integration.
 
-The install scripts or prompts should work in both Codex Desktop and Codex CLI. The prompt version of the installer was written by GPT-5.4 (High), so it should probably only be used with that version, although it will probably work with other model versions. 
+Choose one. Most users should not install both.
 
-## Option 1: Full Plugin Installer
-This installer installs all the skills as a single plugin, which provides additional functionality beyond just the skills.
+## Which installer should you use?
 
-## Option 2: All-in-1 Skills Only Installer
-This installer provides a simple way to get all caveman-related skills installed as Codex skills without any plugin integration. 
+### Use `plugin-with-all-skills` if:
 
+- you use Codex Desktop
+- you want Caveman to appear in Codex's local plugin marketplace
+- you want one plugin entry that contains all Caveman skills
+- you want plugin uninstall to remove plugin-managed skills together
+
+### Use `skills-only` if:
+
+- you want simplest install
+- you want plain skills under `~/.codex/skills`
+- you do not need plugin marketplace integration
+- you use Codex CLI or prefer direct skill install
+
+## What gets installed?
+
+### `skills-only`
+
+Installs these skill directories into `~/.codex/skills/`:
+
+- `caveman`
+- `compress`
+- `caveman-commit`
+- `caveman-help`
+- `caveman-review`
+
+### `plugin-with-all-skills`
+
+Installs local plugin at:
+
+- `~/.codex/plugins/caveman`
+
+That plugin contains these skills under `~/.codex/plugins/caveman/skills/`:
+
+- `caveman`
+- `compress`
+- `caveman-commit`
+- `caveman-help`
+- `caveman-review`
+
+It also adds local marketplace entry at:
+
+- `~/.agents/plugins/marketplace.json`
+
+After script finishes, plugin files exist locally but plugin is not fully active until you restart Codex and install `Caveman` from `Local Plugins` inside marketplace.
+
+## Requirements
+
+### Common
+
+- macOS
+- internet access to clone [github.com/JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman)
+- permission to write inside your home directory
+
+### `skills-only/install.sh`
+
+Needs:
+
+- `git`
+- `mv`
+- `mkdir`
+
+### `skills-only/uninstall.sh`
+
+Needs:
+
+- `rm`
+- `rmdir`
+
+### `plugin-with-all-skills/install.sh`
+
+Needs:
+
+- `git`
+- `python3`
+- `mv`
+- `mkdir`
+
+### `plugin-with-all-skills/uninstall.sh`
+
+Needs:
+
+- `python3`
+- `rm`
+- `rmdir`
+
+## Safety and overwrite behavior
+
+Both installers are conservative:
+
+- they clone only needed parts of repo with Git sparse checkout
+- they fail instead of overwriting existing target install
+- they verify expected files exist after install
+- they clean up temporary clone directory on exit
+
+### Existing install behavior
+
+`skills-only/install.sh` stops if any of these already exist:
+
+- `~/.codex/skills/caveman`
+- `~/.codex/skills/compress`
+- `~/.codex/skills/caveman-commit`
+- `~/.codex/skills/caveman-help`
+- `~/.codex/skills/caveman-review`
+
+`plugin-with-all-skills/install.sh` stops if this already exists:
+
+- `~/.codex/plugins/caveman`
+
+Neither installer offers in-place upgrade. If you want clean reinstall, uninstall first.
+
+## Script install
+
+Run from this directory or by absolute path.
+
+### Skills-only install
+
+```sh
+chmod +x installers/codex/macos/skills-only/install.sh
+installers/codex/macos/skills-only/install.sh
+```
+
+Result:
+
+- clones only required skill folders
+- creates `~/.codex/skills` if missing
+- moves five skill directories into `~/.codex/skills`
+- tells you to restart Codex
+
+### Plugin install
+
+```sh
+chmod +x installers/codex/macos/plugin-with-all-skills/install.sh
+installers/codex/macos/plugin-with-all-skills/install.sh
+```
+
+Result:
+
+- clones plugin subtree plus companion skill folders
+- creates `~/.codex/plugins` and `~/.agents/plugins` if missing
+- writes or updates `~/.agents/plugins/marketplace.json` with local `caveman` entry
+- installs plugin to `~/.codex/plugins/caveman`
+- moves companion skills into plugin's `skills/` directory
+- tells you to restart Codex, open marketplace, then install `Caveman` from `Local Plugins`
+
+## Prompt install
+
+Each installer folder also includes `prompt-install.md`.
+
+These files are not shell scripts. They are exact step-by-step prompts for Codex to perform install manually.
+
+Use prompt version if:
+
+- you want Codex to execute install for you
+- you prefer reviewed instructions over running shell script directly
+- you want same install logic expressed as agent workflow
+
+### Prompt files
+
+- `skills-only/prompt-install.md`
+- `plugin-with-all-skills/prompt-install.md`
+
+Important differences:
+
+- `skills-only/prompt-install.md` explicitly forbids writing under `~/.codex/plugins` or `~/.agents/plugins`
+- `plugin-with-all-skills/prompt-install.md` explicitly uses local plugin marketplace flow for Codex Desktop
+
+## Uninstall
+
+### Skills-only uninstall
+
+```sh
+chmod +x installers/codex/macos/skills-only/uninstall.sh
+installers/codex/macos/skills-only/uninstall.sh
+```
+
+Optional non-interactive mode:
+
+```sh
+installers/codex/macos/skills-only/uninstall.sh --yes
+```
+
+Behavior:
+
+- prompts for confirmation unless `--yes`
+- removes any of these if present:
+  - `~/.codex/skills/caveman`
+  - `~/.codex/skills/compress`
+  - `~/.codex/skills/caveman-commit`
+  - `~/.codex/skills/caveman-help`
+  - `~/.codex/skills/caveman-review`
+- prints `Nothing to do` if none exist
+- tells you to restart Codex if skills still appear in current session
+
+### Plugin uninstall
+
+```sh
+chmod +x installers/codex/macos/plugin-with-all-skills/uninstall.sh
+installers/codex/macos/plugin-with-all-skills/uninstall.sh
+```
+
+Optional non-interactive mode:
+
+```sh
+installers/codex/macos/plugin-with-all-skills/uninstall.sh --yes
+```
+
+Behavior:
+
+- prompts for confirmation unless `--yes`
+- removes plugin directory `~/.codex/plugins/caveman` if present
+- removes installed plugin cache at `~/.codex/plugins/cache/local-plugins/caveman` if present
+- removes `caveman` entry from `~/.agents/plugins/marketplace.json`
+- deletes `~/.agents/plugins/marketplace.json` entirely if file becomes empty and still matches default local-marketplace shape
+- removes config section `[plugins."caveman@local-plugins"]` from `~/.codex/config.toml` if present
+- removes empty parent dirs like `~/.agents/plugins`, `~/.codex/plugins/cache/local-plugins`, and `~/.agents` when they become empty
+
+## Important caveat about plugin uninstall
+
+`plugin-with-all-skills/uninstall.sh` also removes these standalone skill directories from `~/.codex/skills` if they exist:
+
+- `~/.codex/skills/caveman-commit`
+- `~/.codex/skills/caveman-help`
+- `~/.codex/skills/caveman-review`
+
+Script labels these as legacy standalone skills. If you intentionally installed those three outside plugin flow, uninstall will still delete them. README calls this out because behavior is easy to miss.
+
+It does **not** remove standalone:
+
+- `~/.codex/skills/caveman`
+- `~/.codex/skills/compress`
+
+## Recommended path
+
+### Best default
+
+Use `skills-only` if you want lowest-friction install.
+
+### Use plugin flow only when you specifically want:
+
+- Codex Desktop local plugin marketplace integration
+- one plugin container for all Caveman skills
+- plugin-style install/uninstall lifecycle
+
+## Verify install
+
+### Skills-only
+
+Check:
+
+- `~/.codex/skills/caveman/SKILL.md`
+- `~/.codex/skills/compress/SKILL.md`
+- `~/.codex/skills/caveman-commit/SKILL.md`
+- `~/.codex/skills/caveman-help/SKILL.md`
+- `~/.codex/skills/caveman-review/SKILL.md`
+
+Then restart Codex.
+
+### Plugin install
+
+Check:
+
+- `~/.codex/plugins/caveman/.codex-plugin/plugin.json`
+- `~/.codex/plugins/caveman/skills/caveman/SKILL.md`
+- `~/.codex/plugins/caveman/skills/compress/SKILL.md`
+- `~/.codex/plugins/caveman/skills/caveman-commit/SKILL.md`
+- `~/.codex/plugins/caveman/skills/caveman-help/SKILL.md`
+- `~/.codex/plugins/caveman/skills/caveman-review/SKILL.md`
+- `~/.agents/plugins/marketplace.json`
+
+Then:
+
+1. Restart Codex.
+2. Open plugin marketplace.
+3. Install `Caveman` from `Local Plugins`.
+
+## Troubleshooting
+
+### Error: target already exists
+
+You already have previous install or partial install at target path. Uninstall first, or remove conflicting install manually if you know what you are doing.
+
+### Error: missing required command
+
+Install missing dependency first. Script checks commands before doing real work.
+
+### Marketplace entry exists but plugin not visible
+
+Restart Codex first. Plugin flow depends on Codex reloading local marketplace after files land on disk.
+
+### Prompt install vs script install
+
+Use one method per target. Running prompt flow after script flow usually hits existing-path safety checks.
+
+## Folder map
+
+```text
+installers/codex/macos/
+├── README.md
+├── plugin-with-all-skills/
+│   ├── install.sh
+│   ├── prompt-install.md
+│   └── uninstall.sh
+└── skills-only/
+    ├── install.sh
+    ├── prompt-install.md
+    └── uninstall.sh
+```

--- a/installers/codex/macos/README.md
+++ b/installers/codex/macos/README.md
@@ -95,11 +95,16 @@ Needs:
 
 Needs:
 
-- `python3`
 - `rm`
 - `rmdir`
 - `ls`
 - `dirname`
+
+Optional:
+
+- `python3` for marketplace/config cleanup
+
+Without `python3`, uninstall still removes plugin files but skips marketplace/config edits and prints a warning.
 
 ## Safety and overwrite behavior
 

--- a/installers/codex/macos/README.md
+++ b/installers/codex/macos/README.md
@@ -203,6 +203,13 @@ Behavior:
 - prints `Nothing to do` where one install type is not present
 - tells you to restart Codex before fresh install
 
+Important note:
+
+- if you are working inside this `caveman` repo, Codex may still show `Caveman Repo` in plugin marketplace even after full expunge
+- that entry comes from repo-local source files in this workspace, not from installed user state
+- specifically, this repo includes `.agents/plugins/marketplace.json` and `plugins/caveman`
+- full expunge removes installed Caveman state under your home directory, but it does not remove source files that are part of this repo
+
 Recommended use:
 
 - switching from one install mode to another
@@ -251,12 +258,12 @@ Behavior:
 
 - prompts for confirmation unless `--yes`
 - removes plugin directory `~/.codex/plugins/caveman` if present
-- removes installed plugin cache at `~/.codex/plugins/cache/local-plugins/caveman` if present
+- removes installed plugin cache at any path matching `~/.codex/plugins/cache/*/caveman`
 - removes `caveman` entry from `~/.agents/plugins/marketplace.json`
 - deletes `~/.agents/plugins/marketplace.json` entirely if file becomes empty and still matches default local-marketplace shape
-- removes config section `[plugins."caveman@local-plugins"]` from `~/.codex/config.toml` if present
+- removes any config section matching `[plugins."caveman@..."]` from `~/.codex/config.toml`
 - does not remove standalone skills under `~/.codex/skills`
-- removes empty parent dirs like `~/.agents/plugins`, `~/.codex/plugins/cache/local-plugins`, and `~/.agents` when they become empty
+- removes empty parent dirs like `~/.agents/plugins`, empty Caveman cache parents under `~/.codex/plugins/cache`, and `~/.agents` when they become empty
 
 It leaves standalone installs untouched, including:
 

--- a/installers/codex/macos/README.md
+++ b/installers/codex/macos/README.md
@@ -98,6 +98,8 @@ Needs:
 - `python3`
 - `rm`
 - `rmdir`
+- `ls`
+- `dirname`
 
 ## Safety and overwrite behavior
 

--- a/installers/codex/macos/README.md
+++ b/installers/codex/macos/README.md
@@ -179,6 +179,13 @@ Important differences:
 
 ## Uninstall
 
+Prompt-based uninstall docs also exist:
+
+- `skills-only/prompt-uninstall.md`
+- `plugin-with-all-skills/prompt-uninstall.md`
+
+These are manual Codex prompts, not shell scripts.
+
 ### Full expunge
 
 Use this when you want highest-confidence cleanup before reinstalling.
@@ -330,9 +337,11 @@ installers/codex/macos/
 ├── plugin-with-all-skills/
 │   ├── install.sh
 │   ├── prompt-install.md
+│   ├── prompt-uninstall.md
 │   └── uninstall.sh
 └── skills-only/
     ├── install.sh
     ├── prompt-install.md
+    ├── prompt-uninstall.md
     └── uninstall.sh
 ```

--- a/installers/codex/macos/README.md
+++ b/installers/codex/macos/README.md
@@ -2,7 +2,7 @@
 
 # Install instructions for Codex Desktop and Codex CLI on macOS
 
-The codex-desktop scripts should work in both Codex Desktop and Codex CLI.
+The install scripts or prompts should work in both Codex Desktop and Codex CLI. The prompt version of the installer was written by GPT-5.4 (High), so it should probably only be used with that version, although it will probably work with other model versions. 
 
 ## Option 1: Full Plugin Installer
 This installer installs all the skills as a single plugin, which provides additional functionality beyond just the skills.

--- a/installers/codex/macos/README.md
+++ b/installers/codex/macos/README.md
@@ -1,0 +1,12 @@
+
+
+# Install instructions for Codex Desktop and Codex CLI on macOS
+
+The codex-desktop scripts should work in both Codex Desktop and Codex CLI.
+
+## Option 1: Full Plugin Installer
+This installer installs all the skills as a single plugin, which provides additional functionality beyond just the skills.
+
+## Option 2: All-in-1 Skills Only Installer
+This installer provides a simple way to get all caveman-related skills installed as Codex skills without any plugin integration. 
+

--- a/installers/codex/macos/expunge-all-caveman-files.sh
+++ b/installers/codex/macos/expunge-all-caveman-files.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Expunge all Caveman installer-managed files..."
+
+echo "Run skills-only uninstall..."
+"${SCRIPT_DIR}/skills-only/uninstall.sh" --yes
+
+echo "Run plugin uninstall..."
+"${SCRIPT_DIR}/plugin-with-all-skills/uninstall.sh" --yes
+
+echo
+echo "Expunge complete."
+echo "Restart Codex before fresh install."

--- a/installers/codex/macos/expunge-all-caveman-files.sh
+++ b/installers/codex/macos/expunge-all-caveman-files.sh
@@ -7,10 +7,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "Expunge all Caveman installer-managed files..."
 
 echo "Run skills-only uninstall..."
-"${SCRIPT_DIR}/skills-only/uninstall.sh" --yes
+bash "${SCRIPT_DIR}/skills-only/uninstall.sh" --yes
 
 echo "Run plugin uninstall..."
-"${SCRIPT_DIR}/plugin-with-all-skills/uninstall.sh" --yes
+bash "${SCRIPT_DIR}/plugin-with-all-skills/uninstall.sh" --yes
 
 echo
 echo "Expunge complete."

--- a/installers/codex/macos/plugin-with-all-skills/install.sh
+++ b/installers/codex/macos/plugin-with-all-skills/install.sh
@@ -8,10 +8,18 @@ TARGET_PLUGIN_DIR="${HOME}/.codex/plugins/${PLUGIN_NAME}"
 EXTRA_SKILLS=("caveman-commit" "caveman-help" "caveman-review")
 MARKETPLACE_DIR="${HOME}/.agents/plugins"
 MARKETPLACE_FILE="${MARKETPLACE_DIR}/marketplace.json"
-TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/caveman-install.XXXXXX")"
+TMP_DIR=""
+INSTALL_COMPLETE=0
+PLUGIN_INSTALLED=0
 
 cleanup() {
-  rm -rf "${TMP_DIR}"
+  if [ "${INSTALL_COMPLETE}" -eq 0 ] && [ "${PLUGIN_INSTALLED}" -eq 1 ] && [ -e "${TARGET_PLUGIN_DIR}" ]; then
+    rm -rf "${TARGET_PLUGIN_DIR}"
+  fi
+
+  if [ -n "${TMP_DIR}" ]; then
+    rm -rf "${TMP_DIR}"
+  fi
 }
 
 trap cleanup EXIT
@@ -29,12 +37,15 @@ need_cmd git
 need_cmd python3
 need_cmd mv
 need_cmd mkdir
+need_cmd mktemp
+need_cmd rm
 
 if [ -e "${TARGET_PLUGIN_DIR}" ]; then
   fail "${TARGET_PLUGIN_DIR} already exists. Stop before overwrite."
 fi
 
 echo "Clone caveman plugin and standalone skill subtrees..."
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/caveman-install.XXXXXX")"
 git clone --depth 1 --filter=blob:none --sparse "${REPO_URL}" "${TMP_DIR}/repo"
 git -C "${TMP_DIR}/repo" sparse-checkout set \
   "plugins/${PLUGIN_NAME}" \
@@ -53,6 +64,22 @@ done
 
 echo "Ensure local plugin directories exist..."
 mkdir -p "${HOME}/.codex/plugins" "${MARKETPLACE_DIR}"
+
+echo "Move plugin into Codex plugin directory..."
+mv "${PLUGIN_SRC_DIR}" "${TARGET_PLUGIN_DIR}"
+PLUGIN_INSTALLED=1
+
+echo "Move companion skills into plugin skills directory..."
+for skill in "${EXTRA_SKILLS[@]}"; do
+  mv "${TMP_DIR}/repo/skills/${skill}" "${TARGET_PLUGIN_DIR}/skills/${skill}"
+done
+
+[ -f "${TARGET_PLUGIN_DIR}/.codex-plugin/plugin.json" ] || fail "installed manifest missing"
+[ -f "${TARGET_PLUGIN_DIR}/skills/caveman/SKILL.md" ] || fail "installed caveman skill missing"
+[ -f "${TARGET_PLUGIN_DIR}/skills/compress/SKILL.md" ] || fail "installed compress skill missing"
+for skill in "${EXTRA_SKILLS[@]}"; do
+  [ -f "${TARGET_PLUGIN_DIR}/skills/${skill}/SKILL.md" ] || fail "installed companion skill missing: ${skill}"
+done
 
 echo "Update local marketplace..."
 python3 - "${MARKETPLACE_FILE}" <<'PY'
@@ -75,7 +102,12 @@ entry = {
 }
 
 if marketplace_path.exists():
-    data = json.loads(marketplace_path.read_text())
+    try:
+        data = json.loads(marketplace_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        raise SystemExit(f"marketplace file is not valid JSON: {marketplace_path}")
+    if not isinstance(data, dict):
+        raise SystemExit(f"marketplace file is not valid JSON: {marketplace_path}")
 else:
     data = {
         "name": "local-plugins",
@@ -89,32 +121,25 @@ if data.get("name") != "local-plugins":
     data["name"] = data.get("name") or "local-plugins"
 
 interface = data.setdefault("interface", {})
+if not isinstance(interface, dict):
+    interface = {}
+    data["interface"] = interface
 if not interface.get("displayName"):
     interface["displayName"] = "Local Plugins"
 
 plugins = data.setdefault("plugins", [])
-plugins = [plugin for plugin in plugins if plugin.get("name") != "caveman"]
+if not isinstance(plugins, list):
+    raise SystemExit(f"marketplace file is not valid JSON: {marketplace_path}")
+plugins = [plugin for plugin in plugins if isinstance(plugin, dict) and plugin.get("name") != "caveman"]
 plugins.append(entry)
 data["plugins"] = plugins
 
 marketplace_path.write_text(json.dumps(data, indent=2) + "\n")
 PY
 
-echo "Move plugin into Codex plugin directory..."
-mv "${PLUGIN_SRC_DIR}" "${TARGET_PLUGIN_DIR}"
-
-echo "Move companion skills into plugin skills directory..."
-for skill in "${EXTRA_SKILLS[@]}"; do
-  mv "${TMP_DIR}/repo/skills/${skill}" "${TARGET_PLUGIN_DIR}/skills/${skill}"
-done
-
-[ -f "${TARGET_PLUGIN_DIR}/.codex-plugin/plugin.json" ] || fail "installed manifest missing"
-[ -f "${TARGET_PLUGIN_DIR}/skills/caveman/SKILL.md" ] || fail "installed caveman skill missing"
-[ -f "${TARGET_PLUGIN_DIR}/skills/compress/SKILL.md" ] || fail "installed compress skill missing"
-for skill in "${EXTRA_SKILLS[@]}"; do
-  [ -f "${TARGET_PLUGIN_DIR}/skills/${skill}/SKILL.md" ] || fail "installed companion skill missing: ${skill}"
-done
 [ -f "${MARKETPLACE_FILE}" ] || fail "marketplace file missing"
+
+INSTALL_COMPLETE=1
 
 echo
 echo "Install complete."

--- a/installers/codex/macos/plugin-with-all-skills/install.sh
+++ b/installers/codex/macos/plugin-with-all-skills/install.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_URL="https://github.com/JuliusBrussee/caveman"
+PLUGIN_NAME="caveman"
+TARGET_PLUGIN_DIR="${HOME}/.codex/plugins/${PLUGIN_NAME}"
+EXTRA_SKILLS=("caveman-commit" "caveman-help" "caveman-review")
+MARKETPLACE_DIR="${HOME}/.agents/plugins"
+MARKETPLACE_FILE="${MARKETPLACE_DIR}/marketplace.json"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/caveman-install.XXXXXX")"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+
+trap cleanup EXIT
+
+fail() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+need_cmd git
+need_cmd python3
+need_cmd mv
+need_cmd mkdir
+
+if [ -e "${TARGET_PLUGIN_DIR}" ]; then
+  fail "${TARGET_PLUGIN_DIR} already exists. Stop before overwrite."
+fi
+
+echo "Clone caveman plugin and standalone skill subtrees..."
+git clone --depth 1 --filter=blob:none --sparse "${REPO_URL}" "${TMP_DIR}/repo"
+git -C "${TMP_DIR}/repo" sparse-checkout set \
+  "plugins/${PLUGIN_NAME}" \
+  "skills/caveman-commit" \
+  "skills/caveman-help" \
+  "skills/caveman-review"
+
+PLUGIN_SRC_DIR="${TMP_DIR}/repo/plugins/${PLUGIN_NAME}"
+
+[ -f "${PLUGIN_SRC_DIR}/.codex-plugin/plugin.json" ] || fail "missing plugin manifest"
+[ -f "${PLUGIN_SRC_DIR}/skills/caveman/SKILL.md" ] || fail "missing caveman skill"
+[ -f "${PLUGIN_SRC_DIR}/skills/compress/SKILL.md" ] || fail "missing compress skill"
+for skill in "${EXTRA_SKILLS[@]}"; do
+  [ -f "${TMP_DIR}/repo/skills/${skill}/SKILL.md" ] || fail "missing standalone skill: ${skill}"
+done
+
+echo "Ensure local plugin directories exist..."
+mkdir -p "${HOME}/.codex/plugins" "${MARKETPLACE_DIR}"
+
+echo "Update local marketplace..."
+python3 - "${MARKETPLACE_FILE}" <<'PY'
+import json
+import pathlib
+import sys
+
+marketplace_path = pathlib.Path(sys.argv[1])
+entry = {
+    "name": "caveman",
+    "source": {
+        "source": "local",
+        "path": "./.codex/plugins/caveman",
+    },
+    "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL",
+    },
+    "category": "Productivity",
+}
+
+if marketplace_path.exists():
+    data = json.loads(marketplace_path.read_text())
+else:
+    data = {
+        "name": "local-plugins",
+        "interface": {
+            "displayName": "Local Plugins",
+        },
+        "plugins": [],
+    }
+
+if data.get("name") != "local-plugins":
+    data["name"] = data.get("name") or "local-plugins"
+
+interface = data.setdefault("interface", {})
+if not interface.get("displayName"):
+    interface["displayName"] = "Local Plugins"
+
+plugins = data.setdefault("plugins", [])
+plugins = [plugin for plugin in plugins if plugin.get("name") != "caveman"]
+plugins.append(entry)
+data["plugins"] = plugins
+
+marketplace_path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+
+echo "Move plugin into Codex plugin directory..."
+mv "${PLUGIN_SRC_DIR}" "${TARGET_PLUGIN_DIR}"
+
+echo "Move companion skills into plugin skills directory..."
+for skill in "${EXTRA_SKILLS[@]}"; do
+  mv "${TMP_DIR}/repo/skills/${skill}" "${TARGET_PLUGIN_DIR}/skills/${skill}"
+done
+
+[ -f "${TARGET_PLUGIN_DIR}/.codex-plugin/plugin.json" ] || fail "installed manifest missing"
+[ -f "${TARGET_PLUGIN_DIR}/skills/caveman/SKILL.md" ] || fail "installed caveman skill missing"
+[ -f "${TARGET_PLUGIN_DIR}/skills/compress/SKILL.md" ] || fail "installed compress skill missing"
+for skill in "${EXTRA_SKILLS[@]}"; do
+  [ -f "${TARGET_PLUGIN_DIR}/skills/${skill}/SKILL.md" ] || fail "installed companion skill missing: ${skill}"
+done
+[ -f "${MARKETPLACE_FILE}" ] || fail "marketplace file missing"
+
+echo
+echo "Install complete."
+echo "Next:"
+echo "1. Restart Codex."
+echo "2. Open plugin marketplace."
+echo "3. Install 'Caveman' from 'Local Plugins'."

--- a/installers/codex/macos/plugin-with-all-skills/install.sh
+++ b/installers/codex/macos/plugin-with-all-skills/install.sh
@@ -117,8 +117,8 @@ else:
         "plugins": [],
     }
 
-if data.get("name") != "local-plugins":
-    data["name"] = data.get("name") or "local-plugins"
+if not data.get("name"):
+    data["name"] = "local-plugins"
 
 interface = data.setdefault("interface", {})
 if not isinstance(interface, dict):

--- a/installers/codex/macos/plugin-with-all-skills/install.sh
+++ b/installers/codex/macos/plugin-with-all-skills/install.sh
@@ -85,7 +85,9 @@ echo "Update local marketplace..."
 python3 - "${MARKETPLACE_FILE}" <<'PY'
 import json
 import pathlib
+import shutil
 import sys
+import tempfile
 
 marketplace_path = pathlib.Path(sys.argv[1])
 entry = {
@@ -101,6 +103,13 @@ entry = {
     "category": "Productivity",
 }
 
+def write_atomic(path: pathlib.Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp:
+        tmp.write(content)
+        tmp_path = pathlib.Path(tmp.name)
+    tmp_path.replace(path)
+
 if marketplace_path.exists():
     try:
         data = json.loads(marketplace_path.read_text())
@@ -108,6 +117,7 @@ if marketplace_path.exists():
         raise SystemExit(f"marketplace file is not valid JSON: {marketplace_path}")
     if not isinstance(data, dict):
         raise SystemExit(f"marketplace file is not valid JSON: {marketplace_path}")
+    shutil.copy2(marketplace_path, pathlib.Path(f"{marketplace_path}.bak"))
 else:
     data = {
         "name": "local-plugins",
@@ -134,7 +144,7 @@ plugins = [plugin for plugin in plugins if isinstance(plugin, dict) and plugin.g
 plugins.append(entry)
 data["plugins"] = plugins
 
-marketplace_path.write_text(json.dumps(data, indent=2) + "\n")
+write_atomic(marketplace_path, json.dumps(data, indent=2) + "\n")
 PY
 
 [ -f "${MARKETPLACE_FILE}" ] || fail "marketplace file missing"

--- a/installers/codex/macos/plugin-with-all-skills/prompt-install.md
+++ b/installers/codex/macos/plugin-with-all-skills/prompt-install.md
@@ -50,7 +50,7 @@ Follow these steps exactly:
    }
    ```
 
-4. If `~/.agents/plugins/marketplace.json` already exists, do not overwrite whole file. Merge new `caveman` entry into existing `plugins` array with same values shown above.
+4. If `~/.agents/plugins/marketplace.json` already exists, do not overwrite whole file. Merge new `caveman` entry into existing `plugins` array with same values shown above, and leave existing top-level fields unchanged.
 
 5. Ensure parent directories exist:
 
@@ -89,6 +89,7 @@ Follow these steps exactly:
 Important constraints:
    - If `~/.codex/plugins/caveman` already exists, stop and ask before overwriting.
    - Use local plugin path `./.codex/plugins/caveman` exactly.
-   - Keep marketplace name `local-plugins` and display name `Local Plugins`.
+   - If creating new `~/.agents/plugins/marketplace.json`, use marketplace name `local-plugins` and display name `Local Plugins`.
+   - If `~/.agents/plugins/marketplace.json` already exists, preserve its existing top-level fields and only merge `caveman` into `plugins`.
    - This flow stages plugin plus companion skills locally first, then Codex picks it up after restart.
    - Companion skills must live under `~/.codex/plugins/caveman/skills/` so uninstalling plugin removes them too.

--- a/installers/codex/macos/plugin-with-all-skills/prompt-install.md
+++ b/installers/codex/macos/plugin-with-all-skills/prompt-install.md
@@ -1,0 +1,94 @@
+# Caveman Codex Desktop App Install Prompt
+
+Install the `caveman` Codex plugin from https://github.com/JuliusBrussee/caveman using the exact manual local-plugin flow below. Do not use a generic skill installer. Do not invent a different plugin path.
+
+Follow these steps exactly:
+
+1. Inspect the repo and confirm it contains:
+   - Codex plugin files:
+   - `plugins/caveman/.codex-plugin/plugin.json`
+   - `plugins/caveman/skills/caveman/SKILL.md`
+   - `plugins/caveman/skills/compress/SKILL.md`
+   - companion skills that will be copied into plugin `skills/` directory:
+   - `skills/caveman-commit/SKILL.md`
+   - `skills/caveman-help/SKILL.md`
+   - `skills/caveman-review/SKILL.md`
+
+2. Clone only the needed plugin and companion skill subtrees into workspace scratch:
+
+   ```sh
+   git clone --depth 1 --filter=blob:none --sparse https://github.com/JuliusBrussee/caveman <workspace>/.tmp/caveman-repo
+   git -C <workspace>/.tmp/caveman-repo sparse-checkout set \
+     plugins/caveman \
+     skills/caveman-commit \
+     skills/caveman-help \
+     skills/caveman-review
+   ```
+
+3. Create the local marketplace file at `~/.agents/plugins/marketplace.json` with this exact JSON if the file does not already exist:
+
+   ```json
+   {
+     "name": "local-plugins",
+     "interface": {
+       "displayName": "Local Plugins"
+     },
+     "plugins": [
+       {
+         "name": "caveman",
+         "source": {
+           "source": "local",
+           "path": "./.codex/plugins/caveman"
+         },
+         "policy": {
+           "installation": "AVAILABLE",
+           "authentication": "ON_INSTALL"
+         },
+         "category": "Productivity"
+       }
+     ]
+   }
+   ```
+
+4. If `~/.agents/plugins/marketplace.json` already exists, do not overwrite whole file. Merge new `caveman` entry into existing `plugins` array with same values shown above.
+
+5. Ensure parent directories exist:
+
+   ```sh
+   mkdir -p ~/.codex/plugins ~/.agents/plugins
+   ```
+
+6. Move extracted plugin directory into final Codex plugin path:
+
+   ```sh
+   mv <workspace>/.tmp/caveman-repo/plugins/caveman ~/.codex/plugins/caveman
+   ```
+
+7. Move companion skills into plugin skills path so they install/uninstall as part of main plugin:
+
+   ```sh
+   mv <workspace>/.tmp/caveman-repo/skills/caveman-commit ~/.codex/plugins/caveman/skills/caveman-commit
+   mv <workspace>/.tmp/caveman-repo/skills/caveman-help ~/.codex/plugins/caveman/skills/caveman-help
+   mv <workspace>/.tmp/caveman-repo/skills/caveman-review ~/.codex/plugins/caveman/skills/caveman-review
+   ```
+
+8. Verify install by checking these files exist:
+   - `~/.codex/plugins/caveman/.codex-plugin/plugin.json`
+   - `~/.codex/plugins/caveman/skills/caveman/SKILL.md`
+   - `~/.codex/plugins/caveman/skills/compress/SKILL.md`
+   - `~/.codex/plugins/caveman/skills/caveman-commit/SKILL.md`
+   - `~/.codex/plugins/caveman/skills/caveman-help/SKILL.md`
+   - `~/.codex/plugins/caveman/skills/caveman-review/SKILL.md`
+   - `~/.agents/plugins/marketplace.json`
+
+9. Tell the user final step:
+   - Restart Codex so it reloads local marketplace.
+   - Open plugin marketplace.
+   - Install `Caveman` from `Local Plugins`.
+
+Important constraints:
+   - If `~/.codex/plugins/caveman` already exists, stop and ask before overwriting.
+   - Use local plugin path `./.codex/plugins/caveman` exactly.
+   - Keep marketplace name `local-plugins` and display name `Local Plugins`.
+   - This flow stages plugin plus companion skills locally first, then Codex picks it up after restart.
+   - Companion skills must live under `~/.codex/plugins/caveman/skills/` so uninstalling plugin removes them too.

--- a/installers/codex/macos/plugin-with-all-skills/prompt-uninstall.md
+++ b/installers/codex/macos/plugin-with-all-skills/prompt-uninstall.md
@@ -1,0 +1,55 @@
+# Caveman Codex Desktop App Uninstall Prompt
+
+Remove Caveman local Codex plugin installed through local marketplace flow. Do not remove standalone skills from `~/.codex/skills`.
+
+Follow these steps exactly:
+
+1. Check whether any of these Caveman plugin artifacts exist:
+   - `~/.codex/plugins/caveman`
+   - `~/.codex/plugins/cache/local-plugins/caveman`
+   - `~/.agents/plugins/marketplace.json` containing plugin entry named `caveman`
+   - `~/.codex/config.toml` containing section `[plugins."caveman@local-plugins"]`
+
+2. If none exist, tell user:
+   - `Caveman not installed. Nothing to do.`
+   - Stop.
+
+3. Ask for confirmation before deleting anything unless user already made clear they want removal now.
+
+4. If `~/.agents/plugins/marketplace.json` exists:
+   - remove plugin entry named `caveman` from its `plugins` array
+   - if file becomes empty and still matches default local marketplace shape:
+     - `name` = `local-plugins`
+     - `interface.displayName` = `Local Plugins`
+     - `plugins` = empty
+     then delete `~/.agents/plugins/marketplace.json`
+
+5. If `~/.codex/config.toml` exists and contains `[plugins."caveman@local-plugins"]`:
+   - remove that whole TOML section
+
+6. Remove these directories if they exist:
+
+   ```sh
+   rm -rf ~/.codex/plugins/caveman
+   rm -rf ~/.codex/plugins/cache/local-plugins/caveman
+   ```
+
+7. Remove these parent directories only if they exist and are empty:
+   - `~/.agents/plugins`
+   - `~/.codex/plugins/cache/local-plugins`
+   - `~/.agents`
+
+8. Verify:
+   - `~/.codex/plugins/caveman` does not exist
+   - `~/.codex/plugins/cache/local-plugins/caveman` does not exist
+   - `~/.agents/plugins/marketplace.json` does not contain plugin entry named `caveman`
+   - `~/.codex/config.toml` does not contain section `[plugins."caveman@local-plugins"]`
+
+9. Tell user final step:
+   - Restart Codex if plugin still appears in current session.
+
+Important constraints:
+   - Do not remove anything from `~/.codex/skills`.
+   - Do not remove unrelated local plugin entries from `~/.agents/plugins/marketplace.json`.
+   - Only remove empty parent directories.
+   - Use local plugin name `caveman` and config section `[plugins."caveman@local-plugins"]` exactly.

--- a/installers/codex/macos/plugin-with-all-skills/prompt-uninstall.md
+++ b/installers/codex/macos/plugin-with-all-skills/prompt-uninstall.md
@@ -1,14 +1,14 @@
 # Caveman Codex Desktop App Uninstall Prompt
 
-Remove Caveman local Codex plugin installed through local marketplace flow. Do not remove standalone skills from `~/.codex/skills`.
+Remove Caveman Codex plugin state completely. This includes local-plugin installs and marketplace-installed Caveman cache/config state. Do not remove standalone skills from `~/.codex/skills`.
 
 Follow these steps exactly:
 
 1. Check whether any of these Caveman plugin artifacts exist:
    - `~/.codex/plugins/caveman`
-   - `~/.codex/plugins/cache/local-plugins/caveman`
+   - any cache path matching `~/.codex/plugins/cache/*/caveman`
    - `~/.agents/plugins/marketplace.json` containing plugin entry named `caveman`
-   - `~/.codex/config.toml` containing section `[plugins."caveman@local-plugins"]`
+   - `~/.codex/config.toml` containing any section matching `[plugins."caveman@..."]`
 
 2. If none exist, tell user:
    - `Caveman not installed. Nothing to do.`
@@ -24,26 +24,26 @@ Follow these steps exactly:
      - `plugins` = empty
      then delete `~/.agents/plugins/marketplace.json`
 
-5. If `~/.codex/config.toml` exists and contains `[plugins."caveman@local-plugins"]`:
-   - remove that whole TOML section
+5. If `~/.codex/config.toml` exists and contains any section matching `[plugins."caveman@..."]`:
+   - remove every such Caveman plugin section
 
 6. Remove these directories if they exist:
 
    ```sh
    rm -rf ~/.codex/plugins/caveman
-   rm -rf ~/.codex/plugins/cache/local-plugins/caveman
+   rm -rf ~/.codex/plugins/cache/*/caveman
    ```
 
 7. Remove these parent directories only if they exist and are empty:
    - `~/.agents/plugins`
-   - `~/.codex/plugins/cache/local-plugins`
+   - any now-empty parent under `~/.codex/plugins/cache/*`
    - `~/.agents`
 
 8. Verify:
    - `~/.codex/plugins/caveman` does not exist
-   - `~/.codex/plugins/cache/local-plugins/caveman` does not exist
+   - no cache path matching `~/.codex/plugins/cache/*/caveman` exists
    - `~/.agents/plugins/marketplace.json` does not contain plugin entry named `caveman`
-   - `~/.codex/config.toml` does not contain section `[plugins."caveman@local-plugins"]`
+   - `~/.codex/config.toml` does not contain any section matching `[plugins."caveman@..."]`
 
 9. Tell user final step:
    - Restart Codex if plugin still appears in current session.
@@ -52,4 +52,4 @@ Important constraints:
    - Do not remove anything from `~/.codex/skills`.
    - Do not remove unrelated local plugin entries from `~/.agents/plugins/marketplace.json`.
    - Only remove empty parent directories.
-   - Use local plugin name `caveman` and config section `[plugins."caveman@local-plugins"]` exactly.
+   - Remove Caveman plugin state regardless of marketplace source suffix after `@`.

--- a/installers/codex/macos/plugin-with-all-skills/uninstall.sh
+++ b/installers/codex/macos/plugin-with-all-skills/uninstall.sh
@@ -51,6 +51,8 @@ done
 need_cmd python3
 need_cmd rm
 need_cmd rmdir
+need_cmd ls
+need_cmd dirname
 
 shopt -s nullglob
 
@@ -79,7 +81,16 @@ try:
 except Exception:
     raise SystemExit(2)
 
-for plugin in data.get("plugins", []):
+if not isinstance(data, dict):
+    raise SystemExit(2)
+
+plugins_value = data.get("plugins", [])
+if not isinstance(plugins_value, list):
+    raise SystemExit(2)
+
+for plugin in plugins_value:
+    if not isinstance(plugin, dict):
+        continue
     if plugin.get("name") == "caveman":
         raise SystemExit(0)
 
@@ -131,7 +142,18 @@ import sys
 
 marketplace_path = pathlib.Path(sys.argv[1])
 data = json.loads(marketplace_path.read_text())
-plugins = [plugin for plugin in data.get("plugins", []) if plugin.get("name") != "caveman"]
+if not isinstance(data, dict):
+    raise SystemExit(f"marketplace file is not valid JSON: {marketplace_path}")
+
+plugins_value = data.get("plugins", [])
+if not isinstance(plugins_value, list):
+    raise SystemExit(f"marketplace file is not valid JSON: {marketplace_path}")
+
+plugins = [
+    plugin
+    for plugin in plugins_value
+    if isinstance(plugin, dict) and plugin.get("name") != "caveman"
+]
 data["plugins"] = plugins
 
 delete_file = (
@@ -156,6 +178,7 @@ import sys
 
 config_path = pathlib.Path(sys.argv[1])
 pattern = re.compile(r'^\[plugins\."caveman@[^"]+"\]$')
+section_header_pattern = re.compile(r'^\[\[?(?:[A-Za-z_"\'][^\]]*)\]\]?$')
 lines = config_path.read_text().splitlines(keepends=True)
 
 result = []
@@ -165,7 +188,7 @@ for line in lines:
     if not skip and pattern.match(stripped):
         skip = True
         continue
-    if skip and stripped.startswith("["):
+    if skip and section_header_pattern.match(stripped) and "=" not in stripped and "," not in stripped:
         skip = False
     if not skip:
         result.append(line)
@@ -217,7 +240,16 @@ import json
 import sys
 
 data = json.load(open(sys.argv[1]))
-for plugin in data.get("plugins", []):
+if not isinstance(data, dict):
+    raise SystemExit(2)
+
+plugins_value = data.get("plugins", [])
+if not isinstance(plugins_value, list):
+    raise SystemExit(2)
+
+for plugin in plugins_value:
+    if not isinstance(plugin, dict):
+        continue
     if plugin.get("name") == "caveman":
         raise SystemExit(1)
 raise SystemExit(0)
@@ -225,6 +257,10 @@ PY
   then
     :
   else
+    status=$?
+    if [ "${status}" -eq 2 ]; then
+      fail "marketplace file is not valid JSON: ${MARKETPLACE_FILE}"
+    fi
     fail "marketplace still contains caveman entry"
   fi
 fi

--- a/installers/codex/macos/plugin-with-all-skills/uninstall.sh
+++ b/installers/codex/macos/plugin-with-all-skills/uninstall.sh
@@ -168,13 +168,12 @@ def write_atomic(path: pathlib.Path, content: str) -> None:
     tmp_path.replace(path)
 
 delete_file = (
-    not plugins
-    and data.get("name") == "local-plugins"
-    and (
-        data.get("interface", {}).get("displayName")
-        if isinstance(data.get("interface"), dict)
-        else None
-    ) == "Local Plugins"
+    data
+    == {
+        "name": "local-plugins",
+        "interface": {"displayName": "Local Plugins"},
+        "plugins": [],
+    }
 )
 
 if delete_file:
@@ -202,11 +201,14 @@ result = []
 skip = False
 for line in lines:
     stripped = line.strip()
-    if not skip and pattern.match(stripped):
+    if pattern.match(stripped):
         skip = True
         continue
-    if skip and section_header_pattern.match(stripped):
-        skip = False
+    if skip:
+        if section_header_pattern.match(stripped):
+            skip = False
+        else:
+            continue
     if not skip:
         result.append(line)
 
@@ -225,23 +227,27 @@ if [ -e "${TARGET_PLUGIN_DIR}" ]; then
   rm -rf "${TARGET_PLUGIN_DIR}"
 fi
 
-for cached_plugin_dir in "${CACHED_PLUGIN_DIRS[@]}"; do
-  if [ -e "${cached_plugin_dir}" ]; then
-    echo "Remove installed plugin cache ${cached_plugin_dir}..."
-    rm -rf "${cached_plugin_dir}"
-  fi
-done
+if [ "${#CACHED_PLUGIN_DIRS[@]}" -gt 0 ]; then
+  for cached_plugin_dir in "${CACHED_PLUGIN_DIRS[@]}"; do
+    if [ -e "${cached_plugin_dir}" ]; then
+      echo "Remove installed plugin cache ${cached_plugin_dir}..."
+      rm -rf "${cached_plugin_dir}"
+    fi
+  done
+fi
 
 if [ -d "${MARKETPLACE_DIR}" ] && [ -z "$(ls -A "${MARKETPLACE_DIR}")" ]; then
   rmdir "${MARKETPLACE_DIR}"
 fi
 
-for cached_plugin_dir in "${CACHED_PLUGIN_DIRS[@]}"; do
-  cached_marketplace_dir="$(dirname "${cached_plugin_dir}")"
-  if [ -d "${cached_marketplace_dir}" ] && [ -z "$(ls -A "${cached_marketplace_dir}")" ]; then
-    rmdir "${cached_marketplace_dir}"
-  fi
-done
+if [ "${#CACHED_PLUGIN_DIRS[@]}" -gt 0 ]; then
+  for cached_plugin_dir in "${CACHED_PLUGIN_DIRS[@]}"; do
+    cached_marketplace_dir="$(dirname "${cached_plugin_dir}")"
+    if [ -d "${cached_marketplace_dir}" ] && [ -z "$(ls -A "${cached_marketplace_dir}")" ]; then
+      rmdir "${cached_marketplace_dir}"
+    fi
+  done
+fi
 
 if [ -d "${HOME}/.agents" ] && [ -z "$(ls -A "${HOME}/.agents")" ]; then
   rmdir "${HOME}/.agents"
@@ -251,11 +257,13 @@ if [ -e "${TARGET_PLUGIN_DIR}" ]; then
   fail "plugin directory still exists: ${TARGET_PLUGIN_DIR}"
 fi
 
-for cached_plugin_dir in "${CACHED_PLUGIN_DIRS[@]}"; do
-  if [ -e "${cached_plugin_dir}" ]; then
-    fail "installed cache still exists: ${cached_plugin_dir}"
-  fi
-done
+if [ "${#CACHED_PLUGIN_DIRS[@]}" -gt 0 ]; then
+  for cached_plugin_dir in "${CACHED_PLUGIN_DIRS[@]}"; do
+    if [ -e "${cached_plugin_dir}" ]; then
+      fail "installed cache still exists: ${cached_plugin_dir}"
+    fi
+  done
+fi
 
 if [ -f "${MARKETPLACE_FILE}" ]; then
   if python3 - "${MARKETPLACE_FILE}" <<'PY'

--- a/installers/codex/macos/plugin-with-all-skills/uninstall.sh
+++ b/installers/codex/macos/plugin-with-all-skills/uninstall.sh
@@ -6,8 +6,6 @@ PLUGIN_NAME="caveman"
 TARGET_PLUGIN_DIR="${HOME}/.codex/plugins/${PLUGIN_NAME}"
 CACHED_PLUGIN_DIR="${HOME}/.codex/plugins/cache/local-plugins/${PLUGIN_NAME}"
 CACHED_MARKETPLACE_DIR="${HOME}/.codex/plugins/cache/local-plugins"
-TARGET_SKILLS_DIR="${HOME}/.codex/skills"
-EXTRA_SKILLS=("caveman-commit" "caveman-help" "caveman-review")
 MARKETPLACE_DIR="${HOME}/.agents/plugins"
 MARKETPLACE_FILE="${MARKETPLACE_DIR}/marketplace.json"
 CODEX_CONFIG_FILE="${HOME}/.codex/config.toml"
@@ -59,7 +57,6 @@ PLUGIN_EXISTS=0
 MARKETPLACE_HAS_ENTRY=0
 CONFIG_HAS_ENTRY=0
 CACHED_PLUGIN_EXISTS=0
-STANDALONE_SKILLS_EXIST=0
 
 if [ -e "${TARGET_PLUGIN_DIR}" ]; then
   PLUGIN_EXISTS=1
@@ -68,12 +65,6 @@ fi
 if [ -e "${CACHED_PLUGIN_DIR}" ]; then
   CACHED_PLUGIN_EXISTS=1
 fi
-
-for skill in "${EXTRA_SKILLS[@]}"; do
-  if [ -e "${TARGET_SKILLS_DIR}/${skill}" ]; then
-    STANDALONE_SKILLS_EXIST=1
-  fi
-done
 
 if [ -f "${MARKETPLACE_FILE}" ]; then
   if python3 - "${MARKETPLACE_FILE}" <<'PY'
@@ -121,7 +112,7 @@ PY
   fi
 fi
 
-if [ "${PLUGIN_EXISTS}" -eq 0 ] && [ "${MARKETPLACE_HAS_ENTRY}" -eq 0 ] && [ "${CONFIG_HAS_ENTRY}" -eq 0 ] && [ "${CACHED_PLUGIN_EXISTS}" -eq 0 ] && [ "${STANDALONE_SKILLS_EXIST}" -eq 0 ]; then
+if [ "${PLUGIN_EXISTS}" -eq 0 ] && [ "${MARKETPLACE_HAS_ENTRY}" -eq 0 ] && [ "${CONFIG_HAS_ENTRY}" -eq 0 ] && [ "${CACHED_PLUGIN_EXISTS}" -eq 0 ]; then
   echo "Caveman not installed. Nothing to do."
   exit 0
 fi
@@ -189,13 +180,6 @@ if [ -e "${CACHED_PLUGIN_DIR}" ]; then
   rm -rf "${CACHED_PLUGIN_DIR}"
 fi
 
-for skill in "${EXTRA_SKILLS[@]}"; do
-  if [ -e "${TARGET_SKILLS_DIR}/${skill}" ]; then
-    echo "Remove legacy standalone skill ${skill}..."
-    rm -rf "${TARGET_SKILLS_DIR}/${skill}"
-  fi
-done
-
 if [ -d "${MARKETPLACE_DIR}" ] && [ -z "$(ls -A "${MARKETPLACE_DIR}")" ]; then
   rmdir "${MARKETPLACE_DIR}"
 fi
@@ -215,12 +199,6 @@ fi
 if [ -e "${CACHED_PLUGIN_DIR}" ]; then
   fail "installed cache still exists: ${CACHED_PLUGIN_DIR}"
 fi
-
-for skill in "${EXTRA_SKILLS[@]}"; do
-  if [ -e "${TARGET_SKILLS_DIR}/${skill}" ]; then
-    fail "legacy standalone skill still exists: ${TARGET_SKILLS_DIR}/${skill}"
-  fi
-done
 
 if [ -f "${MARKETPLACE_FILE}" ]; then
   if python3 - "${MARKETPLACE_FILE}" <<'PY'

--- a/installers/codex/macos/plugin-with-all-skills/uninstall.sh
+++ b/installers/codex/macos/plugin-with-all-skills/uninstall.sh
@@ -112,7 +112,7 @@ import re
 import sys
 
 path = sys.argv[1]
-pattern = re.compile(r'^\[plugins\."caveman@[^"]+"\]$')
+pattern = re.compile(r'^\[plugins\."caveman@[^"]+"\s*\]\s*(?:#.*)?$')
 
 with open(path, "r", encoding="utf-8") as f:
     for line in f:
@@ -138,7 +138,9 @@ if [ -f "${MARKETPLACE_FILE}" ] && [ "${MARKETPLACE_HAS_ENTRY}" -eq 1 ]; then
   python3 - "${MARKETPLACE_FILE}" <<'PY'
 import json
 import pathlib
+import shutil
 import sys
+import tempfile
 
 marketplace_path = pathlib.Path(sys.argv[1])
 data = json.loads(marketplace_path.read_text())
@@ -156,6 +158,15 @@ plugins = [
 ]
 data["plugins"] = plugins
 
+backup_path = pathlib.Path(f"{marketplace_path}.bak")
+shutil.copy2(marketplace_path, backup_path)
+
+def write_atomic(path: pathlib.Path, content: str) -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp:
+        tmp.write(content)
+        tmp_path = pathlib.Path(tmp.name)
+    tmp_path.replace(path)
+
 delete_file = (
     not plugins
     and data.get("name") == "local-plugins"
@@ -165,7 +176,7 @@ delete_file = (
 if delete_file:
     marketplace_path.unlink()
 else:
-    marketplace_path.write_text(json.dumps(data, indent=2) + "\n")
+    write_atomic(marketplace_path, json.dumps(data, indent=2) + "\n")
 PY
 fi
 
@@ -174,10 +185,12 @@ if [ -f "${CODEX_CONFIG_FILE}" ] && [ "${CONFIG_HAS_ENTRY}" -eq 1 ]; then
   python3 - "${CODEX_CONFIG_FILE}" <<'PY'
 import pathlib
 import re
+import shutil
 import sys
+import tempfile
 
 config_path = pathlib.Path(sys.argv[1])
-pattern = re.compile(r'^\[plugins\."caveman@[^"]+"\]$')
+pattern = re.compile(r'^\[plugins\."caveman@[^"]+"\s*\]\s*(?:#.*)?$')
 section_header_pattern = re.compile(r'^\[\[?[^\]]+\]\]?$')
 lines = config_path.read_text().splitlines(keepends=True)
 
@@ -193,7 +206,13 @@ for line in lines:
     if not skip:
         result.append(line)
 
-config_path.write_text("".join(result))
+shutil.copy2(config_path, pathlib.Path(f"{config_path}.bak"))
+
+with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=config_path.parent, delete=False) as tmp:
+    tmp.write("".join(result))
+    tmp_path = pathlib.Path(tmp.name)
+
+tmp_path.replace(config_path)
 PY
 fi
 
@@ -271,7 +290,7 @@ import re
 import sys
 
 path = sys.argv[1]
-pattern = re.compile(r'^\[plugins\."caveman@[^"]+"\]$')
+pattern = re.compile(r'^\[plugins\."caveman@[^"]+"\s*\]\s*(?:#.*)?$')
 
 with open(path, "r", encoding="utf-8") as f:
     for line in f:

--- a/installers/codex/macos/plugin-with-all-skills/uninstall.sh
+++ b/installers/codex/macos/plugin-with-all-skills/uninstall.sh
@@ -25,7 +25,7 @@ confirm() {
   fi
 
   printf "Remove Caveman plugin from Codex? [y/N] "
-  read -r reply
+  read -r reply || reply=""
   case "${reply}" in
     y|Y|yes|YES)
       return 0

--- a/installers/codex/macos/plugin-with-all-skills/uninstall.sh
+++ b/installers/codex/macos/plugin-with-all-skills/uninstall.sh
@@ -15,6 +15,10 @@ fail() {
   exit 1
 }
 
+warn() {
+  echo "Warning: $*" >&2
+}
+
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
 }
@@ -48,11 +52,15 @@ for arg in "$@"; do
   esac
 done
 
-need_cmd python3
 need_cmd rm
 need_cmd rmdir
 need_cmd ls
 need_cmd dirname
+
+PYTHON_AVAILABLE=0
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_AVAILABLE=1
+fi
 
 shopt -s nullglob
 
@@ -60,6 +68,8 @@ PLUGIN_EXISTS=0
 MARKETPLACE_HAS_ENTRY=0
 CONFIG_HAS_ENTRY=0
 CACHED_PLUGIN_EXISTS=0
+PYTHON_SKIPPED_MARKETPLACE=0
+PYTHON_SKIPPED_CONFIG=0
 CACHED_PLUGIN_DIRS=( "${CACHE_ROOT_DIR}"/*/"${PLUGIN_NAME}" )
 
 if [ -e "${TARGET_PLUGIN_DIR}" ]; then
@@ -71,7 +81,8 @@ if [ "${#CACHED_PLUGIN_DIRS[@]}" -gt 0 ]; then
 fi
 
 if [ -f "${MARKETPLACE_FILE}" ]; then
-  if python3 - "${MARKETPLACE_FILE}" <<'PY'
+  if [ "${PYTHON_AVAILABLE}" -eq 1 ]; then
+    if python3 - "${MARKETPLACE_FILE}" <<'PY'
 import json
 import sys
 
@@ -96,18 +107,23 @@ for plugin in plugins_value:
 
 raise SystemExit(1)
 PY
-  then
-    MARKETPLACE_HAS_ENTRY=1
-  else
-    status=$?
-    if [ "${status}" -eq 2 ]; then
-      fail "marketplace file is not valid JSON: ${MARKETPLACE_FILE}"
+    then
+      MARKETPLACE_HAS_ENTRY=1
+    else
+      status=$?
+      if [ "${status}" -eq 2 ]; then
+        fail "marketplace file is not valid JSON: ${MARKETPLACE_FILE}"
+      fi
     fi
+  else
+    PYTHON_SKIPPED_MARKETPLACE=1
+    warn "python3 not found; skipping marketplace cleanup: ${MARKETPLACE_FILE}"
   fi
 fi
 
 if [ -f "${CODEX_CONFIG_FILE}" ]; then
-  if python3 - "${CODEX_CONFIG_FILE}" <<'PY'
+  if [ "${PYTHON_AVAILABLE}" -eq 1 ]; then
+    if python3 - "${CODEX_CONFIG_FILE}" <<'PY'
 import re
 import sys
 
@@ -121,12 +137,16 @@ with open(path, "r", encoding="utf-8") as f:
 
 raise SystemExit(1)
 PY
-  then
-    CONFIG_HAS_ENTRY=1
+    then
+      CONFIG_HAS_ENTRY=1
+    fi
+  else
+    PYTHON_SKIPPED_CONFIG=1
+    warn "python3 not found; skipping Codex config cleanup: ${CODEX_CONFIG_FILE}"
   fi
 fi
 
-if [ "${PLUGIN_EXISTS}" -eq 0 ] && [ "${MARKETPLACE_HAS_ENTRY}" -eq 0 ] && [ "${CONFIG_HAS_ENTRY}" -eq 0 ] && [ "${CACHED_PLUGIN_EXISTS}" -eq 0 ]; then
+if [ "${PLUGIN_EXISTS}" -eq 0 ] && [ "${MARKETPLACE_HAS_ENTRY}" -eq 0 ] && [ "${CONFIG_HAS_ENTRY}" -eq 0 ] && [ "${CACHED_PLUGIN_EXISTS}" -eq 0 ] && [ "${PYTHON_SKIPPED_MARKETPLACE}" -eq 0 ] && [ "${PYTHON_SKIPPED_CONFIG}" -eq 0 ]; then
   echo "Caveman not installed. Nothing to do."
   exit 0
 fi
@@ -265,7 +285,7 @@ if [ "${#CACHED_PLUGIN_DIRS[@]}" -gt 0 ]; then
   done
 fi
 
-if [ -f "${MARKETPLACE_FILE}" ]; then
+if [ "${PYTHON_AVAILABLE}" -eq 1 ] && [ -f "${MARKETPLACE_FILE}" ]; then
   if python3 - "${MARKETPLACE_FILE}" <<'PY'
 import json
 import sys
@@ -296,7 +316,7 @@ PY
   fi
 fi
 
-if [ -f "${CODEX_CONFIG_FILE}" ]; then
+if [ "${PYTHON_AVAILABLE}" -eq 1 ] && [ -f "${CODEX_CONFIG_FILE}" ]; then
   if python3 - "${CODEX_CONFIG_FILE}" <<'PY'
 import re
 import sys
@@ -319,5 +339,8 @@ PY
 fi
 
 echo
+if [ "${PYTHON_SKIPPED_MARKETPLACE}" -eq 1 ] || [ "${PYTHON_SKIPPED_CONFIG}" -eq 1 ]; then
+  echo "Skipped marketplace/config cleanup because python3 is not available."
+fi
 echo "Uninstall complete."
 echo "Restart Codex if plugin still appears in current session."

--- a/installers/codex/macos/plugin-with-all-skills/uninstall.sh
+++ b/installers/codex/macos/plugin-with-all-skills/uninstall.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PLUGIN_NAME="caveman"
+TARGET_PLUGIN_DIR="${HOME}/.codex/plugins/${PLUGIN_NAME}"
+CACHED_PLUGIN_DIR="${HOME}/.codex/plugins/cache/local-plugins/${PLUGIN_NAME}"
+CACHED_MARKETPLACE_DIR="${HOME}/.codex/plugins/cache/local-plugins"
+TARGET_SKILLS_DIR="${HOME}/.codex/skills"
+EXTRA_SKILLS=("caveman-commit" "caveman-help" "caveman-review")
+MARKETPLACE_DIR="${HOME}/.agents/plugins"
+MARKETPLACE_FILE="${MARKETPLACE_DIR}/marketplace.json"
+CODEX_CONFIG_FILE="${HOME}/.codex/config.toml"
+ASSUME_YES=0
+
+fail() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+confirm() {
+  if [ "${ASSUME_YES}" -eq 1 ]; then
+    return 0
+  fi
+
+  printf "Remove Caveman plugin from Codex? [y/N] "
+  read -r reply
+  case "${reply}" in
+    y|Y|yes|YES)
+      return 0
+      ;;
+    *)
+      echo "Cancelled."
+      exit 0
+      ;;
+  esac
+}
+
+for arg in "$@"; do
+  case "${arg}" in
+    --yes)
+      ASSUME_YES=1
+      ;;
+    *)
+      fail "unknown argument: ${arg}"
+      ;;
+  esac
+done
+
+need_cmd python3
+need_cmd rm
+need_cmd rmdir
+
+PLUGIN_EXISTS=0
+MARKETPLACE_HAS_ENTRY=0
+CONFIG_HAS_ENTRY=0
+CACHED_PLUGIN_EXISTS=0
+STANDALONE_SKILLS_EXIST=0
+
+if [ -e "${TARGET_PLUGIN_DIR}" ]; then
+  PLUGIN_EXISTS=1
+fi
+
+if [ -e "${CACHED_PLUGIN_DIR}" ]; then
+  CACHED_PLUGIN_EXISTS=1
+fi
+
+for skill in "${EXTRA_SKILLS[@]}"; do
+  if [ -e "${TARGET_SKILLS_DIR}/${skill}" ]; then
+    STANDALONE_SKILLS_EXIST=1
+  fi
+done
+
+if [ -f "${MARKETPLACE_FILE}" ]; then
+  if python3 - "${MARKETPLACE_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    data = json.load(open(path))
+except Exception:
+    raise SystemExit(2)
+
+for plugin in data.get("plugins", []):
+    if plugin.get("name") == "caveman":
+        raise SystemExit(0)
+
+raise SystemExit(1)
+PY
+  then
+    MARKETPLACE_HAS_ENTRY=1
+  else
+    status=$?
+    if [ "${status}" -eq 2 ]; then
+      fail "marketplace file is not valid JSON: ${MARKETPLACE_FILE}"
+    fi
+  fi
+fi
+
+if [ -f "${CODEX_CONFIG_FILE}" ]; then
+  if python3 - "${CODEX_CONFIG_FILE}" <<'PY'
+import sys
+
+path = sys.argv[1]
+target = '[plugins."caveman@local-plugins"]'
+
+with open(path, "r", encoding="utf-8") as f:
+    for line in f:
+        if line.strip() == target:
+            raise SystemExit(0)
+
+raise SystemExit(1)
+PY
+  then
+    CONFIG_HAS_ENTRY=1
+  fi
+fi
+
+if [ "${PLUGIN_EXISTS}" -eq 0 ] && [ "${MARKETPLACE_HAS_ENTRY}" -eq 0 ] && [ "${CONFIG_HAS_ENTRY}" -eq 0 ] && [ "${CACHED_PLUGIN_EXISTS}" -eq 0 ] && [ "${STANDALONE_SKILLS_EXIST}" -eq 0 ]; then
+  echo "Caveman not installed. Nothing to do."
+  exit 0
+fi
+
+confirm
+
+if [ -f "${MARKETPLACE_FILE}" ]; then
+  echo "Update marketplace..."
+  python3 - "${MARKETPLACE_FILE}" <<'PY'
+import json
+import pathlib
+import sys
+
+marketplace_path = pathlib.Path(sys.argv[1])
+data = json.loads(marketplace_path.read_text())
+plugins = [plugin for plugin in data.get("plugins", []) if plugin.get("name") != "caveman"]
+data["plugins"] = plugins
+
+delete_file = (
+    not plugins
+    and data.get("name") == "local-plugins"
+    and data.get("interface", {}).get("displayName") == "Local Plugins"
+)
+
+if delete_file:
+    marketplace_path.unlink()
+else:
+    marketplace_path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+fi
+
+if [ -f "${CODEX_CONFIG_FILE}" ]; then
+  echo "Update Codex config..."
+  python3 - "${CODEX_CONFIG_FILE}" <<'PY'
+import pathlib
+import sys
+
+config_path = pathlib.Path(sys.argv[1])
+target = '[plugins."caveman@local-plugins"]'
+lines = config_path.read_text().splitlines(keepends=True)
+
+result = []
+skip = False
+for line in lines:
+    stripped = line.strip()
+    if not skip and stripped == target:
+        skip = True
+        continue
+    if skip and stripped.startswith("["):
+        skip = False
+    if not skip:
+        result.append(line)
+
+config_path.write_text("".join(result))
+PY
+fi
+
+if [ -e "${TARGET_PLUGIN_DIR}" ]; then
+  echo "Remove plugin directory..."
+  rm -rf "${TARGET_PLUGIN_DIR}"
+fi
+
+if [ -e "${CACHED_PLUGIN_DIR}" ]; then
+  echo "Remove installed plugin cache..."
+  rm -rf "${CACHED_PLUGIN_DIR}"
+fi
+
+for skill in "${EXTRA_SKILLS[@]}"; do
+  if [ -e "${TARGET_SKILLS_DIR}/${skill}" ]; then
+    echo "Remove legacy standalone skill ${skill}..."
+    rm -rf "${TARGET_SKILLS_DIR}/${skill}"
+  fi
+done
+
+if [ -d "${MARKETPLACE_DIR}" ] && [ -z "$(ls -A "${MARKETPLACE_DIR}")" ]; then
+  rmdir "${MARKETPLACE_DIR}"
+fi
+
+if [ -d "${CACHED_MARKETPLACE_DIR}" ] && [ -z "$(ls -A "${CACHED_MARKETPLACE_DIR}")" ]; then
+  rmdir "${CACHED_MARKETPLACE_DIR}"
+fi
+
+if [ -d "${HOME}/.agents" ] && [ -z "$(ls -A "${HOME}/.agents")" ]; then
+  rmdir "${HOME}/.agents"
+fi
+
+if [ -e "${TARGET_PLUGIN_DIR}" ]; then
+  fail "plugin directory still exists: ${TARGET_PLUGIN_DIR}"
+fi
+
+if [ -e "${CACHED_PLUGIN_DIR}" ]; then
+  fail "installed cache still exists: ${CACHED_PLUGIN_DIR}"
+fi
+
+for skill in "${EXTRA_SKILLS[@]}"; do
+  if [ -e "${TARGET_SKILLS_DIR}/${skill}" ]; then
+    fail "legacy standalone skill still exists: ${TARGET_SKILLS_DIR}/${skill}"
+  fi
+done
+
+if [ -f "${MARKETPLACE_FILE}" ]; then
+  if python3 - "${MARKETPLACE_FILE}" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1]))
+for plugin in data.get("plugins", []):
+    if plugin.get("name") == "caveman":
+        raise SystemExit(1)
+raise SystemExit(0)
+PY
+  then
+    :
+  else
+    fail "marketplace still contains caveman entry"
+  fi
+fi
+
+if [ -f "${CODEX_CONFIG_FILE}" ]; then
+  if python3 - "${CODEX_CONFIG_FILE}" <<'PY'
+import sys
+
+path = sys.argv[1]
+target = '[plugins."caveman@local-plugins"]'
+
+with open(path, "r", encoding="utf-8") as f:
+    for line in f:
+        if line.strip() == target:
+            raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+  then
+    :
+  else
+    fail "Codex config still contains caveman plugin entry"
+  fi
+fi
+
+echo
+echo "Uninstall complete."
+echo "Restart Codex if plugin still appears in current session."

--- a/installers/codex/macos/plugin-with-all-skills/uninstall.sh
+++ b/installers/codex/macos/plugin-with-all-skills/uninstall.sh
@@ -112,7 +112,8 @@ PY
     else
       status=$?
       if [ "${status}" -eq 2 ]; then
-        fail "marketplace file is not valid JSON: ${MARKETPLACE_FILE}"
+        PYTHON_SKIPPED_MARKETPLACE=1
+        warn "marketplace file is not valid JSON; skipping marketplace cleanup: ${MARKETPLACE_FILE}"
       fi
     fi
   else
@@ -290,7 +291,11 @@ if [ "${PYTHON_AVAILABLE}" -eq 1 ] && [ -f "${MARKETPLACE_FILE}" ]; then
 import json
 import sys
 
-data = json.load(open(sys.argv[1]))
+try:
+    data = json.load(open(sys.argv[1]))
+except Exception:
+    raise SystemExit(2)
+
 if not isinstance(data, dict):
     raise SystemExit(2)
 
@@ -310,9 +315,11 @@ PY
   else
     status=$?
     if [ "${status}" -eq 2 ]; then
-      fail "marketplace file is not valid JSON: ${MARKETPLACE_FILE}"
+      warn "marketplace file is not valid JSON; skipping marketplace verification: ${MARKETPLACE_FILE}"
+      :
+    else
+      fail "marketplace still contains caveman entry"
     fi
-    fail "marketplace still contains caveman entry"
   fi
 fi
 

--- a/installers/codex/macos/plugin-with-all-skills/uninstall.sh
+++ b/installers/codex/macos/plugin-with-all-skills/uninstall.sh
@@ -133,7 +133,7 @@ fi
 
 confirm
 
-if [ -f "${MARKETPLACE_FILE}" ]; then
+if [ -f "${MARKETPLACE_FILE}" ] && [ "${MARKETPLACE_HAS_ENTRY}" -eq 1 ]; then
   echo "Update marketplace..."
   python3 - "${MARKETPLACE_FILE}" <<'PY'
 import json
@@ -169,7 +169,7 @@ else:
 PY
 fi
 
-if [ -f "${CODEX_CONFIG_FILE}" ]; then
+if [ -f "${CODEX_CONFIG_FILE}" ] && [ "${CONFIG_HAS_ENTRY}" -eq 1 ]; then
   echo "Update Codex config..."
   python3 - "${CODEX_CONFIG_FILE}" <<'PY'
 import pathlib
@@ -178,7 +178,7 @@ import sys
 
 config_path = pathlib.Path(sys.argv[1])
 pattern = re.compile(r'^\[plugins\."caveman@[^"]+"\]$')
-section_header_pattern = re.compile(r'^\[\[?(?:[A-Za-z_"\'][^\]]*)\]\]?$')
+section_header_pattern = re.compile(r'^\[\[?[^\]]+\]\]?$')
 lines = config_path.read_text().splitlines(keepends=True)
 
 result = []
@@ -188,7 +188,7 @@ for line in lines:
     if not skip and pattern.match(stripped):
         skip = True
         continue
-    if skip and section_header_pattern.match(stripped) and "=" not in stripped and "," not in stripped:
+    if skip and section_header_pattern.match(stripped):
         skip = False
     if not skip:
         result.append(line)

--- a/installers/codex/macos/plugin-with-all-skills/uninstall.sh
+++ b/installers/codex/macos/plugin-with-all-skills/uninstall.sh
@@ -170,7 +170,11 @@ def write_atomic(path: pathlib.Path, content: str) -> None:
 delete_file = (
     not plugins
     and data.get("name") == "local-plugins"
-    and data.get("interface", {}).get("displayName") == "Local Plugins"
+    and (
+        data.get("interface", {}).get("displayName")
+        if isinstance(data.get("interface"), dict)
+        else None
+    ) == "Local Plugins"
 )
 
 if delete_file:
@@ -191,7 +195,7 @@ import tempfile
 
 config_path = pathlib.Path(sys.argv[1])
 pattern = re.compile(r'^\[plugins\."caveman@[^"]+"\s*\]\s*(?:#.*)?$')
-section_header_pattern = re.compile(r'^\[\[?[^\]]+\]\]?$')
+section_header_pattern = re.compile(r'^\[\[?[^\]]+\]\]?\s*(?:#.*)?$')
 lines = config_path.read_text().splitlines(keepends=True)
 
 result = []

--- a/installers/codex/macos/plugin-with-all-skills/uninstall.sh
+++ b/installers/codex/macos/plugin-with-all-skills/uninstall.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 
 PLUGIN_NAME="caveman"
 TARGET_PLUGIN_DIR="${HOME}/.codex/plugins/${PLUGIN_NAME}"
-CACHED_PLUGIN_DIR="${HOME}/.codex/plugins/cache/local-plugins/${PLUGIN_NAME}"
-CACHED_MARKETPLACE_DIR="${HOME}/.codex/plugins/cache/local-plugins"
+CACHE_ROOT_DIR="${HOME}/.codex/plugins/cache"
 MARKETPLACE_DIR="${HOME}/.agents/plugins"
 MARKETPLACE_FILE="${MARKETPLACE_DIR}/marketplace.json"
 CODEX_CONFIG_FILE="${HOME}/.codex/config.toml"
@@ -53,16 +52,19 @@ need_cmd python3
 need_cmd rm
 need_cmd rmdir
 
+shopt -s nullglob
+
 PLUGIN_EXISTS=0
 MARKETPLACE_HAS_ENTRY=0
 CONFIG_HAS_ENTRY=0
 CACHED_PLUGIN_EXISTS=0
+CACHED_PLUGIN_DIRS=( "${CACHE_ROOT_DIR}"/*/"${PLUGIN_NAME}" )
 
 if [ -e "${TARGET_PLUGIN_DIR}" ]; then
   PLUGIN_EXISTS=1
 fi
 
-if [ -e "${CACHED_PLUGIN_DIR}" ]; then
+if [ "${#CACHED_PLUGIN_DIRS[@]}" -gt 0 ]; then
   CACHED_PLUGIN_EXISTS=1
 fi
 
@@ -95,14 +97,15 @@ fi
 
 if [ -f "${CODEX_CONFIG_FILE}" ]; then
   if python3 - "${CODEX_CONFIG_FILE}" <<'PY'
+import re
 import sys
 
 path = sys.argv[1]
-target = '[plugins."caveman@local-plugins"]'
+pattern = re.compile(r'^\[plugins\."caveman@[^"]+"\]$')
 
 with open(path, "r", encoding="utf-8") as f:
     for line in f:
-        if line.strip() == target:
+        if pattern.match(line.strip()):
             raise SystemExit(0)
 
 raise SystemExit(1)
@@ -148,17 +151,18 @@ if [ -f "${CODEX_CONFIG_FILE}" ]; then
   echo "Update Codex config..."
   python3 - "${CODEX_CONFIG_FILE}" <<'PY'
 import pathlib
+import re
 import sys
 
 config_path = pathlib.Path(sys.argv[1])
-target = '[plugins."caveman@local-plugins"]'
+pattern = re.compile(r'^\[plugins\."caveman@[^"]+"\]$')
 lines = config_path.read_text().splitlines(keepends=True)
 
 result = []
 skip = False
 for line in lines:
     stripped = line.strip()
-    if not skip and stripped == target:
+    if not skip and pattern.match(stripped):
         skip = True
         continue
     if skip and stripped.startswith("["):
@@ -175,18 +179,23 @@ if [ -e "${TARGET_PLUGIN_DIR}" ]; then
   rm -rf "${TARGET_PLUGIN_DIR}"
 fi
 
-if [ -e "${CACHED_PLUGIN_DIR}" ]; then
-  echo "Remove installed plugin cache..."
-  rm -rf "${CACHED_PLUGIN_DIR}"
-fi
+for cached_plugin_dir in "${CACHED_PLUGIN_DIRS[@]}"; do
+  if [ -e "${cached_plugin_dir}" ]; then
+    echo "Remove installed plugin cache ${cached_plugin_dir}..."
+    rm -rf "${cached_plugin_dir}"
+  fi
+done
 
 if [ -d "${MARKETPLACE_DIR}" ] && [ -z "$(ls -A "${MARKETPLACE_DIR}")" ]; then
   rmdir "${MARKETPLACE_DIR}"
 fi
 
-if [ -d "${CACHED_MARKETPLACE_DIR}" ] && [ -z "$(ls -A "${CACHED_MARKETPLACE_DIR}")" ]; then
-  rmdir "${CACHED_MARKETPLACE_DIR}"
-fi
+for cached_plugin_dir in "${CACHED_PLUGIN_DIRS[@]}"; do
+  cached_marketplace_dir="$(dirname "${cached_plugin_dir}")"
+  if [ -d "${cached_marketplace_dir}" ] && [ -z "$(ls -A "${cached_marketplace_dir}")" ]; then
+    rmdir "${cached_marketplace_dir}"
+  fi
+done
 
 if [ -d "${HOME}/.agents" ] && [ -z "$(ls -A "${HOME}/.agents")" ]; then
   rmdir "${HOME}/.agents"
@@ -196,9 +205,11 @@ if [ -e "${TARGET_PLUGIN_DIR}" ]; then
   fail "plugin directory still exists: ${TARGET_PLUGIN_DIR}"
 fi
 
-if [ -e "${CACHED_PLUGIN_DIR}" ]; then
-  fail "installed cache still exists: ${CACHED_PLUGIN_DIR}"
-fi
+for cached_plugin_dir in "${CACHED_PLUGIN_DIRS[@]}"; do
+  if [ -e "${cached_plugin_dir}" ]; then
+    fail "installed cache still exists: ${cached_plugin_dir}"
+  fi
+done
 
 if [ -f "${MARKETPLACE_FILE}" ]; then
   if python3 - "${MARKETPLACE_FILE}" <<'PY'
@@ -220,14 +231,15 @@ fi
 
 if [ -f "${CODEX_CONFIG_FILE}" ]; then
   if python3 - "${CODEX_CONFIG_FILE}" <<'PY'
+import re
 import sys
 
 path = sys.argv[1]
-target = '[plugins."caveman@local-plugins"]'
+pattern = re.compile(r'^\[plugins\."caveman@[^"]+"\]$')
 
 with open(path, "r", encoding="utf-8") as f:
     for line in f:
-        if line.strip() == target:
+        if pattern.match(line.strip()):
             raise SystemExit(1)
 
 raise SystemExit(0)

--- a/installers/codex/macos/skills-only/install.sh
+++ b/installers/codex/macos/skills-only/install.sh
@@ -5,10 +5,20 @@ set -euo pipefail
 REPO_URL="https://github.com/JuliusBrussee/caveman"
 TARGET_SKILLS_DIR="${HOME}/.codex/skills"
 SKILLS=("caveman" "compress" "caveman-commit" "caveman-help" "caveman-review")
-TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/caveman-skill-only.XXXXXX")"
+TMP_DIR=""
+INSTALL_COMPLETE=0
+INSTALLED_SKILLS=()
 
 cleanup() {
-  rm -rf "${TMP_DIR}"
+  if [ "${INSTALL_COMPLETE}" -eq 0 ]; then
+    for skill in "${INSTALLED_SKILLS[@]}"; do
+      rm -rf "${TARGET_SKILLS_DIR}/${skill}"
+    done
+  fi
+
+  if [ -n "${TMP_DIR}" ]; then
+    rm -rf "${TMP_DIR}"
+  fi
 }
 
 trap cleanup EXIT
@@ -25,6 +35,8 @@ need_cmd() {
 need_cmd git
 need_cmd mv
 need_cmd mkdir
+need_cmd mktemp
+need_cmd rm
 
 for skill in "${SKILLS[@]}"; do
   if [ -e "${TARGET_SKILLS_DIR}/${skill}" ]; then
@@ -33,6 +45,7 @@ for skill in "${SKILLS[@]}"; do
 done
 
 echo "Clone caveman skill subtrees..."
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/caveman-skill-only.XXXXXX")"
 git clone --depth 1 --filter=blob:none --sparse "${REPO_URL}" "${TMP_DIR}/repo"
 git -C "${TMP_DIR}/repo" sparse-checkout set \
   "skills/caveman" \
@@ -51,11 +64,14 @@ mkdir -p "${TARGET_SKILLS_DIR}"
 echo "Move skills into Codex skills directory..."
 for skill in "${SKILLS[@]}"; do
   mv "${TMP_DIR}/repo/skills/${skill}" "${TARGET_SKILLS_DIR}/${skill}"
+  INSTALLED_SKILLS+=("${skill}")
 done
 
 for skill in "${SKILLS[@]}"; do
   [ -f "${TARGET_SKILLS_DIR}/${skill}/SKILL.md" ] || fail "installed skill missing: ${skill}"
 done
+
+INSTALL_COMPLETE=1
 
 echo
 echo "Install complete."

--- a/installers/codex/macos/skills-only/install.sh
+++ b/installers/codex/macos/skills-only/install.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_URL="https://github.com/JuliusBrussee/caveman"
+TARGET_SKILLS_DIR="${HOME}/.codex/skills"
+SKILLS=("caveman" "compress" "caveman-commit" "caveman-help" "caveman-review")
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/caveman-skill-only.XXXXXX")"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+
+trap cleanup EXIT
+
+fail() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+need_cmd git
+need_cmd mv
+need_cmd mkdir
+
+for skill in "${SKILLS[@]}"; do
+  if [ -e "${TARGET_SKILLS_DIR}/${skill}" ]; then
+    fail "${TARGET_SKILLS_DIR}/${skill} already exists. Stop before overwrite."
+  fi
+done
+
+echo "Clone caveman skill subtrees..."
+git clone --depth 1 --filter=blob:none --sparse "${REPO_URL}" "${TMP_DIR}/repo"
+git -C "${TMP_DIR}/repo" sparse-checkout set \
+  "skills/caveman" \
+  "skills/compress" \
+  "skills/caveman-commit" \
+  "skills/caveman-help" \
+  "skills/caveman-review"
+
+for skill in "${SKILLS[@]}"; do
+  [ -f "${TMP_DIR}/repo/skills/${skill}/SKILL.md" ] || fail "missing skill: ${skill}"
+done
+
+echo "Ensure Codex skills directory exists..."
+mkdir -p "${TARGET_SKILLS_DIR}"
+
+echo "Move skills into Codex skills directory..."
+for skill in "${SKILLS[@]}"; do
+  mv "${TMP_DIR}/repo/skills/${skill}" "${TARGET_SKILLS_DIR}/${skill}"
+done
+
+for skill in "${SKILLS[@]}"; do
+  [ -f "${TARGET_SKILLS_DIR}/${skill}/SKILL.md" ] || fail "installed skill missing: ${skill}"
+done
+
+echo
+echo "Install complete."
+echo "Next:"
+echo "1. Restart Codex."

--- a/installers/codex/macos/skills-only/prompt-install.md
+++ b/installers/codex/macos/skills-only/prompt-install.md
@@ -1,0 +1,63 @@
+# Caveman Codex Skill-Only Install Prompt
+
+Install Caveman from https://github.com/JuliusBrussee/caveman as plain Codex skills only. Do not install any plugin files. Do not write anything under `~/.codex/plugins` or `~/.agents/plugins`.
+
+Follow these steps exactly:
+
+1. Inspect repo and confirm it contains these top-level skills:
+   - `skills/caveman/SKILL.md`
+   - `skills/compress/SKILL.md`
+   - `skills/caveman-commit/SKILL.md`
+   - `skills/caveman-help/SKILL.md`
+   - `skills/caveman-review/SKILL.md`
+
+2. Clone only needed skill subtrees into workspace scratch:
+
+   ```sh
+   git clone --depth 1 --filter=blob:none --sparse https://github.com/JuliusBrussee/caveman <workspace>/.tmp/caveman-repo
+   git -C <workspace>/.tmp/caveman-repo sparse-checkout set \
+     skills/caveman \
+     skills/compress \
+     skills/caveman-commit \
+     skills/caveman-help \
+     skills/caveman-review
+   ```
+
+3. Ensure Codex skills directory exists:
+
+   ```sh
+   mkdir -p ~/.codex/skills
+   ```
+
+4. If any target skill already exists, stop and ask before overwriting:
+   - `~/.codex/skills/caveman`
+   - `~/.codex/skills/compress`
+   - `~/.codex/skills/caveman-commit`
+   - `~/.codex/skills/caveman-help`
+   - `~/.codex/skills/caveman-review`
+
+5. Move extracted skill directories into final Codex skills path:
+
+   ```sh
+   mv <workspace>/.tmp/caveman-repo/skills/caveman ~/.codex/skills/caveman
+   mv <workspace>/.tmp/caveman-repo/skills/compress ~/.codex/skills/compress
+   mv <workspace>/.tmp/caveman-repo/skills/caveman-commit ~/.codex/skills/caveman-commit
+   mv <workspace>/.tmp/caveman-repo/skills/caveman-help ~/.codex/skills/caveman-help
+   mv <workspace>/.tmp/caveman-repo/skills/caveman-review ~/.codex/skills/caveman-review
+   ```
+
+6. Verify install by checking these files exist:
+   - `~/.codex/skills/caveman/SKILL.md`
+   - `~/.codex/skills/compress/SKILL.md`
+   - `~/.codex/skills/caveman-commit/SKILL.md`
+   - `~/.codex/skills/caveman-help/SKILL.md`
+   - `~/.codex/skills/caveman-review/SKILL.md`
+
+7. Tell user final step:
+   - Restart Codex so new skills are discovered cleanly.
+
+Important constraints:
+   - Install only into `~/.codex/skills`.
+   - Do not create plugin marketplace entries.
+   - Do not create `~/.codex/plugins/caveman`.
+   - Do not modify `~/.codex/config.toml` for plugin enablement.

--- a/installers/codex/macos/skills-only/prompt-uninstall.md
+++ b/installers/codex/macos/skills-only/prompt-uninstall.md
@@ -1,0 +1,44 @@
+# Caveman Codex Skill-Only Uninstall Prompt
+
+Remove Caveman plain Codex skills from `~/.codex/skills`. Do not remove any plugin files. Do not write anything under `~/.codex/plugins` or `~/.agents/plugins`.
+
+Follow these steps exactly:
+
+1. Check whether any of these paths exist:
+   - `~/.codex/skills/caveman`
+   - `~/.codex/skills/compress`
+   - `~/.codex/skills/caveman-commit`
+   - `~/.codex/skills/caveman-help`
+   - `~/.codex/skills/caveman-review`
+
+2. If none exist, tell user:
+   - `Caveman skill-only install not found. Nothing to do.`
+   - Stop.
+
+3. Ask for confirmation before deleting anything unless user already made clear they want removal now.
+
+4. Remove any of these directories that exist:
+
+   ```sh
+   rm -rf ~/.codex/skills/caveman
+   rm -rf ~/.codex/skills/compress
+   rm -rf ~/.codex/skills/caveman-commit
+   rm -rf ~/.codex/skills/caveman-help
+   rm -rf ~/.codex/skills/caveman-review
+   ```
+
+5. Verify these paths no longer exist:
+   - `~/.codex/skills/caveman`
+   - `~/.codex/skills/compress`
+   - `~/.codex/skills/caveman-commit`
+   - `~/.codex/skills/caveman-help`
+   - `~/.codex/skills/caveman-review`
+
+6. Tell user final step:
+   - Restart Codex if skills still appear in current session.
+
+Important constraints:
+   - Remove only from `~/.codex/skills`.
+   - Do not remove `~/.codex/plugins/caveman`.
+   - Do not modify `~/.agents/plugins/marketplace.json`.
+   - Do not modify `~/.codex/config.toml`.

--- a/installers/codex/macos/skills-only/uninstall.sh
+++ b/installers/codex/macos/skills-only/uninstall.sh
@@ -45,7 +45,6 @@ for arg in "$@"; do
 done
 
 need_cmd rm
-need_cmd rmdir
 
 FOUND=0
 for skill in "${SKILLS[@]}"; do

--- a/installers/codex/macos/skills-only/uninstall.sh
+++ b/installers/codex/macos/skills-only/uninstall.sh
@@ -21,7 +21,7 @@ confirm() {
   fi
 
   printf "Remove Caveman skill-only install from Codex? [y/N] "
-  read -r reply
+  read -r reply || reply=""
   case "${reply}" in
     y|Y|yes|YES)
       return 0

--- a/installers/codex/macos/skills-only/uninstall.sh
+++ b/installers/codex/macos/skills-only/uninstall.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TARGET_SKILLS_DIR="${HOME}/.codex/skills"
+SKILLS=("caveman" "compress" "caveman-commit" "caveman-help" "caveman-review")
+ASSUME_YES=0
+
+fail() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+confirm() {
+  if [ "${ASSUME_YES}" -eq 1 ]; then
+    return 0
+  fi
+
+  printf "Remove Caveman skill-only install from Codex? [y/N] "
+  read -r reply
+  case "${reply}" in
+    y|Y|yes|YES)
+      return 0
+      ;;
+    *)
+      echo "Cancelled."
+      exit 0
+      ;;
+  esac
+}
+
+for arg in "$@"; do
+  case "${arg}" in
+    --yes)
+      ASSUME_YES=1
+      ;;
+    *)
+      fail "unknown argument: ${arg}"
+      ;;
+  esac
+done
+
+need_cmd rm
+need_cmd rmdir
+
+FOUND=0
+for skill in "${SKILLS[@]}"; do
+  if [ -e "${TARGET_SKILLS_DIR}/${skill}" ]; then
+    FOUND=1
+  fi
+done
+
+if [ "${FOUND}" -eq 0 ]; then
+  echo "Caveman skill-only install not found. Nothing to do."
+  exit 0
+fi
+
+confirm
+
+for skill in "${SKILLS[@]}"; do
+  if [ -e "${TARGET_SKILLS_DIR}/${skill}" ]; then
+    echo "Remove skill ${skill}..."
+    rm -rf "${TARGET_SKILLS_DIR}/${skill}"
+  fi
+done
+
+for skill in "${SKILLS[@]}"; do
+  if [ -e "${TARGET_SKILLS_DIR}/${skill}" ]; then
+    fail "skill still exists: ${TARGET_SKILLS_DIR}/${skill}"
+  fi
+done
+
+echo
+echo "Uninstall complete."
+echo "Restart Codex if skills still appear in current session."

--- a/tests/verify_repo.py
+++ b/tests/verify_repo.py
@@ -111,6 +111,11 @@ def verify_manifests_and_syntax() -> None:
     run(["bash", "-n", "hooks/install.sh"])
     run(["bash", "-n", "hooks/uninstall.sh"])
     run(["bash", "-n", "hooks/caveman-statusline.sh"])
+    run(["bash", "-n", "installers/codex/macos/skills-only/install.sh"])
+    run(["bash", "-n", "installers/codex/macos/skills-only/uninstall.sh"])
+    run(["bash", "-n", "installers/codex/macos/plugin-with-all-skills/install.sh"])
+    run(["bash", "-n", "installers/codex/macos/plugin-with-all-skills/uninstall.sh"])
+    run(["bash", "-n", "installers/codex/macos/expunge-all-caveman-files.sh"])
 
     # Ensure install/uninstall scripts include caveman-config.js
     install_sh = (ROOT / "hooks/install.sh").read_text()


### PR DESCRIPTION
## Summary

Add complete macOS installer package for Caveman in Codex.

This PR adds two supported install flows under `installers/codex/macos`:

- `plugin-with-all-skills`: install Caveman as local Codex plugin with all Caveman skills bundled under plugin
- `skills-only`: install Caveman skills directly into `~/.codex/skills` with no plugin marketplace integration

It also adds matching uninstall flows, prompt-driven install/uninstall docs for both modes, one-shot expunge script for users who want clean slate before reinstalling, and direct-run Codex installer/uninstaller commands in the root `README.md`.

## What’s Included

### Plugin installer flow

- add `install.sh` for local-plugin install on macOS
- add `uninstall.sh` for local-plugin cleanup
- add `prompt-install.md` for Codex-driven manual install flow
- add `prompt-uninstall.md` for Codex-driven manual uninstall flow

This flow:

- installs plugin to `~/.codex/plugins/caveman`
- manages local marketplace entry in `~/.agents/plugins/marketplace.json`
- removes plugin config/cache on uninstall
- leaves standalone skills in `~/.codex/skills` untouched on uninstall

### Skills-only flow

- add `install.sh` for direct skill install
- add `uninstall.sh` for direct skill removal
- add `prompt-install.md` for Codex-driven manual install flow
- add `prompt-uninstall.md` for Codex-driven manual uninstall flow

This flow installs and removes:

- `caveman`
- `compress`
- `caveman-commit`
- `caveman-help`
- `caveman-review`

directly under `~/.codex/skills`.

### Shared docs and cleanup

- add top-level README for macOS installers
- document install choice, requirements, managed files, verification, troubleshooting, and uninstall behavior
- update root `README.md` Codex install section with direct-run install/uninstall commands for macOS users
- add `expunge-all-caveman-files.sh` to run both uninstallers with `--yes`

## Related Open Issues

This installer work also helps address open Codex install/docs gaps:

- [#240 Clear instructions for Codex native app](https://github.com/JuliusBrussee/caveman/issues/240)
- [#107 Can't figure out the plugin version in use in Codex](https://github.com/JuliusBrussee/caveman/issues/107)

## Behavior and Safety

- installers fail instead of overwriting existing targets
- scripts verify required commands before making changes
- install flows verify expected files exist after copy/move
- uninstall flows support interactive confirmation and `--yes`
- plugin uninstall removes only plugin-managed plugin/marketplace/config state
- expunge script gives users one command to clear installer-managed Caveman files before fresh install

## Why

Codex users now have clear, documented install path for Caveman on macOS whether they want:

- full local plugin integration in Codex Desktop
- simple skill-only install in Codex
- prompt-based flow instead of shell script
- clean reinstall path when switching modes or testing installer docs
