### PR TITLE
docs: align headline compression numbers with the evals snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ---
 
-A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin (also Codex, Gemini, Cursor, Windsurf, Cline, Copilot, 30+ more) that makes agent talk like caveman — cuts **~75% of output tokens**, keeps full technical accuracy. Brain still big. Mouth small.
+A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin (also Codex, Gemini, Cursor, Windsurf, Cline, Copilot, 30+ more) that makes agent talk like caveman — cuts **~50% of output tokens** (median across the [evals snapshot](evals/snapshots/results.json), range 0% to 88%), keeps full technical accuracy. Brain still big. Mouth small.
 
 ## Before / After
 
@@ -63,11 +63,11 @@ A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin (al
 </tr>
 </table>
 
-**Same fix. 75% less word. Brain still big.**
+**Same fix. ~50% less word (median). Brain still big.**
 
 ```
 ┌─────────────────────────────────────┐
-│  TOKENS SAVED          ████████ 75% │
+│  TOKENS SAVED          █████░░░ 50% │
 │  TECHNICAL ACCURACY    ████████ 100%│
 │  SPEED INCREASE        ████████ ~3x │
 │  VIBES                 ████████ OOG │

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: caveman
 description: >
-  Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
+  Ultra-compressed communication mode. Cuts token usage ~50% (median; up to 88%) by speaking like caveman
   while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
   wenyan-lite, wenyan-full, wenyan-ultra.
   Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",


### PR DESCRIPTION
## Summary

`README.md` and `skills/caveman/SKILL.md` both advertise ~75% output
token reduction, but the committed `evals/snapshots/results.json`
measures **median −50.3% vs `__terse__`** (mean −46.1%, range −0.4% to
−87.9% across 10 prompts) using the same `tiktoken o200k_base` encoding
the eval harness uses. The 65–75% band is hit on 3 of 10 prompts and
is not representative of the distribution.

A 50% saving is still a strong claim — anchoring the README at 75%
over-commits anyone planning capacity around caveman and undermines
credibility against the eval data the repo itself ships.

Closes #234.

## Reproduction (from issue body, verified locally)

```bash
python3 - <<'PY'
import json, tiktoken, statistics
d = json.load(open('evals/snapshots/results.json'))
enc = tiktoken.get_encoding('o200k_base')
arms = d['arms']
terse_tok = [len(enc.encode(a)) for a in arms['__terse__']]
cm_tok    = [len(enc.encode(a)) for a in arms['caveman']]
deltas = [(c - t) / t * 100 for t, c in zip(terse_tok, cm_tok)]
print(f"caveman vs __terse__: median {statistics.median(deltas):+.1f}% mean {statistics.mean(deltas):+.1f}%")
PY
```

## Changes

- `README.md` lead paragraph: link the evals snapshot directly so
  readers can verify the number.
- `README.md` "Same fix. 75% less word." → `~50%`.
- `README.md` ASCII summary box: TOKENS SAVED bar shortened from
  `████████ 75%` to `█████░░░ 50%`.
- `README.md` "not just claim 75%" intro to the Evals section.
- `README.md` ecosystem table footer.
- `skills/caveman/SKILL.md` frontmatter description.

## Out of scope

The `<!-- BENCHMARK-TABLE -->` block in `README.md` (mean 65% across
10 prompts vs a verbose `Normal` baseline) uses a different denominator
than the evals snapshot. Aligning that table deserves its own scoped
patch with a fresh measurement run, and `evals/README.md` already
hints that the prior verbose-baseline approach was inflated. Happy to
do the follow-up if helpful.