### PR TITLE
enh: add /caveman-stats command for session token usage stats (Claude…

### DIFF
--- a/commands/caveman-stats.toml
+++ b/commands/caveman-stats.toml
@@ -1,0 +1,2 @@
+description = "Show token usage and estimated savings for the current session"
+prompt = "Run caveman-stats and display the output."

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -5,6 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { execFileSync } = require('child_process');
 const { getDefaultMode, safeWriteFlag, readFlag } = require('./caveman-config');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
@@ -28,6 +29,25 @@ process.stdin.on('end', () => {
           safeWriteFlag(flagPath, mode);
         }
       }
+    }
+
+    if (prompt === '/caveman-stats' || prompt === '/caveman:caveman-stats') {
+      try {
+        const statsPath = path.join(__dirname, 'caveman-stats.js');
+        const args = [statsPath];
+        if (data.transcript_path) args.push('--session-file', data.transcript_path);
+        const output = execFileSync(process.execPath, args, {
+          encoding: 'utf8',
+          timeout: 5000
+        });
+        process.stdout.write(JSON.stringify({ decision: 'block', reason: output.trim() }));
+      } catch (e) {
+        process.stdout.write(JSON.stringify({
+          decision: 'block',
+          reason: 'caveman-stats: could not run stats script.\nTry manually: node hooks/caveman-stats.js'
+        }));
+      }
+      process.exit(0);
     }
 
     // Match /caveman commands

--- a/hooks/caveman-stats.js
+++ b/hooks/caveman-stats.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// caveman-stats reads the active Claude Code session file and prints token usage
+// plus an estimated savings figure based on the full-mode benchmark average.
+// Run it directly any time: node hooks/caveman-stats.js
+// Inside Claude Code, /caveman-stats triggers this via the UserPromptSubmit hook.
+
+const fs   = require('fs');
+const path = require('path');
+const os   = require('os');
+const { readFlag } = require('./caveman-config');
+
+// Only 'full' mode has a measured compression ratio (65% average across 10 tasks,
+// from the benchmark in benchmarks/). No measured data exists for other modes.
+const COMPRESSION = {
+  'full': 0.65,
+};
+
+function findMostRecentFile(dirs, matchFn) {
+  let latest = null;
+  let latestMtime = 0;
+  for (const dir of dirs) {
+    let entries;
+    try { entries = fs.readdirSync(dir); } catch { continue; }
+    for (const entry of entries) {
+      const fp = path.join(dir, entry);
+      try {
+        const st = fs.statSync(fp);
+        if (st.isDirectory()) {
+          const nested = findMostRecentFile([fp], matchFn);
+          if (nested && nested.mtime > latestMtime) {
+            latestMtime = nested.mtime; latest = nested;
+          }
+        } else if (matchFn(entry) && st.mtimeMs > latestMtime) {
+          latestMtime = st.mtimeMs; latest = { file: fp, mtime: st.mtimeMs };
+        }
+      } catch {}
+    }
+  }
+  return latest;
+}
+
+function findClaudeCodeSession() {
+  const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+  const result = findMostRecentFile(
+    [path.join(claudeDir, 'projects')],
+    (name) => name.endsWith('.jsonl')
+  );
+  return result ? result.file : null;
+}
+
+function parseSession(filePath) {
+  let raw;
+  try { raw = fs.readFileSync(filePath, 'utf8'); } catch { return { outputTokens: 0, cacheReadTokens: 0, turns: 0 }; }
+  let outputTokens = 0, cacheReadTokens = 0, turns = 0;
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'assistant' && entry.message?.usage) {
+        const u = entry.message.usage;
+        outputTokens    += u.output_tokens           || 0;
+        cacheReadTokens += u.cache_read_input_tokens || 0;
+        turns++;
+      }
+    } catch {}
+  }
+  return { outputTokens, cacheReadTokens, turns };
+}
+
+// --session-file is passed by caveman-mode-tracker.js via the hook's transcript_path
+// so we always read the active session, not whichever file was modified most recently.
+const cliArgs = process.argv.slice(2);
+const sessionFileArg = (() => {
+  const i = cliArgs.indexOf('--session-file');
+  return i !== -1 ? cliArgs[i + 1] : null;
+})();
+
+const sessionFile = sessionFileArg || findClaudeCodeSession();
+
+if (!sessionFile) {
+  process.stderr.write('caveman-stats: no Claude Code session found.\n');
+  process.exit(1);
+}
+
+const { outputTokens, cacheReadTokens, turns } = parseSession(sessionFile);
+const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+const mode  = readFlag(path.join(claudeDir, '.caveman-active'));
+const ratio = COMPRESSION[mode] ?? null;
+const sep   = '──────────────────────────────────';
+const shortPath = sessionFile.length > 45 ? '...' + sessionFile.slice(-45) : sessionFile;
+
+if (turns === 0) {
+  process.stdout.write(`
+Caveman Stats
+${sep}
+No conversation yet — stats available after first response.
+${sep}
+`);
+  process.exit(0);
+}
+
+let savingsBlock, footer;
+if (ratio !== null) {
+  const estNormal = Math.round(outputTokens / (1 - ratio));
+  const estSaved  = estNormal - outputTokens;
+  savingsBlock = [
+    `Est. without caveman:  ${estNormal.toLocaleString()}`,
+    `Est. tokens saved:     ${estSaved.toLocaleString()} (~${Math.round(ratio * 100)}%)`,
+  ].join('\n');
+  footer = 'Savings est. from 10-task benchmark (benchmarks/). Actual varies by task.';
+} else if (mode && mode !== 'off') {
+  savingsBlock = `No savings estimate for '${mode}' mode — only 'full' has benchmark data.`;
+  footer = '';
+} else {
+  savingsBlock = 'Caveman not active this session.';
+  footer = '';
+}
+
+process.stdout.write(`
+Caveman Stats
+${sep}
+Session:  ${shortPath}
+Turns:    ${turns}
+${sep}
+Output tokens:         ${outputTokens.toLocaleString()}
+Cache-read tokens:     ${cacheReadTokens.toLocaleString()}
+${sep}
+${savingsBlock}
+${footer ? footer + '\n' : ''}`);

--- a/hooks/install.ps1
+++ b/hooks/install.ps1
@@ -24,7 +24,7 @@ $HooksDir = Join-Path $ClaudeDir "hooks"
 $Settings = Join-Path $ClaudeDir "settings.json"
 $RepoUrl = "https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks"
 
-$HookFiles = @("package.json", "caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-statusline.sh", "caveman-statusline.ps1")
+$HookFiles = @("package.json", "caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-stats.js", "caveman-statusline.sh", "caveman-statusline.ps1")
 
 # Resolve source — works from repo clone or remote
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { $null }

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -37,7 +37,7 @@ HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS="$CLAUDE_DIR/settings.json"
 REPO_URL="https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks"
 
-HOOK_FILES=("package.json" "caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-statusline.sh")
+HOOK_FILES=("package.json" "caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-stats.js" "caveman-statusline.sh")
 
 # Resolve source — works from repo clone or curl pipe
 SCRIPT_DIR=""

--- a/hooks/uninstall.ps1
+++ b/hooks/uninstall.ps1
@@ -11,7 +11,7 @@ $HooksDir = Join-Path $ClaudeDir "hooks"
 $Settings = Join-Path $ClaudeDir "settings.json"
 $FlagFile = Join-Path $ClaudeDir ".caveman-active"
 
-$HookFiles = @("package.json", "caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-statusline.sh", "caveman-statusline.ps1")
+$HookFiles = @("package.json", "caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-stats.js", "caveman-statusline.sh", "caveman-statusline.ps1")
 
 # Detect if caveman is installed as a plugin
 $PluginInstalled = $false

--- a/hooks/uninstall.sh
+++ b/hooks/uninstall.sh
@@ -10,7 +10,7 @@ HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS="$CLAUDE_DIR/settings.json"
 FLAG_FILE="$CLAUDE_DIR/.caveman-active"
 
-HOOK_FILES=("package.json" "caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-statusline.sh")
+HOOK_FILES=("package.json" "caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-stats.js" "caveman-statusline.sh")
 
 # Detect if caveman is installed as a plugin (check plugin cache)
 PLUGIN_INSTALLED=0

--- a/plugins/caveman/skills/caveman-stats/SKILL.md
+++ b/plugins/caveman/skills/caveman-stats/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: caveman-stats
+description: >
+  Shows real token usage and estimated savings for the current session.
+  Reads directly from the session log file — no AI estimation needed.
+  Invoke with /caveman-stats.
+---
+
+Show token usage stats for this session. Data comes from the session log, not from estimating context.

--- a/skills/caveman-stats/SKILL.md
+++ b/skills/caveman-stats/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: caveman-stats
+description: >
+  Shows real token usage and estimated savings for the current session.
+  Reads directly from the session log file — no AI estimation needed.
+  Invoke with /caveman-stats.
+---
+
+Show token usage stats for this session. Data comes from the session log, not from estimating context.


### PR DESCRIPTION
… Code only)

Addresses #251

Caveman cut token. But user no know how many token caveman cut. This fix that.

## What

New `/caveman-stats` command. Type it, see real numbers from your session. No AI, no guessing, reads directly from the Claude Code session file that gets written to disk as you chat. Hook intercepts the command before Claude sees it, so running stats costs nothing.

Output look like this:

```
Caveman Stats
──────────────────────────────────
Session:  .../<session>.jsonl
Turns:    12
──────────────────────────────────
Output tokens:         1,840
Cache-read tokens:     204,112
──────────────────────────────────
Est. without caveman:  5,257
Est. tokens saved:     3,417 (~65%)
──────────────────────────────────
Savings est. from 10-task benchmark (benchmarks/). Actual varies by task.
```

Savings estimate only shown for `full` mode, that the only mode with real benchmark data. No made-up numbers for other modes.

## Scope

Claude Code only for now. Gemini and Codex write session data to disk too (confirmed), but need live testing with working API keys before shipping (me no have now). Coming in a separate PR.
