### PR TITLE
fix: `/caveman stop` and `/caveman off` actually deactivate

### DIFF
--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -45,7 +45,8 @@ process.stdin.on('end', () => {
       } else if (cmd === '/caveman-compress' || cmd === '/caveman:caveman-compress') {
         mode = 'compress';
       } else if (cmd === '/caveman' || cmd === '/caveman:caveman') {
-        if (arg === 'lite') mode = 'lite';
+        if (arg === 'stop' || arg === 'off') mode = 'off';
+        else if (arg === 'lite') mode = 'lite';
         else if (arg === 'ultra') mode = 'ultra';
         else if (arg === 'wenyan-lite') mode = 'wenyan-lite';
         else if (arg === 'wenyan' || arg === 'wenyan-full') mode = 'wenyan';


### PR DESCRIPTION
## Summary

`/caveman stop` (and `/caveman:caveman stop`) was effectively a no-op
because the slash-command handler had no `stop`/`off` arg branch. The
arg fell through to `mode = getDefaultMode()` and a fresh
`safeWriteFlag()` ran with the default mode. The natural-language
matcher further down does eventually unlink the flag, but the interim
write is wasted I/O and the intent is unclear.

## Change

One line: `if (arg === 'stop' || arg === 'off') mode = 'off';` placed
before the existing arg branches, which routes through the existing
`mode === 'off'` path that unlinks the flag.

Net effect: a single filesystem op, the statusline clears immediately,
and the slash command matches the documented natural-language exit.

Fixes #245.

## Test plan

- [x] `/caveman` → flag set to `full`, statusline shows `[CAVEMAN]`
- [x] `/caveman stop` → flag deleted, statusline empty, no `[CAVEMAN]`
- [x] `/caveman off` → same as above
- [x] `/caveman lite` → flag set to `lite`
- [x] Existing natural-language exit (`stop caveman`) still unlinks