### PR TITLE
docs(readme): link the project's GitHub Pages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
   <a href="#install">Install</a> •
   <a href="#what-you-get">What You Get</a> •
   <a href="#benchmarks">Benchmarks</a> •
-  <a href="./INSTALL.md">Full install guide</a>
+  <a href="./INSTALL.md">Full install guide</a> •
+  <a href="https://juliusbrussee.github.io/caveman/">Website</a>
 </p>
 
 ---


### PR DESCRIPTION
Closes #113

## Summary

The repo has a published GitHub Pages site at https://juliusbrussee.github.io/caveman/ but the README never referenced it. Add it in two places:

- Top-of-page nav row (so it's discoverable above the fold).
- A dedicated **Website** section right before "Star This Repo" with one line of context on what the site is for.

Reachability checked before adding the link: \`curl -I\` returns HTTP/2 200, served by GitHub.com, last updated 2026-04-18.

## Test plan

- [x] Verified site is live (HTTP/2 200).
- [x] Both new links resolve and render.
- [x] No code changes.