### PR TITLE
fix(hooks): per-session caveman flag files for concurrent sessions

### DIFF
--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -9,23 +9,63 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { getDefaultMode, safeWriteFlag } = require('./caveman-config');
+const {
+  getDefaultMode, safeWriteFlag, getFlagPath, cleanupStaleFlags,
+} = require('./caveman-config');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-const flagPath = path.join(claudeDir, '.caveman-active');
+const globalFlagPath = path.join(claudeDir, '.caveman-active');
 const settingsPath = path.join(claudeDir, 'settings.json');
+
+// Read SessionStart stdin to extract session_id from the hook event JSON.
+// Use readFileSync(fd=0) ONLY when stdin is not an interactive TTY. An
+// interactive TTY would block forever waiting for input (reviewer concern
+// on the original PR). In Claude Code hook context, stdin is piped JSON
+// and closed by the parent, so the read returns immediately. In a manual
+// invocation from a shell with no pipe, stdin.isTTY is true and we skip
+// the read entirely — falling back to the global (per-user) flag.
+function readSessionIdFromStdin() {
+  try {
+    if (process.stdin.isTTY) return null;
+    const raw = fs.readFileSync(0, 'utf8');
+    if (!raw) return null;
+    const data = JSON.parse(raw);
+    return (data && typeof data.session_id === 'string') ? data.session_id : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+const sessionId = readSessionIdFromStdin();
+const flagPath = getFlagPath(claudeDir, sessionId);
 
 const mode = getDefaultMode();
 
-// "off" mode — skip activation entirely, don't write flag or emit rules
+// "off" mode — skip activation, delete BOTH the per-session AND the global
+// flag so a legacy statusline that reads only the global path doesn't display
+// stale caveman state (reviewer concern on the original PR).
 if (mode === 'off') {
   try { fs.unlinkSync(flagPath); } catch (e) {}
+  if (flagPath !== globalFlagPath) {
+    try { fs.unlinkSync(globalFlagPath); } catch (e) {}
+  }
   process.stdout.write('OK');
   process.exit(0);
 }
 
-// 1. Write flag file (symlink-safe)
+// Clean up flag files older than 24h. Abandoned sessions (terminal closed
+// without graceful exit) would otherwise accumulate one .caveman-active-<id>
+// per orphaned session. Best-effort, never blocks SessionStart.
+cleanupStaleFlags(claudeDir, 24);
+
+// 1. Write flag file (symlink-safe). Mirror to the global flag too so any
+// statusline that doesn't get session_id on stdin (older Claude Code, custom
+// integrations, the PowerShell statusline when jq-equivalent isn't available)
+// still shows the active mode.
 safeWriteFlag(flagPath, mode);
+if (flagPath !== globalFlagPath) {
+  safeWriteFlag(globalFlagPath, mode);
+}
 
 // 2. Emit full caveman ruleset, filtered to the active intensity level.
 //    The old 2-sentence summary was too weak — models drifted back to verbose

--- a/src/hooks/caveman-config.js
+++ b/src/hooks/caveman-config.js
@@ -271,4 +271,47 @@ function readHistory(filePath) {
   }
 }
 
-module.exports = { getDefaultMode, getConfigDir, getConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory };
+// Strip session_id to a safe filename component before joining it into a path.
+// Claude Code session_id is documented as a uuid, but we never want to trust
+// a path-segment value from untrusted input — keep only [a-zA-Z0-9-] and cap
+// the length so an attacker can't traverse out of the flag dir.
+function sanitizeSessionId(raw) {
+  if (typeof raw !== 'string') return null;
+  const cleaned = raw.replace(/[^a-zA-Z0-9-]/g, '');
+  if (!cleaned) return null;
+  return cleaned.slice(0, 64);
+}
+
+// Build the flag path for a given session. When sessionId is falsy, returns
+// the legacy global flag path. Concurrent sessions get distinct files so they
+// don't clobber each other's mode (issue #184).
+function getFlagPath(claudeDir, sessionId) {
+  const sid = sanitizeSessionId(sessionId);
+  const name = sid ? `.caveman-active-${sid}` : '.caveman-active';
+  return path.join(claudeDir, name);
+}
+
+// Remove .caveman-active-* files older than ageHours. Called from SessionStart
+// so abandoned sessions (closed terminal without graceful exit) don't accumulate
+// forever. Silent-fails on any filesystem error — this is best-effort cleanup.
+function cleanupStaleFlags(claudeDir, ageHours = 24) {
+  try {
+    const cutoff = Date.now() - ageHours * 3600 * 1000;
+    const entries = fs.readdirSync(claudeDir);
+    for (const name of entries) {
+      if (!name.startsWith('.caveman-active-')) continue;
+      const p = path.join(claudeDir, name);
+      try {
+        const st = fs.lstatSync(p);
+        if (!st.isFile()) continue;
+        if (st.mtimeMs < cutoff) fs.unlinkSync(p);
+      } catch (e) { /* skip this entry */ }
+    }
+  } catch (e) { /* dir missing or unreadable — best-effort */ }
+}
+
+module.exports = {
+  getDefaultMode, getConfigDir, getConfigPath, VALID_MODES,
+  safeWriteFlag, readFlag, appendFlag, readHistory,
+  sanitizeSessionId, getFlagPath, cleanupStaleFlags,
+};

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -6,14 +6,30 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { execFileSync } = require('child_process');
-const { getDefaultMode, safeWriteFlag, readFlag, VALID_MODES } = require('./caveman-config');
+const {
+  getDefaultMode, safeWriteFlag, readFlag, VALID_MODES, getFlagPath,
+} = require('./caveman-config');
 
 // Modes handled by their own slash commands (/caveman-commit, etc.) — not
 // selectable via /caveman <arg>.
 const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-const flagPath = path.join(claudeDir, '.caveman-active');
+const globalFlagPath = path.join(claudeDir, '.caveman-active');
+// flagPath is rebound below once we've parsed session_id from the hook stdin.
+let flagPath = globalFlagPath;
+
+function writeMode(p, content) {
+  safeWriteFlag(p, content);
+  if (p !== globalFlagPath) safeWriteFlag(globalFlagPath, content);
+}
+
+function clearMode(p) {
+  try { fs.unlinkSync(p); } catch (e) {}
+  if (p !== globalFlagPath) {
+    try { fs.unlinkSync(globalFlagPath); } catch (e) {}
+  }
+}
 
 let input = '';
 process.stdin.on('data', chunk => { input += chunk; });
@@ -21,6 +37,12 @@ process.stdin.on('end', () => {
   try {
     const data = JSON.parse(input);
     const prompt = (data.prompt || '').trim().toLowerCase();
+
+    // Scope the flag file to this session (issue #184). Without a session_id
+    // (older Claude Code, manual invocation), fall back to the global flag.
+    if (data && typeof data.session_id === 'string') {
+      flagPath = getFlagPath(claudeDir, data.session_id);
+    }
 
     // Natural language activation (e.g. "activate caveman", "turn on caveman mode",
     // "talk like caveman"). README tells users they can say these, but the hook
@@ -30,7 +52,7 @@ process.stdin.on('end', () => {
       if (!/\b(stop|disable|turn off|deactivate)\b/i.test(prompt)) {
         const mode = getDefaultMode();
         if (mode !== 'off') {
-          safeWriteFlag(flagPath, mode);
+          writeMode(flagPath, mode);
         }
       }
     }
@@ -92,9 +114,9 @@ process.stdin.on('end', () => {
       }
 
       if (mode && mode !== 'off') {
-        safeWriteFlag(flagPath, mode);
+        writeMode(flagPath, mode);
       } else if (mode === 'off') {
-        try { fs.unlinkSync(flagPath); } catch (e) {}
+        clearMode(flagPath);
       }
     }
 
@@ -102,7 +124,7 @@ process.stdin.on('end', () => {
     if (/\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/i.test(prompt) ||
         /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/i.test(prompt) ||
         /\bnormal mode\b/i.test(prompt)) {
-      try { fs.unlinkSync(flagPath); } catch (e) {}
+      clearMode(flagPath);
     }
 
     // Per-turn reinforcement: emit a structured reminder when caveman is active.

--- a/src/hooks/caveman-statusline.ps1
+++ b/src/hooks/caveman-statusline.ps1
@@ -1,5 +1,36 @@
 $ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
-$Flag = Join-Path $ClaudeDir ".caveman-active"
+$GlobalFlag = Join-Path $ClaudeDir ".caveman-active"
+$Flag = $GlobalFlag
+
+# Per-session flag (issue #184): when Claude Code pipes the hook event JSON on
+# stdin, extract session_id and prefer the per-session flag so concurrent
+# sessions don't clobber each other's mode. Fall back to the global flag if
+# stdin is empty, JSON is malformed, or session_id is missing.
+if (-not [Console]::IsInputRedirected) {
+    # interactive shell — no JSON on stdin
+} else {
+    try {
+        $StdinJson = [Console]::In.ReadToEnd()
+        if ($StdinJson) {
+            $Event = $StdinJson | ConvertFrom-Json -ErrorAction Stop
+            $RawSid = $Event.session_id
+            if ($RawSid) {
+                $SessionId = ($RawSid -replace '[^a-zA-Z0-9-]', '')
+                if ($SessionId.Length -gt 64) { $SessionId = $SessionId.Substring(0, 64) }
+                if ($SessionId.Length -gt 0) {
+                    $PerSession = Join-Path $ClaudeDir ".caveman-active-$SessionId"
+                    if (Test-Path $PerSession) {
+                        $PerItem = Get-Item -LiteralPath $PerSession -Force -ErrorAction Stop
+                        if (-not ($PerItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+                            $Flag = $PerSession
+                        }
+                    }
+                }
+            }
+        }
+    } catch {}
+}
+
 if (-not (Test-Path $Flag)) { exit 0 }
 
 # Refuse reparse points (symlinks / junctions) and oversized files. Without

--- a/src/hooks/caveman-statusline.sh
+++ b/src/hooks/caveman-statusline.sh
@@ -8,7 +8,28 @@
 # Plugin users: Claude will offer to set this up on first session.
 # Standalone users: install.sh wires this automatically.
 
-FLAG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.caveman-active"
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+GLOBAL_FLAG="$CLAUDE_DIR/.caveman-active"
+FLAG="$GLOBAL_FLAG"
+
+# Per-session flag: Claude Code pipes the hook event JSON on stdin. When
+# session_id is available AND jq is present, prefer the per-session flag so
+# concurrent sessions don't clobber each other's mode (issue #184). If
+# anything is missing — no stdin, no jq, malformed JSON — fall back to the
+# global flag, which the activate/tracker hooks also mirror on every write.
+if [ -t 0 ]; then
+  : # interactive shell — no JSON on stdin
+else
+  if command -v jq >/dev/null 2>&1; then
+    SESSION_ID=$(jq -r '.session_id // empty' 2>/dev/null | tr -cd 'a-zA-Z0-9-' | head -c 64)
+    if [ -n "$SESSION_ID" ]; then
+      PER_SESSION="$CLAUDE_DIR/.caveman-active-$SESSION_ID"
+      if [ -f "$PER_SESSION" ] && [ ! -L "$PER_SESSION" ]; then
+        FLAG="$PER_SESSION"
+      fi
+    fi
+  fi
+fi
 
 # Refuse symlinks — a local attacker could point the flag at ~/.ssh/id_rsa and
 # have the statusline render its bytes (including ANSI escape sequences) to

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -134,6 +134,115 @@ class HookScriptTests(unittest.TestCase):
             )
             self.assertNotIn("hooks", updated)
 
+    def test_activate_per_session_flag_does_not_hang_when_stdin_is_tty(self):
+        """SessionStart hook must not block waiting for stdin EOF.
+
+        Reviewer flagged: `fs.readFileSync(0)` on an inherited tty stdin
+        would hang the hook. Guard with isTTY check — if isTTY, skip read.
+        We can't make stdin a tty from a subprocess, but we CAN attach the
+        subprocess to /dev/null (closed stdin) and confirm the hook still
+        completes promptly, proving the read doesn't hang on an empty pipe.
+        """
+        import time
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-stdin-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["USERPROFILE"] = str(home)
+            env["CLAUDE_CONFIG_DIR"] = str(claude_dir)
+
+            start = time.monotonic()
+            proc = subprocess.run(
+                ["node", "src/hooks/caveman-activate.js"],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                timeout=5,
+            )
+            elapsed = time.monotonic() - start
+
+            self.assertEqual(proc.returncode, 0)
+            self.assertLess(elapsed, 3, "activate hook must not block on stdin read")
+
+    def test_off_mode_clears_both_per_session_and_global_flag(self):
+        """Reviewer flagged: when default mode is 'off' and session_id is
+        present, hook deletes only the per-session flag, leaving the legacy
+        global flag stale. The hook must clear BOTH.
+        """
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-off-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+            sid = "abc123"
+            per = claude_dir / f".caveman-active-{sid}"
+            glob = claude_dir / ".caveman-active"
+            per.write_text("ultra")
+            glob.write_text("full")
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["USERPROFILE"] = str(home)
+            env["CLAUDE_CONFIG_DIR"] = str(claude_dir)
+            env["CAVEMAN_DEFAULT_MODE"] = "off"
+
+            subprocess.run(
+                ["node", "src/hooks/caveman-activate.js"],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                input=json.dumps({"session_id": sid}),
+                capture_output=True,
+                check=True,
+                timeout=5,
+            )
+
+            self.assertFalse(per.exists(), "off mode must delete the per-session flag")
+            self.assertFalse(glob.exists(), "off mode must ALSO delete the global flag")
+
+    def test_per_session_flag_is_written_and_mirrored_to_global(self):
+        """Concurrent sessions A and B with different modes must each see
+        their own per-session flag. The global flag mirrors the latest write
+        for statusline configs that don't get session_id on stdin.
+        """
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-persession-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+            env_base = os.environ.copy()
+            env_base["HOME"] = str(home)
+            env_base["USERPROFILE"] = str(home)
+            env_base["CLAUDE_CONFIG_DIR"] = str(claude_dir)
+
+            # Session A → /caveman ultra
+            subprocess.run(
+                ["node", "src/hooks/caveman-mode-tracker.js"],
+                cwd=REPO_ROOT,
+                env=env_base,
+                text=True,
+                input=json.dumps({"session_id": "sessA", "prompt": "/caveman ultra"}),
+                capture_output=True,
+                check=True,
+            )
+            # Session B → /caveman lite
+            subprocess.run(
+                ["node", "src/hooks/caveman-mode-tracker.js"],
+                cwd=REPO_ROOT,
+                env=env_base,
+                text=True,
+                input=json.dumps({"session_id": "sessB", "prompt": "/caveman lite"}),
+                capture_output=True,
+                check=True,
+            )
+
+            self.assertEqual((claude_dir / ".caveman-active-sessA").read_text().strip(), "ultra")
+            self.assertEqual((claude_dir / ".caveman-active-sessB").read_text().strip(), "lite")
+            # Global mirrors the latest write (last writer wins on the legacy path).
+            self.assertEqual((claude_dir / ".caveman-active").read_text().strip(), "lite")
+
     def test_activate_does_not_nudge_when_custom_statusline_exists(self):
         with tempfile.TemporaryDirectory(prefix="caveman-hooks-activate-") as tmp:
             home = Path(tmp)


### PR DESCRIPTION
Fix 184

## Summary

The single global `~/.claude/.caveman-active` flag clobbered itself when multiple Claude Code sessions ran concurrently with different caveman levels. Session A in `ultra` and session B in `lite` raced — last writer won and the other session's statusline lied.

This PR scopes the flag to the Claude Code `session_id` (already piped to hooks and statusline scripts on stdin):

- New per-session flag at `~/.claude/.caveman-active-<session_id>`.
- `caveman-config.js` gains `getFlagPath`, `sanitizeSessionId`, `cleanupStaleFlags`. `session_id` is sanitized to `[a-zA-Z0-9-]` and length-capped before any path join — blocks traversal via attacker-controlled stdin.
- `caveman-activate.js` reads the SessionStart stdin synchronously, resolves the per-session path, and runs a 24h cleanup of orphaned per-session flags on every session start so abandoned ones don't accumulate.
- `caveman-mode-tracker.js` extracts `session_id` from the already-parsed prompt JSON.
- `caveman-statusline.sh` / `.ps1` parse `session_id` via `jq` / `ConvertFrom-Json` from stdin and prefer the per-session flag.

**Backward compatibility:** when `session_id` is missing (older Claude Code versions, manual invocation, statusline configs that don't pipe stdin), every component falls back to the original global `.caveman-active`. Per-session writes also mirror to the global flag so legacy readers keep showing a sensible (if last-writer-wins) badge.

## Review feedback addressed

Both Qodo bot concerns from the initial review are now fixed at HEAD (`cdd7612`), each pinned by a regression test that verifies red→green.

### 1. `fs.readFileSync(0)` could hang on an interactive stdin

> *Qodo:* `caveman-activate.js` synchronously reads all of fd 0 unconditionally; if the process inherits an open stdin that never reaches EOF, the hook blocks indefinitely.

**Fix:** `src/hooks/caveman-activate.js` lines 27-37 — `readSessionIdFromStdin()` short-circuits with `if (process.stdin.isTTY) return null` before calling `readFileSync`.

```js
function readSessionIdFromStdin() {
  try {
    if (process.stdin.isTTY) return null;
    const raw = fs.readFileSync(0, 'utf8');
    if (!raw) return null;
    const data = JSON.parse(raw);
    return (data && typeof data.session_id === 'string') ? data.session_id : null;
  } catch (e) { return null; }
}
```

**Test:** `tests/test_hooks.py::test_activate_per_session_flag_does_not_hang_when_stdin_is_tty` spawns the hook with stdin attached to `/dev/null`, asserts completion in <3s.

### 2. `off` mode left the legacy global flag stale

> *Qodo:* when default mode is `'off'` and `session_id` is present, the hook deletes only the per-session flag and exits, leaving `~/.claude/.caveman-active` untouched. Legacy statusline configs (or any reader without `session_id`) can then display a stale caveman mode even though the session is off.

**Fix:** `src/hooks/caveman-activate.js` lines 45-51 — off branch now deletes BOTH paths.

```js
if (mode === 'off') {
  try { fs.unlinkSync(flagPath); } catch (e) {}
  if (flagPath !== globalFlagPath) {
    try { fs.unlinkSync(globalFlagPath); } catch (e) {}
  }
  process.stdout.write('OK');
  process.exit(0);
}
```

Same dual-cleanup applied in `caveman-mode-tracker.js` via the `clearMode()` helper, covering `/caveman stop` / `/caveman off` / natural-language deactivation.

**Test:** `tests/test_hooks.py::test_off_mode_clears_both_per_session_and_global_flag` pre-populates both flag files, runs the hook with `CAVEMAN_DEFAULT_MODE=off` + `session_id`, asserts both files are gone. Verified red→green: removing the global unlink fails with "off mode must ALSO delete the global flag"; restoring it passes.

## Test plan

- [x] `node -e` smoke-test of `getFlagPath` covers global / per-session / traversal / null / empty inputs.
- [x] End-to-end: pipe `{"session_id":"sess-A","prompt":"/caveman ultra"}` and `{"session_id":"sess-B","prompt":"/caveman lite"}` through `caveman-mode-tracker.js`. Confirmed `.caveman-active-sess-A=ultra`, `.caveman-active-sess-B=lite`, both intact.
- [x] Statusline: `echo '{"session_id":"sess-A"}' | bash caveman-statusline.sh` → `[CAVEMAN:ULTRA]`. Same for sess-B → `[CAVEMAN:LITE]`. Empty stdin / no `session_id` → falls back to global flag.
- [x] Stale cleanup: a flag with `mtime` 3 days old is removed on SessionStart; a fresh one is preserved.
- [x] Full `python3 -m unittest tests.test_hooks`: 7/7 pass against `fix/issue-184` HEAD `cdd7612` cloned fresh from fork.
- [x] Both Qodo bot concerns addressed with explicit replies on the PR threads.