### PR TITLE
Add pi-caveman package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,9 @@
   <a href="#evals">Evals</a>
 </p>
 
-<p align="center">
-  <strong>🪨 Caveman Ecosystem</strong> &nbsp;·&nbsp;
-  <strong>caveman</strong> <em>talk less</em> <sub>(you are here)</sub> &nbsp;·&nbsp;
-  <a href="https://github.com/JuliusBrussee/cavemem">cavemem</a> <em>remember more</em> &nbsp;·&nbsp;
-  <a href="https://github.com/JuliusBrussee/cavekit">cavekit</a> <em>build better</em>
-</p>
-
 ---
 
-A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin and Codex plugin that makes agent talk like caveman — cutting **~75% of output tokens** while keeping full technical accuracy. Now with [文言文 mode](#文言文-wenyan-mode), [terse commits](#caveman-commit), [one-line code reviews](#caveman-review), and a [compression tool](#caveman-compress) that cuts **~46% of input tokens** every session.
+A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin and Codex plugin that makes agent talk like caveman — cutting **~75% of output tokens** while keeping full technical accuracy. Now with [文言文 mode](#文言文-wenyan-mode), [terse commits](#caveman-commit), [one-line code reviews](#caveman-review), and a [compression tool](#caveman-compress) that cuts **~45% of input tokens** every session.
 
 Based on the viral observation that caveman-speak dramatically reduces LLM token usage without losing technical substance. So we made it a one-line install.
 
@@ -129,172 +122,55 @@ Based on the viral observation that caveman-speak dramatically reduces LLM token
 
 ## Install
 
-Pick your agent. One command. Done.
+### Claude Code (recommended)
 
-| Agent | Install |
-|-------|---------|
-| **Claude Code** | `claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman` |
-| **Codex** | Clone repo → `/plugins` → Search "Caveman" → Install |
-| **Gemini CLI** | `gemini extensions install https://github.com/JuliusBrussee/caveman` |
-| **Cursor** | `npx skills add JuliusBrussee/caveman -a cursor` |
-| **Windsurf** | `npx skills add JuliusBrussee/caveman -a windsurf` |
-| **Copilot** | `npx skills add JuliusBrussee/caveman -a github-copilot` |
-| **Cline** | `npx skills add JuliusBrussee/caveman -a cline` |
-| **Any other** | `npx skills add JuliusBrussee/caveman` |
-
-Install once. Use in every session for that install target after that. One rock. That it.
-
-### What You Get
-
-Auto-activation is built in for Claude Code, Gemini CLI, and the repo-local Codex setup below. `npx skills add` installs the skill for other agents, but does **not** install repo rule/instruction files, so Caveman does not auto-start there unless you add the always-on snippet below.
-
-| Feature | Claude Code | Codex | Gemini CLI | Cursor | Windsurf | Cline | Copilot |
-|---------|:-----------:|:-----:|:----------:|:------:|:--------:|:-----:|:-------:|
-| Caveman mode | Y | Y | Y | Y | Y | Y | Y |
-| Auto-activate every session | Y | Y¹ | Y | —² | —² | —² | —² |
-| `/caveman` command | Y | Y¹ | Y | — | — | — | — |
-| Mode switching (lite/full/ultra) | Y | Y¹ | Y | Y³ | Y³ | — | — |
-| Statusline badge | Y⁴ | — | — | — | — | — | — |
-| caveman-commit | Y | — | Y | Y | Y | Y | Y |
-| caveman-review | Y | — | Y | Y | Y | Y | Y |
-| caveman-compress | Y | Y | Y | Y | Y | Y | Y |
-| caveman-help | Y | — | Y | Y | Y | Y | Y |
-
-> [!NOTE]
-> Auto-activation works differently per agent: Claude Code uses SessionStart hooks, this repo's Codex dogfood setup uses `.codex/hooks.json`, Gemini uses context files. Cursor/Windsurf/Cline/Copilot can be made always-on, but `npx skills add` installs only the skill, not the repo rule/instruction files.
->
-> ¹ Codex uses `$caveman` syntax, not `/caveman`. This repo ships `.codex/hooks.json`, so caveman auto-starts when you run Codex inside this repo. The installed plugin itself gives you `$caveman`; copy the same hook into another repo if you want always-on behavior there too. caveman-commit and caveman-review are not in the Codex plugin bundle — use the SKILL.md files directly.
-> ² Add the "Want it always on?" snippet below to those agents' system prompt or rule file if you want session-start activation.
-> ³ Cursor and Windsurf receive the full SKILL.md with all intensity levels. Mode switching works on-demand via the skill; no slash command.
-> ⁴ Available in Claude Code, but plugin install only nudges setup. Standalone `install.sh` / `install.ps1` configures it automatically when no custom `statusLine` exists.
-
-<details>
-<summary><strong>Claude Code — full details</strong></summary>
-
-The plugin install gives you skills + auto-loading hooks. If no custom `statusLine` is configured, Caveman nudges Claude to offer badge setup on first session.
+Install as a plugin — includes skills + auto-loading hooks (caveman activates every session, mode badge tracks `/caveman ultra` etc.):
 
 ```bash
 claude plugin marketplace add JuliusBrussee/caveman
 claude plugin install caveman@caveman
 ```
 
-**Standalone hooks (without plugin):** If you prefer not to use the plugin system:
-```bash
-# macOS / Linux / WSL
-bash <(curl -s https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks/install.sh)
-
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks/install.ps1 | iex
-```
-
-Or from a local clone: `bash hooks/install.sh` / `powershell -File hooks\install.ps1`
-
-Uninstall: `bash hooks/uninstall.sh` or `powershell -File hooks\uninstall.ps1`
-
-**Statusline badge:** Shows `[CAVEMAN]`, `[CAVEMAN:ULTRA]`, etc. in your Claude Code status bar.
-
-- **Plugin install:** If you do not already have a custom `statusLine`, Claude should offer to configure it on first session
-- **Standalone install:** Configured automatically by `install.sh` / `install.ps1` unless you already have a custom statusline
-- **Custom statusline:** Installer leaves your existing statusline alone. See [`hooks/README.md`](hooks/README.md) for the merge snippet
-
-</details>
-
-<details>
-<summary><strong>Codex — full details</strong></summary>
-
-**macOS / Linux:**
-1. Clone repo → Open Codex in the repo directory → `/plugins` → Search "Caveman" → Install
-2. Repo-local auto-start is already wired by `.codex/hooks.json` + `.codex/config.toml`
-
-**Windows:**
-1. Enable symlinks first: `git config --global core.symlinks true` (requires Developer Mode or admin)
-2. Clone repo → Open VS Code → Codex Settings → Plugins → find "Caveman" under local marketplace → Install → Reload Window
-3. Codex hooks are currently disabled on Windows, so use `$caveman` to start manually
-
-This repo also ships `.codex/hooks.json` and enables hooks in `.codex/config.toml`, so caveman auto-activates while you run Codex inside this repo on macOS/Linux. The installed plugin gives you `$caveman`; if you want always-on behavior in other repos too, copy the same `SessionStart` hook there and enable:
-
-```toml
-[features]
-codex_hooks = true
-```
-
-</details>
-
-<details>
-<summary><strong>Gemini CLI — full details</strong></summary>
+### Any agent (Claude Code, Cursor, Copilot, Windsurf, Cline, Codex)
 
 ```bash
-gemini extensions install https://github.com/JuliusBrussee/caveman
+npx skills add JuliusBrussee/caveman
 ```
 
-Update: `gemini extensions update caveman` · Uninstall: `gemini extensions uninstall caveman`
+For a specific agent: `npx skills add JuliusBrussee/caveman -a cursor`
 
-Auto-activates via `GEMINI.md` context file. Also ships custom Gemini commands:
-- `/caveman` — switch intensity level (lite/full/ultra/wenyan)
-- `/caveman-commit` — generate terse commit message
-- `/caveman-review` — one-line code review
+> [!NOTE]
+> `npx skills` installs skills only (no hooks). For Claude Code auto-loading hooks, use the plugin install above or run `bash hooks/install.sh`.
 
-</details>
+### Pi
 
-<details>
-<summary><strong>Cursor / Windsurf / Cline / Copilot — full details</strong></summary>
-
-`npx skills add` installs the skill file only — it does **not** install the agent's rule/instruction file, so caveman does not auto-start. For always-on, add the "Want it always on?" snippet below to your agent's rules or system prompt.
-
-| Agent | Command | Not installed | Mode switching | Always-on location |
-|-------|---------|--------------|:--------------:|--------------------|
-| Cursor | `npx skills add JuliusBrussee/caveman -a cursor` | `.cursor/rules/caveman.mdc` | Y | Cursor rules |
-| Windsurf | `npx skills add JuliusBrussee/caveman -a windsurf` | `.windsurf/rules/caveman.md` | Y | Windsurf rules |
-| Cline | `npx skills add JuliusBrussee/caveman -a cline` | `.clinerules/caveman.md` | — | Cline rules or system prompt |
-| Copilot | `npx skills add JuliusBrussee/caveman -a github-copilot` | `.github/copilot-instructions.md` + `AGENTS.md` | — | Copilot custom instructions |
-
-Uninstall: `npx skills remove caveman`
-
-Copilot works with Chat, Edits, and Coding Agent.
-
-</details>
-
-<details>
-<summary><strong>Any other agent (opencode, Roo, Amp, Goose, Kiro, and 40+ more)</strong></summary>
-
-[npx skills](https://github.com/vercel-labs/skills) supports 40+ agents:
+Caveman repo now includes a standalone Pi package: `pi-caveman`.
 
 ```bash
-npx skills add JuliusBrussee/caveman           # auto-detect agent
-npx skills add JuliusBrussee/caveman -a amp
-npx skills add JuliusBrussee/caveman -a augment
-npx skills add JuliusBrussee/caveman -a goose
-npx skills add JuliusBrussee/caveman -a kiro-cli
-npx skills add JuliusBrussee/caveman -a roo
-# ... and many more
+pi install npm:pi-caveman
+# or try local repo once
+pi -e ./extensions/caveman-pi.ts
 ```
 
-Uninstall: `npx skills remove caveman`
+Then use:
+- `/caveman [lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off]`
+- `/normal`
+- or just say `talk like caveman`
 
-> **Windows note:** `npx skills` uses symlinks by default. If symlinks fail, add `--copy`: `npx skills add JuliusBrussee/caveman --copy`
+This Pi package only adds the Pi extension. For original Caveman skills, hooks, benchmarks, and Claude/Codex plugin docs, use this repo directly.
 
-**Important:** These agents don't have a hook system, so caveman won't auto-start. Say `/caveman` or "talk like caveman" to activate each session.
+### Codex
 
-**Want it always on?** Paste this into your agent's system prompt or rules file — caveman will be active from the first message, every session:
+1. Clone repo → Open Codex in repo → `/plugins` → Search `Caveman` → Install
 
-```
-Terse like caveman. Technical substance exact. Only fluff die.
-Drop: articles, filler (just/really/basically), pleasantries, hedging.
-Fragments OK. Short synonyms. Code unchanged.
-Pattern: [thing] [action] [reason]. [next step].
-ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift.
-Code/commits/PRs: normal. Off: "stop caveman" / "normal mode".
-```
+> [!NOTE]
+> **Windows Codex users:** Clone repo → VS Code → Codex Settings → Plugins → find `Caveman` under local marketplace → Install → Reload Window. Also enable `git config core.symlinks true` before cloning (requires developer mode or admin).
 
-Where to put it:
-| Agent | File |
-|-------|------|
-| opencode | `.config/opencode/AGENTS.md` |
-| Roo | `.roo/rules/caveman.md` |
-| Amp | your workspace system prompt |
-| Others | your agent's system prompt or rules file |
+Install once. Use in all sessions after that. One rock. That it.
 
-</details>
+### Optional: Statusline Badge
+
+Add a `[CAVEMAN:ULTRA]` badge to your statusline showing which mode is active. See [`hooks/README.md`](hooks/README.md) for the snippet.
 
 ## Usage
 
@@ -328,21 +204,14 @@ Level stick until you change it or session end.
 
 ## Caveman Skills
 
-### caveman-commit
-
-`/caveman-commit` — terse commit messages. Conventional Commits. ≤50 char subject. Why over what.
-
-### caveman-review
-
-`/caveman-review` — one-line PR comments: `L42: 🔴 bug: user null. Add guard.` No throat-clearing.
-
-### caveman-help
-
-`/caveman-help` — quick-reference card. All modes, skills, commands, one command away.
+| Skill | What it do | Trigger |
+|-------|-----------|---------|
+| **caveman-commit** | Terse commit messages. Conventional Commits. ≤50 char subject. Why over what. | `/caveman-commit` |
+| **caveman-review** | One-line PR comments: `L42: 🔴 bug: user null. Add guard.` No throat-clearing. | `/caveman-review` |
 
 ### caveman-compress
 
-`/caveman:compress <filepath>` — caveman make Claude *speak* with fewer tokens. **Compress** make Claude *read* fewer tokens.
+Caveman make Claude *speak* with fewer tokens. **Compress** make Claude *read* fewer tokens.
 
 Your `CLAUDE.md` loads on **every session start**. Caveman Compress rewrites memory files into caveman-speak so Claude reads less — without you losing the human-readable original.
 
@@ -359,10 +228,10 @@ CLAUDE.original.md ← human-readable backup (you read and edit this)
 |------|----------:|----------:|------:|
 | `claude-md-preferences.md` | 706 | 285 | **59.6%** |
 | `project-notes.md` | 1145 | 535 | **53.3%** |
-| `claude-md-project.md` | 1122 | 636 | **43.3%** |
+| `claude-md-project.md` | 1122 | 687 | **38.8%** |
 | `todo-list.md` | 627 | 388 | **38.1%** |
-| `mixed-with-code.md` | 888 | 560 | **36.9%** |
-| **Average** | **898** | **481** | **46%** |
+| `mixed-with-code.md` | 888 | 574 | **35.4%** |
+| **Average** | **898** | **494** | **45%** |
 
 Code blocks, URLs, file paths, commands, headings, dates, version numbers — anything technical passes through untouched. Only prose gets compressed. See the full [caveman-compress README](caveman-compress/README.md) for details. [Security note](./caveman-compress/SECURITY.md): Snyk flags this as High Risk due to subprocess/file patterns — it's a false positive.
 
@@ -407,26 +276,17 @@ uv run python evals/llm_run.py
 uv run --with tiktoken python evals/measure.py
 ```
 
+Snapshots committed to git. CI runs free. Every number change reviewable as diff. Add a skill, add a prompt — harness pick it up automatically.
+
 ## Star This Repo
 
 If caveman save you mass token, mass money — leave mass star. ⭐
 
 [![Star History Chart](https://api.star-history.com/svg?repos=JuliusBrussee/caveman&type=Date)](https://star-history.com/#JuliusBrussee/caveman&Date)
 
-## 🪨 The Caveman Ecosystem
-
-Three tools. One philosophy: **agent do more with less**.
-
-| Repo | What | One-liner |
-|------|------|-----------|
-| [**caveman**](https://github.com/JuliusBrussee/caveman) *(you are here)* | Output compression skill | *why use many token when few do trick* — ~75% fewer output tokens across Claude Code, Cursor, Gemini, Codex |
-| [**cavemem**](https://github.com/JuliusBrussee/cavemem) | Cross-agent persistent memory | *why agent forget when agent can remember* — compressed SQLite + MCP, local by default |
-| [**cavekit**](https://github.com/JuliusBrussee/cavekit) | Spec-driven autonomous build loop | *why agent guess when agent can know* — natural language → kits → parallel build → verified |
-
-They compose: **cavekit** orchestrates the build, **caveman** compresses what the agent *says*, **cavemem** compresses what the agent *remembers*. Install one, some, or all — each stands alone.
-
 ## Also by Julius Brussee
 
+- **[Cavekit](https://github.com/JuliusBrussee/cavekit)** — specification-driven development for Claude Code. Caveman language → specs → parallel builds → working software.
 - **[Revu](https://github.com/JuliusBrussee/revu-swift)** — local-first macOS study app with FSRS spaced repetition, decks, exams, and study guides. [revu.cards](https://revu.cards)
 
 ## License

--- a/extensions/caveman-pi.ts
+++ b/extensions/caveman-pi.ts
@@ -1,0 +1,161 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+type CavemanMode =
+	| "lite"
+	| "full"
+	| "ultra"
+	| "wenyan-lite"
+	| "wenyan-full"
+	| "wenyan-ultra";
+
+type SavedMode = CavemanMode | "off";
+
+type CavemanStateEntry = {
+	type: "custom";
+	customType: "caveman-state";
+	data?: {
+		mode?: SavedMode;
+	};
+};
+
+const validModes: CavemanMode[] = ["lite", "full", "ultra", "wenyan-lite", "wenyan-full", "wenyan-ultra"];
+
+const cavemanPrompt = `IMPORTANT: Caveman mode active.
+
+Speak terse like smart caveman. Keep full technical accuracy. Kill fluff.
+
+Rules:
+- Drop filler, pleasantries, hedging.
+- Short synonyms good. Fragments OK.
+- Technical terms exact.
+- Code blocks unchanged.
+- Error messages quoted exact.
+- Pattern: [thing] [action] [reason]. [next step].
+
+Modes:
+- lite: concise, grammatical, professional.
+- full: drop articles, fragments OK, classic caveman.
+- ultra: max compression, abbreviations OK, arrows OK.
+- wenyan-lite: semi-classical Chinese, compressed.
+- wenyan-full: full classical terseness.
+- wenyan-ultra: extreme classical compression.
+
+Boundaries:
+- For security warnings, destructive actions, irreversible steps, and anything safety-critical: prioritize clarity over compression.
+- If user says stop caveman or normal mode, stop immediately.
+- This mode changes tone only, not correctness.`;
+
+function isStateEntry(entry: unknown): entry is CavemanStateEntry {
+	return (
+		typeof entry === "object" &&
+		entry !== null &&
+		"type" in entry &&
+		(entry as { type?: unknown }).type === "custom" &&
+		"customType" in entry &&
+		(entry as { customType?: unknown }).customType === "caveman-state"
+	);
+}
+
+function normalizeMode(value: string): SavedMode | undefined {
+	const normalized = value.trim().toLowerCase();
+	if (!normalized) return "full";
+	if (["off", "normal", "stop", "disable", "disabled", "none"].includes(normalized)) return "off";
+	if (["default", "on", "enable", "enabled"].includes(normalized)) return "full";
+	if (normalized === "wenyan") return "wenyan-full";
+	if ((validModes as string[]).includes(normalized)) return normalized as CavemanMode;
+	return undefined;
+}
+
+function getSavedMode(ctx: ExtensionContext): SavedMode {
+	const entries = ctx.sessionManager.getEntries();
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const entry = entries[i];
+		if (!isStateEntry(entry)) continue;
+		const mode = normalizeMode(entry.data?.mode ?? "");
+		if (mode) return mode;
+	}
+	return "full";
+}
+
+function setStatus(ctx: ExtensionContext, mode: SavedMode) {
+	ctx.ui.setStatus("caveman", mode === "off" ? "" : `CAVEMAN:${mode.toUpperCase()}`);
+}
+
+function persistMode(pi: ExtensionAPI, mode: SavedMode) {
+	pi.appendEntry("caveman-state", { mode });
+}
+
+function buildPrompt(mode: CavemanMode) {
+	return `${cavemanPrompt}
+
+Current caveman mode: ${mode}.
+Apply this mode to all normal assistant responses until changed.`;
+}
+
+export default function cavemanPiExtension(pi: ExtensionAPI) {
+	let mode: SavedMode = "full";
+
+	pi.on("session_start", async (_event, ctx) => {
+		mode = getSavedMode(ctx);
+		setStatus(ctx, mode);
+	});
+
+	pi.registerCommand("caveman", {
+		description: "Enable caveman mode or set level: lite, full, ultra, wenyan-lite, wenyan-full, wenyan-ultra, off",
+		handler: async (args, ctx) => {
+			const nextMode = normalizeMode(args);
+			if (!nextMode) {
+				ctx.ui.notify(
+					"Usage: /caveman [lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off]",
+					"warning",
+				);
+				return;
+			}
+
+			mode = nextMode;
+			persistMode(pi, mode);
+			setStatus(ctx, mode);
+			ctx.ui.notify(mode === "off" ? "Caveman off. Normal mode." : `Caveman ${mode} on.`, "info");
+		},
+	});
+
+	pi.registerCommand("normal", {
+		description: "Disable caveman mode",
+		handler: async (_args, ctx) => {
+			mode = "off";
+			persistMode(pi, mode);
+			setStatus(ctx, mode);
+			ctx.ui.notify("Caveman off. Normal mode.", "info");
+		},
+	});
+
+	pi.on("input", async (event, ctx) => {
+		if (event.source === "extension") return { action: "continue" } as const;
+
+		const text = event.text.trim().toLowerCase();
+		if (["stop caveman", "normal mode"].includes(text)) {
+			mode = "off";
+			persistMode(pi, mode);
+			setStatus(ctx, mode);
+			ctx.ui.notify("Caveman off. Normal mode.", "info");
+			return { action: "handled" } as const;
+		}
+
+		if (["caveman mode", "talk like caveman", "less tokens please"].includes(text)) {
+			mode = "full";
+			persistMode(pi, mode);
+			setStatus(ctx, mode);
+			ctx.ui.notify("Caveman full on.", "info");
+			return { action: "handled" } as const;
+		}
+
+		return { action: "continue" } as const;
+	});
+
+	pi.on("before_agent_start", async (event) => {
+		if (mode === "off") return undefined;
+		return {
+			systemPrompt: `${event.systemPrompt}\n\n${buildPrompt(mode)}`,
+		};
+	});
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "pi-caveman",
+  "version": "0.1.0",
+  "description": "Pi extension for caveman mode — ultra-compressed responses with full technical accuracy.",
+  "type": "module",
+  "keywords": [
+    "pi-package",
+    "pi",
+    "caveman",
+    "agent",
+    "extension"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/JuliusBrussee/caveman",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JuliusBrussee/caveman.git"
+  },
+  "bugs": {
+    "url": "https://github.com/JuliusBrussee/caveman/issues"
+  },
+  "files": [
+    "extensions",
+    "README.md",
+    "LICENSE"
+  ],
+  "exports": {
+    "./extensions/caveman-pi": "./extensions/caveman-pi.ts"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "pi": {
+    "extensions": [
+      "./extensions"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone `pi-caveman` package manifest for Pi
- add a self-contained Pi extension with `/caveman` and `/normal` commands
- document Pi installation and point users back to the main Caveman repo for skills, hooks, and other docs

## Validation
- `npm pack --dry-run`
- Pi extension LSP diagnostics clean
