### PR TITLE
fix(hooks): bail loud on unrecognised /caveman arg, add explicit off + full

### DIFF
--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -45,12 +45,27 @@ process.stdin.on('end', () => {
       } else if (cmd === '/caveman-compress' || cmd === '/caveman:caveman-compress') {
         mode = 'compress';
       } else if (cmd === '/caveman' || cmd === '/caveman:caveman') {
-        if (arg === 'lite') mode = 'lite';
+        if (arg === '') mode = getDefaultMode();
+        else if (arg === 'lite') mode = 'lite';
+        else if (arg === 'full') mode = 'full';
         else if (arg === 'ultra') mode = 'ultra';
         else if (arg === 'wenyan-lite') mode = 'wenyan-lite';
         else if (arg === 'wenyan' || arg === 'wenyan-full') mode = 'wenyan';
         else if (arg === 'wenyan-ultra') mode = 'wenyan-ultra';
-        else mode = getDefaultMode();
+        else if (arg === 'off') mode = 'off';
+        else {
+          // Unknown arg: fail loud with usage info, leave flag file untouched.
+          // Silently substituting the default surprised users who guessed
+          // reasonable phrasings like /caveman off — they got no signal that
+          // their input was unrecognised and assumed it had worked.
+          process.stderr.write(
+            "caveman: unknown arg '" + arg + "'. " +
+            "Usage: /caveman [lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off]. " +
+            "Plain-English alternatives: 'stop caveman' or 'normal mode'.\n"
+          );
+          // mode stays null — flag file is not modified, per-turn reinforcement
+          // (further down) still fires for the current active mode.
+        }
       }
 
       if (mode && mode !== 'off') {


### PR DESCRIPTION
## What

`hooks/caveman-mode-tracker.js` is the `UserPromptSubmit` hook that parses `/caveman` slash commands and writes the active mode to `~/.claude/.caveman-active`. Statusline + per-turn reinforcement read that flag.

The slash-command parser handled the known modes (`lite`, `ultra`, `wenyan-lite`, `wenyan`, `wenyan-full`, `wenyan-ultra`) with explicit branches. Anything else fell through to `else mode = getDefaultMode()`, which silently re-asserted the default mode and rewrote the flag file as if the user had typed `/caveman` with no arg.

The user-facing impact: someone types a reasonable guess for "turn it off" — most commonly `/caveman off`, but also `/caveman quiet`, `/caveman normal`, etc. — and gets no error, no usage hint, and no signal that their input was unrecognised. Caveman behaviour continues while they assume they have disabled it. The README documents `stop caveman` and `normal mode` as natural-language deactivation paths (handled by the regex matcher further down the same file), but the slash-command equivalent of "off" did not exist; the silent fall-through hid the gap.

Same principle as #292 (`bail loudly on empty / unchanged compression instead of silent data loss`) — fail loud, don't silently substitute.

## Repro

```sh
# Set caveman to a known state
echo "lite" > ~/.claude/.caveman-active

# Run the hook with /caveman off
echo '{"prompt":"/caveman off"}' | node hooks/caveman-mode-tracker.js

# Observed (before fix): flag file rewritten to default mode
cat ~/.claude/.caveman-active
# full

# Expected: flag file deleted (mode off) OR usage message shown for unknown args.
```

## Fix

Replace the silent fall-through with an explicit unknown-arg branch that emits a usage message to stderr and leaves the flag file untouched. Add explicit `off` and `full` cases so users can deactivate via slash command and so `full` doesn't rely on a default-mode coincidence.

```diff
       } else if (cmd === '/caveman' || cmd === '/caveman:caveman') {
-        if (arg === 'lite') mode = 'lite';
+        if (arg === '') mode = getDefaultMode();
+        else if (arg === 'lite') mode = 'lite';
+        else if (arg === 'full') mode = 'full';
         else if (arg === 'ultra') mode = 'ultra';
         else if (arg === 'wenyan-lite') mode = 'wenyan-lite';
         else if (arg === 'wenyan' || arg === 'wenyan-full') mode = 'wenyan';
         else if (arg === 'wenyan-ultra') mode = 'wenyan-ultra';
-        else mode = getDefaultMode();
+        else if (arg === 'off') mode = 'off';
+        else {
+          // Unknown arg: fail loud with usage info, leave flag file untouched.
+          process.stderr.write(
+            "caveman: unknown arg '" + arg + "'. " +
+            "Usage: /caveman [lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off]. " +
+            "Plain-English alternatives: 'stop caveman' or 'normal mode'.\n"
+          );
+          // mode stays null — flag file untouched, per-turn reinforcement
+          // continues for the current active mode.
+        }
       }
```

The existing `else if (mode === 'off')` branch already handles flag-file deletion when `mode === 'off'`, so adding `arg === 'off'` to the parser hooks straight into that path with no further code changes needed.

The unknown-arg path deliberately leaves `mode` as `null` rather than `return`-ing early. That way the per-turn reinforcement at the bottom of the same callback still fires for the currently active mode — a user who fat-fingers `/caveman foo` doesn't lose mode reinforcement that turn.

### Behaviour after the fix

| Input | Before | After |
| --- | --- | --- |
| `/caveman` (no arg) | Default mode applied | Default mode applied (unchanged) |
| `/caveman lite` | `lite` applied | `lite` applied (unchanged) |
| `/caveman full` | Default mode applied (coincidence) | `full` applied explicitly |
| `/caveman ultra` | `ultra` applied | `ultra` applied (unchanged) |
| `/caveman wenyan-*` | Each variant applied | Each variant applied (unchanged) |
| `/caveman off` | Default mode applied (silent) | Flag file deleted (off) |
| `/caveman foo` | Default mode applied (silent) | stderr usage; flag file unchanged |

## Notes

Discovered while debugging a session where `/caveman off` had no observable effect — a user-visible failure mode for anyone who hasn't read the natural-language regex in this same file. The behavioural fix is small; the larger change is moving the slash-command parser onto the same fail-loud footing as the rest of the project.

Happy to add a behavioural test for the parser if you'd like — `tests/test_hooks.py` currently only covers `install.sh`. I held off here to keep the PR scope minimal, but I can extend it in a follow-up.