### PR TITLE
fix(compress): bail loudly on empty / unchanged compression instead of silent data loss

### DIFF
--- a/skills/compress/scripts/compress.py
+++ b/skills/compress/scripts/compress.py
@@ -182,6 +182,15 @@ def compress_file(filepath: Path) -> bool:
     original_text = filepath.read_text(errors="ignore")
     backup_path = filepath.with_name(filepath.stem + ".original.md")
 
+    # Refuse to "compress" an empty file. Without this, an empty input would
+    # round-trip through Claude and produce an empty backup + empty target,
+    # silently destroying nothing of value but reporting "success" — which
+    # earlier masked the real bug from #237 where users saw an empty backup
+    # and assumed a data-loss bug.
+    if not original_text.strip():
+        print("❌ Refusing to compress: file is empty or whitespace-only.")
+        return False
+
     # Check if backup already exists to prevent accidental overwriting
     if backup_path.exists():
         print(f"⚠️ Backup file already exists: {backup_path}")
@@ -193,8 +202,37 @@ def compress_file(filepath: Path) -> bool:
     print("Compressing with Claude...")
     compressed = call_claude(build_compress_prompt(original_text))
 
-    # Save original as backup, write compressed to original path
+    # Defensive checks before any write touches disk. The bug in #237 had
+    # users seeing an empty backup file and an unchanged input, with the
+    # script still printing "Compression completed successfully" — i.e.
+    # silent data loss masked by a green path. The right answer is to bail
+    # loudly *before* the writes happen rather than try to clean up after.
+    if compressed is None or not compressed.strip():
+        print("❌ Compression aborted: Claude returned an empty response.")
+        print("   Original file is untouched (no backup created).")
+        return False
+
+    if compressed.strip() == original_text.strip():
+        print("❌ Compression aborted: output is identical to input.")
+        print("   Likely causes: Claude refused, returned the prompt verbatim, or the file is")
+        print("   already in caveman form. Original file is untouched (no backup created).")
+        return False
+
+    # Save original as backup, write compressed to original path. Re-read the
+    # backup we just wrote and compare against the in-memory original_text:
+    # if they don't match, the filesystem dropped bytes (encoding mismatch,
+    # disk full, antivirus quarantine on Windows). Roll back rather than
+    # leave the user with a corrupt backup and a compressed primary.
     backup_path.write_text(original_text)
+    backup_readback = backup_path.read_text(errors="ignore")
+    if backup_readback != original_text:
+        print(f"❌ Backup write verification failed: {backup_path}")
+        print("   In-memory original differs from on-disk backup. Aborting before touching the input file.")
+        try:
+            backup_path.unlink()
+        except OSError:
+            pass
+        return False
     filepath.write_text(compressed)
 
     # Step 2: Validate + Retry

--- a/tests/test_compress_safety.py
+++ b/tests/test_compress_safety.py
@@ -1,0 +1,85 @@
+"""Tests for the data-loss guards in `compress_file` (issue #237).
+
+The compress orchestrator used to overwrite the input even when Claude
+returned an empty string or a no-op echo, and used to write a backup
+without verifying that the bytes survived the round-trip. These tests
+pin the new defensive checks: nothing on disk changes when the compressed
+output is empty or identical to the input, and a backup-write that drops
+bytes is detected before the input is overwritten.
+"""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from skills.compress.scripts import compress as compress_mod  # noqa: E402
+
+
+class CompressSafetyTests(unittest.TestCase):
+    def _file_with(self, dirpath: Path, text: str) -> Path:
+        path = dirpath / "task.md"
+        path.write_text(text)
+        return path
+
+    def test_empty_input_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._file_with(Path(tmp), "")
+            with mock.patch.object(compress_mod, "call_claude") as call:
+                ok = compress_mod.compress_file(path)
+            self.assertFalse(ok)
+            call.assert_not_called()
+            self.assertEqual(path.read_text(), "")
+            self.assertFalse((Path(tmp) / "task.original.md").exists())
+
+    def test_empty_compressed_output_does_not_touch_disk(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            original = "# Heading\n\nSome long natural language paragraph that should be compressed.\n"
+            path = self._file_with(Path(tmp), original)
+            with mock.patch.object(compress_mod, "call_claude", return_value=""):
+                ok = compress_mod.compress_file(path)
+            self.assertFalse(ok)
+            self.assertEqual(path.read_text(), original)
+            self.assertFalse((Path(tmp) / "task.original.md").exists())
+
+    def test_whitespace_only_compressed_output_does_not_touch_disk(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            original = "# Heading\n\nProse that should change.\n"
+            path = self._file_with(Path(tmp), original)
+            with mock.patch.object(compress_mod, "call_claude", return_value="   \n  "):
+                ok = compress_mod.compress_file(path)
+            self.assertFalse(ok)
+            self.assertEqual(path.read_text(), original)
+            self.assertFalse((Path(tmp) / "task.original.md").exists())
+
+    def test_identical_compressed_output_does_not_touch_disk(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            original = "# Heading\n\nProse.\n"
+            path = self._file_with(Path(tmp), original)
+            with mock.patch.object(compress_mod, "call_claude", return_value=original):
+                ok = compress_mod.compress_file(path)
+            self.assertFalse(ok)
+            self.assertEqual(path.read_text(), original)
+            self.assertFalse((Path(tmp) / "task.original.md").exists())
+
+    def test_real_compression_writes_backup_and_target(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            original = "# Heading\n\nThe quick brown fox jumps over the lazy dog.\n"
+            compressed = "# Heading\n\nFox jump dog.\n"
+            path = self._file_with(Path(tmp), original)
+            with mock.patch.object(compress_mod, "call_claude", return_value=compressed), \
+                 mock.patch.object(compress_mod, "validate") as v:
+                v.return_value = mock.Mock(is_valid=True, errors=[], warnings=[])
+                ok = compress_mod.compress_file(path)
+            self.assertTrue(ok)
+            self.assertEqual(path.read_text(), compressed)
+            backup = Path(tmp) / "task.original.md"
+            self.assertEqual(backup.read_text(), original)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #237

## Summary

`/caveman:compress` could finish with `Validation passed` / `Compression completed successfully` while leaving the input file unchanged and the `*.original.md` backup empty (or vice versa). The orchestrator trusted Claude's response and wrote both files unconditionally, so three failure modes slipped through:

1. Claude returned an empty (or whitespace-only) string — overwrote both files without complaint.
2. Claude returned the input verbatim (refusal, echo) — passed validation trivially because there were no diffs to check.
3. The backup write completed on disk but with bytes dropped (Windows encoding / antivirus quarantine) — not detected before the input file was overwritten.

Defensive checks added before any write touches the input:

- Refuse empty-or-whitespace **input** up front.
- Refuse empty-or-whitespace **compressed output** before opening any destination file.
- Refuse compressed output that is identical to the input after `strip()`.
- After writing the backup, read it back and compare against the in-memory original; on mismatch, unlink the bad backup and abort before the input file is touched.

Each refusal prints a concrete reason and a "no backup created" line so the user does not have to guess whether they lost data.

## Test plan

- [x] New `tests/test_compress_safety.py` — five unit tests covering: empty input refused, empty compressed output rejected, whitespace-only compressed output rejected, identical compressed output rejected, real compression writes both files. `python3 -m unittest tests.test_compress_safety` passes 5/5.
- [x] All five tests confirm the input file is left byte-identical and **no** `.original.md` is created on the rejection paths — the exact symptom from the bug report.