### PR TITLE
fix(compress): validate inline code spans (close silent-overwrite gap)

### DIFF
--- a/skills/compress/scripts/validate.py
+++ b/skills/compress/scripts/validate.py
@@ -6,6 +6,14 @@ URL_REGEX = re.compile(r"https?://[^\s)]+")
 FENCE_OPEN_REGEX = re.compile(r"^(\s{0,3})(`{3,}|~{3,})(.*)$")
 HEADING_REGEX = re.compile(r"^(#{1,6})\s+(.*)", re.MULTILINE)
 BULLET_REGEX = re.compile(r"^\s*[-*+]\s+", re.MULTILINE)
+# Inline code span. Greedy on the inside, but bounded by a single line —
+# matches CommonMark single-backtick inline code, which is what the
+# compress prompt promises to preserve. Multi-backtick wrappers
+# (`` `code with backticks` ``) are intentionally not handled here:
+# they're rare in caveman-compress targets (CLAUDE.md / memory files)
+# and conservatively under-matching is safer than greedy spans that
+# accidentally bridge two different inline runs.
+INLINE_CODE_REGEX = re.compile(r"`([^`\n]+)`")
 
 # crude but effective path detection
 # Requires either a path prefix (./ ../ / or drive letter) or a slash/backslash within the match
@@ -81,6 +89,27 @@ def extract_code_blocks(text):
     return blocks
 
 
+def _strip_fenced_blocks(text: str) -> str:
+    """Return text with fenced code blocks removed.
+
+    Inline-code validation must not double-count backtick runs that live
+    inside a fenced block — those are already covered by
+    `validate_code_blocks`, and a shell snippet containing a `\\`` literal
+    inside a fenced block would otherwise generate spurious inline
+    mismatches.
+    """
+    blocks = extract_code_blocks(text)
+    out = text
+    for block in blocks:
+        out = out.replace(block, "", 1)
+    return out
+
+
+def extract_inline_code(text):
+    """Return ordered list of inline code spans outside fenced blocks."""
+    return INLINE_CODE_REGEX.findall(_strip_fenced_blocks(text))
+
+
 def extract_urls(text):
     return set(URL_REGEX.findall(text))
 
@@ -113,6 +142,30 @@ def validate_code_blocks(orig, comp, result):
 
     if c1 != c2:
         result.add_error("Code blocks not preserved exactly")
+
+
+def validate_inline_code(orig, comp, result):
+    """Inline backtick spans are part of the preservation contract.
+
+    `caveman-compress` promises to preserve commands, env vars, file
+    paths, and other technical content inside inline backticks exactly
+    (see SKILL.md / README.md). Without this check, the validator could
+    print "Validation passed" while `npm install` had been rewritten to
+    `yarn install` — silent drift on memory files (#112).
+    """
+    i1 = extract_inline_code(orig)
+    i2 = extract_inline_code(comp)
+
+    if i1 != i2:
+        # Surface a small diff sample so the failing span is obvious in
+        # the log without dumping the entire file.
+        s1, s2 = set(i1), set(i2)
+        lost = sorted(s1 - s2)[:5]
+        added = sorted(s2 - s1)[:5]
+        result.add_error(
+            "Inline code not preserved exactly: "
+            f"lost={lost} added={added}"
+        )
 
 
 def validate_urls(orig, comp, result):
@@ -155,6 +208,7 @@ def validate(original_path: Path, compressed_path: Path) -> ValidationResult:
 
     validate_headings(orig, comp, result)
     validate_code_blocks(orig, comp, result)
+    validate_inline_code(orig, comp, result)
     validate_urls(orig, comp, result)
     validate_paths(orig, comp, result)
     validate_bullets(orig, comp, result)

--- a/tests/test_validate_inline_code.py
+++ b/tests/test_validate_inline_code.py
@@ -1,0 +1,78 @@
+"""Tests for the inline-code validation guard (issue #112).
+
+The validator used to never inspect inline backtick spans, so a
+compression run could rewrite `npm install` -> `yarn install` and still
+print "Validation passed". These tests pin the new check.
+"""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from skills.compress.scripts.validate import (  # noqa: E402
+    validate,
+    extract_inline_code,
+)
+
+
+class ExtractInlineCodeTests(unittest.TestCase):
+    def test_extracts_simple_inline(self):
+        self.assertEqual(
+            extract_inline_code("Run `npm install` then `yarn build`."),
+            ["npm install", "yarn build"],
+        )
+
+    def test_skips_fenced_block_content(self):
+        text = "Outside `keep`.\n\n```bash\necho `inside fence`\n```\n\nOutside `also`.\n"
+        self.assertEqual(extract_inline_code(text), ["keep", "also"])
+
+    def test_returns_empty_when_none(self):
+        self.assertEqual(extract_inline_code("Just prose with no code."), [])
+
+
+class ValidateInlineCodeTests(unittest.TestCase):
+    def _validate(self, orig: str, comp: str):
+        with tempfile.TemporaryDirectory() as tmp:
+            o = Path(tmp) / "o.md"
+            c = Path(tmp) / "c.md"
+            o.write_text(orig)
+            c.write_text(comp)
+            return validate(o, c)
+
+    def test_changed_inline_command_is_error(self):
+        result = self._validate(
+            "# T\nRun `npm install` and set `NODE_ENV=production`.\n",
+            "# T\nRun `yarn install` and set `NODE_ENV=development`.\n",
+        )
+        self.assertFalse(result.is_valid)
+        self.assertTrue(
+            any("Inline code not preserved exactly" in e for e in result.errors),
+            f"missing inline-code error in {result.errors}",
+        )
+
+    def test_unchanged_inline_passes(self):
+        # Same inline tokens preserved; surrounding prose differs.
+        result = self._validate(
+            "# T\nRun `npm install` to install all dependencies.\n",
+            "# T\nRun `npm install` to install deps.\n",
+        )
+        self.assertTrue(result.is_valid, f"unexpected errors: {result.errors}")
+
+    def test_inline_inside_fence_does_not_trigger_false_positive(self):
+        # Backticks inside a fenced block are validated by validate_code_blocks,
+        # not by validate_inline_code. The block is identical between orig and
+        # comp, so the inline check should see zero spans on both sides.
+        block = "```bash\nrun `cmd a` then `cmd b`\n```"
+        result = self._validate(
+            f"# T\n\n{block}\n\nProse with `keep` token.\n",
+            f"# T\n\n{block}\n\nShorter prose with `keep` token.\n",
+        )
+        self.assertTrue(result.is_valid, f"unexpected errors: {result.errors}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #112

## Summary

`/caveman:compress` printed "Validation passed" while inline backtick content had been silently rewritten. The validator covered fenced code blocks, headings, URLs, paths (warning-only), and bullets — but **not** inline code spans, the very content the prompt and SKILL.md promise to preserve exactly. The reproducer from the issue rewrites \`npm install\` → \`yarn install\` and \`NODE_ENV=production\` → \`NODE_ENV=development\` and the run still reports success.

## Fix

- New `validate_inline_code` plugged into the main `validate()` pipeline.
- Inline spans are extracted **after** stripping fenced code blocks. Backticks inside a fenced block are already covered by `validate_code_blocks`, and the inline regex would otherwise produce noisy false-positives on shell snippets like `` echo `cmd` ``.
- Comparison is on the ordered list, not the multiset, so a re-ordered inline span (`` `--flag-a` `` and `` `--flag-b` `` swapped) still fails — preserving order is part of preserving the technical instruction.
- Mismatches surface up to five lost / added inline spans in the error message so the failing token is obvious in the log without dumping the entire file.

The maintainer's patch sketch suggested also promoting `validate_paths` from warning to error. I left that as warning for this PR — the path regex is heuristic (`PATH_REGEX` is comment-described as "crude but effective") and promoting it would risk false positives on regular compression runs. Happy to follow up in a separate PR if you'd like.

## Test plan

- [x] New `tests/test_validate_inline_code.py` (6 tests). `python3 -m unittest tests.test_validate_inline_code` passes 6/6.
- [x] Reproduces the exact scenario from the bug report: \`npm install\` -> \`yarn install\` now produces `Inline code not preserved exactly: lost=['NODE_ENV=production', 'npm install'] added=['NODE_ENV=development', 'yarn install']` and `is_valid=False`.
- [x] Confirms prose changes around preserved inline code still pass (no false-positive regression).
- [x] Confirms backticks living inside fenced blocks don't trigger the inline check.