### PR TITLE
feat(compress): add `--no-backup` flag to skip `.original.md`

### DIFF
--- a/skills/caveman-compress/scripts/cli.py
+++ b/skills/caveman-compress/scripts/cli.py
@@ -3,7 +3,12 @@
 Caveman Compress CLI
 
 Usage:
-    caveman <filepath>
+    caveman [--no-backup] <filepath>
+
+Flags:
+    --no-backup    Skip writing `<file>.original.md` next to the input.
+                   Useful for low-stakes, version-controlled files where
+                   git already provides the rollback path.
 """
 
 import sys
@@ -26,15 +31,21 @@ from .detect import detect_file_type, should_compress
 
 
 def print_usage():
-    print("Usage: caveman <filepath>")
+    print("Usage: caveman [--no-backup] <filepath>")
 
 
 def main():
-    if len(sys.argv) != 2:
+    args = sys.argv[1:]
+    no_backup = False
+    if "--no-backup" in args:
+        no_backup = True
+        args = [a for a in args if a != "--no-backup"]
+
+    if len(args) != 1:
         print_usage()
         sys.exit(1)
 
-    filepath = Path(sys.argv[1])
+    filepath = Path(args[0])
 
     # Check file exists
     if not filepath.exists():
@@ -60,13 +71,16 @@ def main():
     print("Starting caveman compression...\n")
 
     try:
-        success = compress_file(filepath)
+        success = compress_file(filepath, no_backup=no_backup)
 
         if success:
             print("\nCompression completed successfully")
-            backup_path = filepath.with_name(filepath.stem + ".original.md")
             print(f"Compressed: {filepath}")
-            print(f"Original:   {backup_path}")
+            if no_backup:
+                print("Original:   (skipped, --no-backup)")
+            else:
+                backup_path = filepath.with_name(filepath.stem + ".original.md")
+                print(f"Original:   {backup_path}")
             sys.exit(0)
         else:
             print("\n❌ Compression failed after retries")

--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -152,7 +152,7 @@ Return ONLY the fixed compressed file. No explanation.
 # ---------- Core Logic ----------
 
 
-def compress_file(filepath: Path) -> bool:
+def compress_file(filepath: Path, no_backup: bool = False) -> bool:
     # Resolve and validate path
     filepath = filepath.resolve()
     MAX_FILE_SIZE = 500_000  # 500KB
@@ -180,75 +180,100 @@ def compress_file(filepath: Path) -> bool:
         return False
 
     original_text = filepath.read_text(errors="ignore")
-    backup_path = filepath.with_name(filepath.stem + ".original.md")
 
     if not original_text.strip():
         print("❌ Refusing to compress: file is empty or whitespace-only.")
         return False
 
-    # Check if backup already exists to prevent accidental overwriting
-    if backup_path.exists():
-        print(f"⚠️ Backup file already exists: {backup_path}")
-        print("The original backup may contain important content.")
-        print("Aborting to prevent data loss. Please remove or rename the backup file if you want to proceed.")
-        return False
-
-    # Step 1: Compress
-    print("Compressing with Claude...")
-    compressed = call_claude(build_compress_prompt(original_text))
-
-    if compressed is None or not compressed.strip():
-        print("❌ Compression aborted: Claude returned an empty response.")
-        print("   Original file is untouched (no backup created).")
-        return False
-
-    if compressed.strip() == original_text.strip():
-        print("❌ Compression aborted: output is identical to input.")
-        print("   Likely causes: Claude refused, returned the prompt verbatim, or the file is")
-        print("   already in caveman form. Original file is untouched (no backup created).")
-        return False
-
-    # Save original as backup, then verify the backup readback before
-    # touching the input file. If the filesystem dropped bytes (encoding,
-    # antivirus, disk full), unlink the bad backup and abort instead of
-    # leaving the user with a corrupt backup + compressed primary.
-    backup_path.write_text(original_text)
-    backup_readback = backup_path.read_text(errors="ignore")
-    if backup_readback != original_text:
-        print(f"❌ Backup write verification failed: {backup_path}")
-        print("   In-memory original differs from on-disk backup. Aborting before touching the input file.")
-        try:
-            backup_path.unlink()
-        except OSError:
-            pass
-        return False
-    filepath.write_text(compressed)
-
-    # Step 2: Validate + Retry
-    for attempt in range(MAX_RETRIES):
-        print(f"\nValidation attempt {attempt + 1}")
-
-        result = validate(backup_path, filepath)
-
-        if result.is_valid:
-            print("Validation passed")
-            break
-
-        print("❌ Validation failed:")
-        for err in result.errors:
-            print(f"   - {err}")
-
-        if attempt == MAX_RETRIES - 1:
-            # Restore original on failure
-            filepath.write_text(original_text)
-            backup_path.unlink(missing_ok=True)
-            print("❌ Failed after retries — original restored")
+    # When no_backup is True, the backup file validate() needs to diff against
+    # is routed through a tempfile outside the user's working directory. The
+    # tempfile is cleaned up in finally below regardless of how compress_file
+    # exits (success, validation failure, or unexpected exception), so an
+    # exception during Claude calls / writes / validation can never orphan it.
+    if no_backup:
+        import tempfile
+        tmp_fd = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".original.md", delete=False, encoding="utf-8"
+        )
+        tmp_fd.close()
+        backup_path = Path(tmp_fd.name)
+    else:
+        backup_path = filepath.with_name(filepath.stem + ".original.md")
+        # Check if backup already exists to prevent accidental overwriting
+        if backup_path.exists():
+            print(f"⚠️ Backup file already exists: {backup_path}")
+            print("The original backup may contain important content.")
+            print("Aborting to prevent data loss. Please remove or rename the backup file if you want to proceed.")
             return False
 
-        print("Fixing with Claude...")
-        compressed = call_claude(
-            build_fix_prompt(original_text, compressed, result.errors)
-        )
+    try:
+        # Step 1: Compress
+        print("Compressing with Claude...")
+        compressed = call_claude(build_compress_prompt(original_text))
+
+        if compressed is None or not compressed.strip():
+            print("❌ Compression aborted: Claude returned an empty response.")
+            print("   Original file is untouched (no backup created).")
+            return False
+
+        if compressed.strip() == original_text.strip():
+            print("❌ Compression aborted: output is identical to input.")
+            print("   Likely causes: Claude refused, returned the prompt verbatim, or the file is")
+            print("   already in caveman form. Original file is untouched (no backup created).")
+            return False
+
+        # Save original as backup, then verify the backup readback before
+        # touching the input file. If the filesystem dropped bytes (encoding,
+        # antivirus, disk full), unlink the bad backup and abort instead of
+        # leaving the user with a corrupt backup + compressed primary.
+        backup_path.write_text(original_text)
+        backup_readback = backup_path.read_text(errors="ignore")
+        if backup_readback != original_text:
+            print(f"❌ Backup write verification failed: {backup_path}")
+            print("   In-memory original differs from on-disk backup. Aborting before touching the input file.")
+            try:
+                backup_path.unlink()
+            except OSError:
+                pass
+            return False
         filepath.write_text(compressed)
 
-    return True
+        # Step 2: Validate + Retry
+        for attempt in range(MAX_RETRIES):
+            print(f"\nValidation attempt {attempt + 1}")
+
+            result = validate(backup_path, filepath)
+
+            if result.is_valid:
+                print("Validation passed")
+                break
+
+            print("❌ Validation failed:")
+            for err in result.errors:
+                print(f"   - {err}")
+
+            if attempt == MAX_RETRIES - 1:
+                # Restore original on failure
+                filepath.write_text(original_text)
+                if not no_backup:
+                    backup_path.unlink(missing_ok=True)
+                print("❌ Failed after retries — original restored")
+                return False
+
+            print("Fixing with Claude...")
+            compressed = call_claude(
+                build_fix_prompt(original_text, compressed, result.errors)
+            )
+            filepath.write_text(compressed)
+
+        return True
+    finally:
+        # When --no-backup is set, never leave the tempfile behind — not on
+        # success, not on validation failure, not on an unexpected exception
+        # from call_claude or filesystem writes. The default path leaves
+        # `.original.md` next to the input on success (the user wants it).
+        if no_backup:
+            try:
+                backup_path.unlink(missing_ok=True)
+            except OSError:
+                pass

--- a/tests/test_compress_safety.py
+++ b/tests/test_compress_safety.py
@@ -80,6 +80,54 @@ class CompressSafetyTests(unittest.TestCase):
             backup = Path(tmp) / "task.original.md"
             self.assertEqual(backup.read_text(), original)
 
+    def test_no_backup_skips_companion_file_on_success(self):
+        """--no-backup must not leave `.original.md` next to the input."""
+        with tempfile.TemporaryDirectory() as tmp:
+            original = "# Heading\n\nThe quick brown fox jumps over the lazy dog.\n"
+            compressed = "# Heading\n\nFox jump dog.\n"
+            path = self._file_with(Path(tmp), original)
+            with mock.patch.object(compress_mod, "call_claude", return_value=compressed), \
+                 mock.patch.object(compress_mod, "validate") as v:
+                v.return_value = mock.Mock(is_valid=True, errors=[], warnings=[])
+                ok = compress_mod.compress_file(path, no_backup=True)
+            self.assertTrue(ok)
+            self.assertEqual(path.read_text(), compressed)
+            self.assertFalse(
+                (Path(tmp) / "task.original.md").exists(),
+                "no_backup=True must NOT leave .original.md next to the input",
+            )
+
+    def test_no_backup_cleans_tempfile_when_call_claude_raises(self):
+        """--no-backup must not orphan the tempfile on exception.
+
+        Reviewer flagged: when no_backup=True, an exception during the
+        Claude call / validation / write leaves the NamedTemporaryFile
+        behind in /tmp. The cleanup must live in finally so it runs on
+        every exit path, including unexpected exceptions.
+        """
+        captured: list[Path] = []
+        real_named_tempfile = tempfile.NamedTemporaryFile
+
+        def spy_named_tempfile(*args, **kwargs):
+            handle = real_named_tempfile(*args, **kwargs)
+            captured.append(Path(handle.name))
+            return handle
+
+        with tempfile.TemporaryDirectory() as tmp:
+            original = "# Heading\n\nProse to compress.\n"
+            path = self._file_with(Path(tmp), original)
+            with mock.patch.object(compress_mod, "call_claude",
+                                   side_effect=RuntimeError("network exploded")), \
+                 mock.patch("tempfile.NamedTemporaryFile", side_effect=spy_named_tempfile):
+                with self.assertRaises(RuntimeError):
+                    compress_mod.compress_file(path, no_backup=True)
+
+        self.assertEqual(len(captured), 1, "expected exactly one tempfile to be created")
+        self.assertFalse(
+            captured[0].exists(),
+            f"tempfile {captured[0]} must be unlinked even when call_claude raises",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds a `--no-backup` flag to `caveman-compress` so users can skip
writing the `<file>.original.md` companion next to their input. When
the input is already in version control, that file is noise — git
already provides the rollback path.

Closes #283.

## Behavior

- **Default (unchanged):** `.original.md` is written, kept on success,
  removed on validation-failure-after-retries (existing logic).
- **With `--no-backup`:** the "backup" the validator needs is routed
  through a `tempfile.NamedTemporaryFile` outside the user's working
  directory, then removed on every exit path. The user's directory
  stays clean.

## Implementation

- `compress_file(filepath, no_backup=False)` — new optional kwarg.
- `cli.py` — argv parsing accepts `--no-backup` anywhere; usage string
  updated; success summary prints `(skipped, --no-backup)` instead of a
  bogus path.
- The existing "abort if `.original.md` already exists" guard still runs
  on the default path; under `--no-backup` it's skipped because the
  temp path is unique.

## Test plan

- [x] `caveman foo.md` → `foo.md` compressed, `foo.original.md` kept
- [x] `caveman --no-backup foo.md` → `foo.md` compressed, no sibling
  file written, tempfile removed
- [x] `caveman --no-backup foo.md` with validation failure → `foo.md`
  restored from in-memory original, tempfile removed, no sibling file
- [x] Flag accepted before or after the path