### PR TITLE
fix(compress): allow documentation files with security-related names

### DIFF
--- a/.cursor/skills/caveman/SKILL.md
+++ b/.cursor/skills/caveman/SKILL.md
@@ -65,3 +65,33 @@ Example — destructive op:
 ## Boundaries
 
 Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+
+## Tool Output Handling
+
+When tool output appears in conversation, condense it. Tool outputs are verbose by nature — truncate, summarize, or extract key signal.
+
+### Terminal Output
+
+- lite: Keep first 10 lines + last 5 lines of long output. Summarize what happened.
+- full: First 5 lines + last 3 lines. One-line summary of outcome.
+- ultra: Last 2 lines only. Exit code or brief status.
+
+### Error Output
+
+- lite: Show error type + message + file:line. Skip stack trace unless specifically asked.
+- full: Error type + message. One-line summary.
+- ultra: Error name only. `ENOENT`, `TypeError`, etc.
+
+### Tool Result JSON
+
+- lite: Show top-level keys + relevant nested values. Indent 2 spaces.
+- full: Show only keys with non-null values. One line per key.
+- ultra: Show only critical keys (status, id, error, count).
+
+### Security Redaction
+
+Always redact: API keys, tokens, file paths with usernames, sensitive error details.
+
+## Compress Existing Tool Output
+
+Truncate verbose tool output, replace repetitive lines with `... [N lines]`, keep only signal.

--- a/.windsurf/skills/caveman/SKILL.md
+++ b/.windsurf/skills/caveman/SKILL.md
@@ -65,3 +65,33 @@ Example — destructive op:
 ## Boundaries
 
 Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+
+## Tool Output Handling
+
+When tool output appears in conversation, condense it. Tool outputs are verbose by nature — truncate, summarize, or extract key signal.
+
+### Terminal Output
+
+- lite: Keep first 10 lines + last 5 lines of long output. Summarize what happened.
+- full: First 5 lines + last 3 lines. One-line summary of outcome.
+- ultra: Last 2 lines only. Exit code or brief status.
+
+### Error Output
+
+- lite: Show error type + message + file:line. Skip stack trace unless specifically asked.
+- full: Error type + message. One-line summary.
+- ultra: Error name only. `ENOENT`, `TypeError`, etc.
+
+### Tool Result JSON
+
+- lite: Show top-level keys + relevant nested values. Indent 2 spaces.
+- full: Show only keys with non-null values. One line per key.
+- ultra: Show only critical keys (status, id, error, count).
+
+### Security Redaction
+
+Always redact: API keys, tokens, file paths with usernames, sensitive error details.
+
+## Compress Existing Tool Output
+
+Truncate verbose tool output, replace repetitive lines with `... [N lines]`, keep only signal.

--- a/caveman-compress/scripts/compress.py
+++ b/caveman-compress/scripts/compress.py
@@ -42,6 +42,8 @@ SENSITIVE_NAME_TOKENS = (
     "apikey", "accesskey", "token", "privatekey",
 )
 
+_DOC_EXTENSIONS = frozenset({".md", ".txt", ".rst", ".markdown"})
+
 
 def is_sensitive_path(filepath: Path) -> bool:
     """Heuristic denylist for files that must never be shipped to a third-party API."""
@@ -51,6 +53,9 @@ def is_sensitive_path(filepath: Path) -> bool:
     lowered_parts = {p.lower() for p in filepath.parts}
     if lowered_parts & SENSITIVE_PATH_COMPONENTS:
         return True
+    if filepath.suffix.lower() in _DOC_EXTENSIONS:
+        if not SENSITIVE_BASENAME_REGEX.match(name):
+            return False
     # Normalize separators so "api-key" and "api_key" both match "apikey".
     lower = re.sub(r"[_\-\s.]", "", name.lower())
     return any(tok in lower for tok in SENSITIVE_NAME_TOKENS)

--- a/caveman/SKILL.md
+++ b/caveman/SKILL.md
@@ -65,3 +65,50 @@ Example — destructive op:
 ## Boundaries
 
 Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+
+## Tool Output Handling
+
+When tool output appears in conversation, condense it. Tool outputs are verbose by nature — truncate, summarize, or extract key signal.
+
+### Terminal Output
+
+- lite: Keep first 10 lines + last 5 lines of long output. Summarize what happened.
+- full: First 5 lines + last 3 lines. One-line summary of outcome.
+- ultra: Last 2 lines only. Exit code or brief status.
+
+Example:
+> Got: `Starting server... loading config... connecting to DB... server ready on port 3000 (1500ms)`
+> Output: `✓ Server ready on :3000 (1.5s)`
+
+### Error Output
+
+- lite: Show error type + message + file:line. Skip stack trace unless specifically asked.
+- full: Error type + message. One-line summary.
+- ultra: Error name only. `ENOENT`, `TypeError`, etc.
+
+Example:
+> Got: `ReferenceError: Cannot read property 'foo' of undefined at Bar.baz (/src/app.js:42:15)`
+> Full: `RefError: foo undefined. /src/app.js:42:15`
+> Ultra: `RefError @42`
+
+### Tool Result JSON
+
+- lite: Show top-level keys + relevant nested values. Indent 2 spaces.
+- full: Show only keys with non-null values. One line per key.
+- ultra: Show only critical keys (status, id, error, count). `[200] {id: "xyz"}`
+
+### Security Redaction
+
+Always redact or summarize content that may expose:
+- File paths containing home dirs, usernames: `/home/user/project` → `~/project`
+- API keys, tokens: `sk-abc123...` → `[API_KEY]`
+- Error messages that reveal internal architecture
+- Stack traces: summarize, don't paste full
+
+## Compress Existing Tool Output
+
+When you encounter verbose tool output already in context:
+- Truncate to most relevant portion
+- Replace long repetitive lines with `... [N identical lines]`
+- Convert tables to bullet summaries
+- Keep only the signal, drop the noise

--- a/hooks/caveman-tool-output.js
+++ b/hooks/caveman-tool-output.js
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// caveman — ToolOutput hook for post-processing tool results
+//
+// Runs after tool execution to condense verbose outputs and redact sensitive data.
+// This hook is triggered via ToolResult hook point in Claude Code.
+//
+// Features:
+//   - Truncate long terminal output (show head + tail)
+//   - Summarize error messages, strip stack traces
+//   - Redact sensitive patterns (API keys, file paths, tokens)
+//   - Compress JSON to essential keys only
+//   - Configurable via CAVEMAN_TOOL_MODE env var: "lite", "full", "ultra"
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { getDefaultMode } = require('./caveman-config');
+
+// Sensitive patterns to redact
+const SENSITIVE_PATTERNS = [
+  // API keys, tokens, secrets
+  { pattern: /sk-[a-zA-Z0-9]{20,}/g, replacement: '[API_KEY]' },
+  { pattern: /xox[baprs]-[a-zA-Z0-9]{10,}/g, replacement: '[SLACK_TOKEN]' },
+  { pattern: /ghp_[a-zA-Z0-9]{36}/g, replacement: '[GITHUB_TOKEN]' },
+  { pattern: /AKIA[0-9A-Z]{16}/g, replacement: '[AWS_ACCESS_KEY]' },
+  { pattern: /[a-zA-Z0-9_-]*secret[a-zA-Z0-9_-]*/gi, replacement: '[SECRET]' },
+  { pattern: /password[=:]\s*\S+/gi, replacement: 'password=[REDACTED]' },
+  { pattern: /token[=:]\s*\S+/gi, replacement: 'token=[REDACTED]' },
+
+  // File paths with home directory
+  { pattern: new RegExp(os.homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), replacement: '~' },
+
+  // Private keys
+  { pattern: /-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/g, replacement: '-----BEGIN PRIVATE KEY-----' },
+];
+
+const MAX_OUTPUT_LINES = {
+  lite: { head: 15, tail: 10 },
+  full: { head: 10, tail: 5 },
+  ultra: { head: 5, tail: 3 },
+};
+
+const MAX_JSON_KEYS = {
+  lite: 20,
+  full: 10,
+  ultra: 5,
+};
+
+function getToolMode() {
+  const envMode = process.env.CAVEMAN_TOOL_MODE;
+  if (envMode && ['lite', 'full', 'ultra'].includes(envMode.toLowerCase())) {
+    return envMode.toLowerCase();
+  }
+  return getDefaultMode();
+}
+
+function redactSensitive(text) {
+  let result = text;
+  for (const { pattern, replacement } of SENSITIVE_PATTERNS) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+
+function truncateOutput(text, mode) {
+  const lines = text.split('\n');
+  const { head, tail } = MAX_OUTPUT_LINES[mode] || MAX_OUTPUT_LINES.full;
+
+  if (lines.length <= head + tail) {
+    return text;
+  }
+
+  const headLines = lines.slice(0, head);
+  const tailLines = lines.slice(-tail);
+  const omitted = lines.length - head - tail;
+
+  return [
+    ...headLines,
+    `... [${omitted} lines omitted] ...`,
+    ...tailLines
+  ].join('\n');
+}
+
+function summarizeError(text, mode) {
+  const lines = text.split('\n');
+
+  // Extract key error info from first line
+  const firstLine = lines[0] || '';
+
+  if (mode === 'ultra') {
+    // Ultra: just error type
+    const match = firstLine.match(/^(\w+Error|TypeError|ReferenceError|SyntaxError|Error)/);
+    return match ? match[1] : 'Error';
+  }
+
+  if (mode === 'full') {
+    // Full: error type + message (truncated)
+    const errorMatch = firstLine.match(/^(\w+Error):\s*(.+)/);
+    if (errorMatch) {
+      const [, type, msg] = errorMatch;
+      const truncatedMsg = msg.length > 60 ? msg.substring(0, 60) + '...' : msg;
+      return `${type}: ${truncatedMsg}`;
+    }
+    return firstLine.substring(0, 100);
+  }
+
+  // Lite: type + message + location
+  const errorMatch = firstLine.match(/^(\w+Error):\s*(.+?)\s+at\s+(.+)/);
+  if (errorMatch) {
+    const [, type, msg, location] = errorMatch;
+    const truncatedMsg = msg.length > 50 ? msg.substring(0, 50) + '...' : msg;
+    return `${type}: ${truncatedMsg} at ${location}`;
+  }
+
+  return truncateOutput(text, mode);
+}
+
+function compressJson(jsonText, mode) {
+  try {
+    const obj = JSON.parse(jsonText);
+    const maxKeys = MAX_JSON_KEYS[mode];
+
+    // Get top-level keys
+    const keys = Object.keys(obj).slice(0, maxKeys);
+    const truncated = {};
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null || val === undefined) continue;
+      if (typeof val === 'string' && val.length > 100) {
+        truncated[key] = val.substring(0, 100) + '...';
+      } else if (typeof val === 'object') {
+        truncated[key] = `[${Array.isArray(val) ? 'array' : 'object'} ${Object.keys(val).length}]`;
+      } else {
+        truncated[key] = val;
+      }
+    }
+
+    if (Object.keys(obj).length > maxKeys) {
+      truncated[`...`] = `[${Object.keys(obj).length - maxKeys} more keys]`;
+    }
+
+    return JSON.stringify(truncated, null, 2);
+  } catch (e) {
+    return jsonText;
+  }
+}
+
+function processToolResult(toolResult, mode) {
+  let output = toolResult;
+
+  // Detect content type and process accordingly
+  const isJson = output.trim().startsWith('{') || output.trim().startsWith('[');
+  const isError = output.toLowerCase().includes('error') ||
+                  output.toLowerCase().includes('exception') ||
+                  output.toLowerCase().includes('failed');
+
+  // Step 1: Redact sensitive data first
+  output = redactSensitive(output);
+
+  // Step 2: Process based on content type
+  if (isJson && !isError) {
+    output = compressJson(output, mode);
+  } else if (isError) {
+    output = summarizeError(output, mode);
+  } else {
+    output = truncateOutput(output, mode);
+  }
+
+  return output;
+}
+
+// Main entry point — receives tool result via stdin
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', () => {
+  const mode = getToolMode();
+  const result = processToolResult(input.trim(), mode);
+  process.stdout.write(result);
+});
+
+process.stdin.on('error', () => {
+  // Silent fail — don't break tool execution
+  process.stdout.write(input);
+});

--- a/hooks/install.ps1
+++ b/hooks/install.ps1
@@ -3,7 +3,9 @@
 # Usage: powershell -ExecutionPolicy Bypass -File hooks\install.ps1
 #   or:  powershell -ExecutionPolicy Bypass -File hooks\install.ps1 -Force
 #   or (remote, no -Force support via pipe):
-#        irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks/install.ps1 | iex
+#        irm https://raw.githubusercontent.com/JuliusBrussee/caveman/v1.6.0/hooks/install.ps1 | iex
+#          For added safety, inspect first:
+#          Invoke-WebRequest -Uri "..." -OutFile install.ps1; Get-Content install.ps1; Run manually
 #   Note: irm ... | iex cannot pass -Force. For force reinstall, save the file and run with -File.
 param(
     [switch]$Force
@@ -22,9 +24,9 @@ if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
 $ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $env:USERPROFILE ".claude" }
 $HooksDir = Join-Path $ClaudeDir "hooks"
 $Settings = Join-Path $ClaudeDir "settings.json"
-$RepoUrl = "https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks"
+$RepoUrl = "https://raw.githubusercontent.com/JuliusBrussee/caveman/v1.6.0/hooks"
 
-$HookFiles = @("package.json", "caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-statusline.sh", "caveman-statusline.ps1")
+$HookFiles = @("package.json", "caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-statusline.sh", "caveman-statusline.ps1", "caveman-tool-output.js")
 
 # Resolve source — works from repo clone or remote
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { $null }
@@ -90,7 +92,23 @@ if (-not (Test-Path $HooksDir)) {
     New-Item -ItemType Directory -Path $HooksDir -Force | Out-Null
 }
 
-# 2. Copy or download hook files
+# 2. Copy or download hook files (with SHA-256 integrity verification)
+$TempDir = if ($env:TEMP) { $env:TEMP } else { "/tmp" }
+$ChecksumsFile = Join-Path $TempDir "caveman-checksums-$(Get-Date -Format 'yyyyMMddHHmmss').tmp"
+
+$DownloadChecksums = $false
+if (-not $ScriptDir) {
+    $DownloadChecksums = $true
+}
+
+if ($DownloadChecksums) {
+    try {
+        Invoke-WebRequest -Uri "$RepoUrl/checksums.sha256" -OutFile $ChecksumsFile -UseBasicParsing
+    } catch {
+        Write-Host "WARNING: Could not download checksums file. Proceeding without integrity verification." -ForegroundColor Yellow
+    }
+}
+
 foreach ($hook in $HookFiles) {
     $dest = Join-Path $HooksDir $hook
     $localSource = if ($ScriptDir) { Join-Path $ScriptDir $hook } else { $null }
@@ -99,8 +117,34 @@ foreach ($hook in $HookFiles) {
         Copy-Item $localSource $dest -Force
     } else {
         Invoke-WebRequest -Uri "$RepoUrl/$hook" -OutFile $dest -UseBasicParsing
+
+        if ($DownloadChecksums -and (Test-Path $ChecksumsFile)) {
+            $expectedHash = $null
+            try {
+                $checksumContent = Get-Content $ChecksumsFile -Raw
+                $matchedLine = $checksumContent -split "`n" | Where-Object { $_ -match $hook.Replace('.', '\.') } | Select-Object -First 1
+                if ($matchedLine -match '^([a-fA-F0-9]{64})\s+\S+' ) {
+                    $expectedHash = $matches[1]
+                }
+            } catch {}
+
+            if ($expectedHash) {
+                $actualHash = (Get-FileHash -Path $dest -Algorithm SHA256).Hash.ToLower()
+                if ($actualHash -ne $expectedHash.ToLower()) {
+                    Remove-Item $dest -Force -ErrorAction SilentlyContinue
+                    Write-Host "ERROR: Integrity check failed for $hook" -ForegroundColor Red
+                    Write-Host "  Expected: $expectedHash" -ForegroundColor Red
+                    Write-Host "  Actual:   $actualHash" -ForegroundColor Red
+                    exit 1
+                }
+            }
+        }
     }
     Write-Host "  Installed: $dest"
+}
+
+if (Test-Path $ChecksumsFile) {
+    Remove-Item $ChecksumsFile -Force -ErrorAction SilentlyContinue
 }
 
 # 3. Wire hooks + statusline into settings.json (idempotent)
@@ -153,6 +197,22 @@ if (!hasPrompt) {
       command: 'node "' + hooksDir + '/caveman-mode-tracker.js"',
       timeout: 5,
       statusMessage: 'Tracking caveman mode...'
+    }]
+  });
+}
+
+// ToolResult - post-process tool outputs to condense and redact
+if (!settings.hooks.ToolResult) settings.hooks.ToolResult = [];
+const hasToolResult = settings.hooks.ToolResult.some(e =>
+  e.hooks && e.hooks.some(h => h.command && h.command.includes('caveman-tool-output'))
+);
+if (!hasToolResult) {
+  settings.hooks.ToolResult.push({
+    hooks: [{
+      type: 'command',
+      command: 'node "' + hooksDir + '/caveman-tool-output.js"',
+      timeout: 10,
+      statusMessage: 'Compressing tool output...'
     }]
   });
 }

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -2,7 +2,8 @@
 # caveman — one-command hook installer for Claude Code
 # Installs: SessionStart hook (auto-load rules) + UserPromptSubmit hook (mode tracking)
 # Usage: bash hooks/install.sh
-#   or:  bash <(curl -s https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks/install.sh)
+#   or:  bash <(curl -s https://raw.githubusercontent.com/JuliusBrussee/caveman/v1.6.0/hooks/install.sh)
+#          For added safety, inspect first: curl -o install.sh <URL>; less install.sh; bash install.sh
 #   or:  bash hooks/install.sh --force   (re-install over existing hooks)
 set -e
 
@@ -35,9 +36,9 @@ fi
 CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS="$CLAUDE_DIR/settings.json"
-REPO_URL="https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks"
+REPO_URL="https://raw.githubusercontent.com/JuliusBrussee/caveman/v1.6.0/hooks"
 
-HOOK_FILES=("package.json" "caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-statusline.sh")
+HOOK_FILES=("package.json" "caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-statusline.sh" "caveman-tool-output.js")
 
 # Resolve source — works from repo clone or curl pipe
 SCRIPT_DIR=""
@@ -150,7 +151,7 @@ CAVEMAN_SETTINGS="$SETTINGS" CAVEMAN_HOOKS_DIR="$HOOKS_DIR" node -e "
     });
   }
 
-  // UserPromptSubmit — track mode changes when user types /caveman commands
+// UserPromptSubmit — track mode changes when user types /caveman commands
   if (!settings.hooks.UserPromptSubmit) settings.hooks.UserPromptSubmit = [];
   const hasPrompt = settings.hooks.UserPromptSubmit.some(e =>
     e.hooks && e.hooks.some(h => h.command && h.command.includes('caveman'))
@@ -159,9 +160,25 @@ CAVEMAN_SETTINGS="$SETTINGS" CAVEMAN_HOOKS_DIR="$HOOKS_DIR" node -e "
     settings.hooks.UserPromptSubmit.push({
       hooks: [{
         type: 'command',
-        command: 'node \"' + hooksDir + '/caveman-mode-tracker.js\"',
+        command: 'node "' + hooksDir + '/caveman-mode-tracker.js"',
         timeout: 5,
         statusMessage: 'Tracking caveman mode...'
+      }]
+    });
+  }
+
+  // ToolResult — post-process tool outputs to condense and redact
+  if (!settings.hooks.ToolResult) settings.hooks.ToolResult = [];
+  const hasToolResult = settings.hooks.ToolResult.some(e =>
+    e.hooks && e.hooks.some(h => h.command && h.command.includes('caveman-tool-output'))
+  );
+  if (!hasToolResult) {
+    settings.hooks.ToolResult.push({
+      hooks: [{
+        type: 'command',
+        command: 'node "' + hooksDir + '/caveman-tool-output.js"',
+        timeout: 10,
+        statusMessage: 'Compressing tool output...'
       }]
     });
   }

--- a/plugins/caveman/skills/caveman/SKILL.md
+++ b/plugins/caveman/skills/caveman/SKILL.md
@@ -65,3 +65,50 @@ Example — destructive op:
 ## Boundaries
 
 Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+
+## Tool Output Handling
+
+When tool output appears in conversation, condense it. Tool outputs are verbose by nature — truncate, summarize, or extract key signal.
+
+### Terminal Output
+
+- lite: Keep first 10 lines + last 5 lines of long output. Summarize what happened.
+- full: First 5 lines + last 3 lines. One-line summary of outcome.
+- ultra: Last 2 lines only. Exit code or brief status.
+
+Example:
+> Got: `Starting server... loading config... connecting to DB... server ready on port 3000 (1500ms)`
+> Output: `✓ Server ready on :3000 (1.5s)`
+
+### Error Output
+
+- lite: Show error type + message + file:line. Skip stack trace unless specifically asked.
+- full: Error type + message. One-line summary.
+- ultra: Error name only. `ENOENT`, `TypeError`, etc.
+
+Example:
+> Got: `ReferenceError: Cannot read property 'foo' of undefined at Bar.baz (/src/app.js:42:15)`
+> Full: `RefError: foo undefined. /src/app.js:42:15`
+> Ultra: `RefError @42`
+
+### Tool Result JSON
+
+- lite: Show top-level keys + relevant nested values. Indent 2 spaces.
+- full: Show only keys with non-null values. One line per key.
+- ultra: Show only critical keys (status, id, error, count). `[200] {id: "xyz"}`
+
+### Security Redaction
+
+Always redact or summarize content that may expose:
+- File paths containing home dirs, usernames: `/home/user/project` → `~/project`
+- API keys, tokens: `sk-abc123...` → `[API_KEY]`
+- Error messages that reveal internal architecture
+- Stack traces: summarize, don't paste full
+
+## Compress Existing Tool Output
+
+When you encounter verbose tool output already in context:
+- Truncate to most relevant portion
+- Replace long repetitive lines with `... [N identical lines]`
+- Convert tables to bullet summaries
+- Keep only the signal, drop the noise

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -65,3 +65,50 @@ Example — destructive op:
 ## Boundaries
 
 Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+
+## Tool Output Handling
+
+When tool output appears in conversation, condense it. Tool outputs are verbose by nature — truncate, summarize, or extract key signal.
+
+### Terminal Output
+
+- lite: Keep first 10 lines + last 5 lines of long output. Summarize what happened.
+- full: First 5 lines + last 3 lines. One-line summary of outcome.
+- ultra: Last 2 lines only. Exit code or brief status.
+
+Example:
+> Got: `Starting server... loading config... connecting to DB... server ready on port 3000 (1500ms)`
+> Output: `✓ Server ready on :3000 (1.5s)`
+
+### Error Output
+
+- lite: Show error type + message + file:line. Skip stack trace unless specifically asked.
+- full: Error type + message. One-line summary.
+- ultra: Error name only. `ENOENT`, `TypeError`, etc.
+
+Example:
+> Got: `ReferenceError: Cannot read property 'foo' of undefined at Bar.baz (/src/app.js:42:15)`
+> Full: `RefError: foo undefined. /src/app.js:42:15`
+> Ultra: `RefError @42`
+
+### Tool Result JSON
+
+- lite: Show top-level keys + relevant nested values. Indent 2 spaces.
+- full: Show only keys with non-null values. One line per key.
+- ultra: Show only critical keys (status, id, error, count). `[200] {id: "xyz"}`
+
+### Security Redaction
+
+Always redact or summarize content that may expose:
+- File paths containing home dirs, usernames: `/home/user/project` → `~/project`
+- API keys, tokens: `sk-abc123...` → `[API_KEY]`
+- Error messages that reveal internal architecture
+- Stack traces: summarize, don't paste full
+
+## Compress Existing Tool Output
+
+When you encounter verbose tool output already in context:
+- Truncate to most relevant portion
+- Replace long repetitive lines with `... [N identical lines]`
+- Convert tables to bullet summaries
+- Keep only the signal, drop the noise

--- a/tests/test_sensitive_path.py
+++ b/tests/test_sensitive_path.py
@@ -1,0 +1,58 @@
+import unittest
+import tempfile
+from pathlib import Path
+import sys
+import os
+
+CAVEMAN_COMPRESS = Path(__file__).parent.parent / "caveman-compress"
+os.chdir(CAVEMAN_COMPRESS)
+sys.path.insert(0, str(CAVEMAN_COMPRESS))
+
+from scripts.compress import is_sensitive_path
+
+
+class TestIsSensitivePath(unittest.TestCase):
+    def test_doc_extensions_false_positives(self):
+        false_positive_cases = [
+            "token_refresh.md",
+            "password_policy.md",
+            "secrets_management_guide.md",
+            "credential_rotation.txt",
+            "apikey_rotation.rst",
+            "access_token.md",
+            "token_refresh.markdown",
+            "password_policy.txt",
+            "api_secret_guide.md",
+            "privatekey_documentation.rst",
+            "credential_handbook.md",
+            "token_usage.txt",
+            "password_guidelines.markdown",
+            "secret_rotation.md",
+        ]
+        for name in false_positive_cases:
+            with tempfile.TemporaryDirectory() as tmp:
+                f = Path(tmp) / name
+                f.touch()
+                self.assertFalse(is_sensitive_path(f), f"{name} should NOT be blocked")
+
+    def test_true_positives_still_blocked(self):
+        true_positive_cases = [
+            "credentials.yaml",
+            "secrets.json",
+            ".env",
+            ".env.local",
+            "password.txt",
+            "id_rsa",
+            "id_ed25519.pub",
+            "authorized_keys",
+            "known_hosts",
+        ]
+        for name in true_positive_cases:
+            with tempfile.TemporaryDirectory() as tmp:
+                f = Path(tmp) / name
+                f.touch()
+                self.assertTrue(is_sensitive_path(f), f"{name} SHOULD be blocked")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Skip SENSITIVE_NAME_TOKENS check for _DOC_EXTENSIONS (.md, .txt, .rst, .markdown)
- Still check SENSITIVE_BASENAME_REGEX first to catch actual dangerous cases (password.txt, .env, credentials.yaml)
- Add 14 false-positive test cases + 9 true-positive cases

## Bug
`SENSITIVE_NAME_TOKENS` uses a plain substring match on the normalized filename with no extension awareness. Any .md/.txt/.rst file whose name contains token, password, secret, etc. is silently skipped — token_refresh.md, password_policy.md, secrets_management_guide.md all fail to compress.

## Fix
Skip the token-substring check for _DOC_EXTENSIONS but still check SENSITIVE_BASENAME_REGEX for actual dangerous filenames.