### PR TITLE
fix(hooks): handle all /caveman <arg> values, drop silent fallback

### DIFF
--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -5,7 +5,11 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { getDefaultMode, safeWriteFlag, readFlag } = require('./caveman-config');
+const { getDefaultMode, safeWriteFlag, readFlag, VALID_MODES } = require('./caveman-config');
+
+// Modes handled by their own slash commands (/caveman-commit, etc.) — not
+// selectable via /caveman <arg>.
+const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');
@@ -45,12 +49,18 @@ process.stdin.on('end', () => {
       } else if (cmd === '/caveman-compress' || cmd === '/caveman:caveman-compress') {
         mode = 'compress';
       } else if (cmd === '/caveman' || cmd === '/caveman:caveman') {
-        if (arg === 'lite') mode = 'lite';
-        else if (arg === 'ultra') mode = 'ultra';
-        else if (arg === 'wenyan-lite') mode = 'wenyan-lite';
-        else if (arg === 'wenyan' || arg === 'wenyan-full') mode = 'wenyan';
-        else if (arg === 'wenyan-ultra') mode = 'wenyan-ultra';
-        else mode = getDefaultMode();
+        // Bare /caveman → activate at configured default
+        if (!arg) {
+          mode = getDefaultMode();
+        } else if (arg === 'off' || arg === 'stop' || arg === 'disable') {
+          mode = 'off';
+        } else if (arg === 'wenyan-full') {
+          // Canonical alias — config stores as 'wenyan'
+          mode = 'wenyan';
+        } else if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) {
+          mode = arg;
+        }
+        // Unknown arg → mode stays null, flag untouched (no silent overwrite)
       }
 
       if (mode && mode !== 'off') {
@@ -78,7 +88,6 @@ process.stdin.on('end', () => {
     // If the flag is missing, corrupted, oversized, or a symlink pointing at
     // something like ~/.ssh/id_rsa, readFlag returns null and we emit nothing
     // — never inject untrusted bytes into model context.
-    const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
     const activeMode = readFlag(flagPath);
     if (activeMode && !INDEPENDENT_MODES.has(activeMode)) {
       process.stdout.write(JSON.stringify({


### PR DESCRIPTION
## Summary

`hooks/caveman-mode-tracker.js` only matched a subset of valid args for `/caveman <arg>`. The rest fell through to `else mode = getDefaultMode()`, which silently overwrote the flag with the configured default instead of doing what the user asked.

Three concrete bugs:

1. **`/caveman full` is impossible** when `defaultMode` is anything other than `full`. The arg has no explicit branch, so it falls through to `getDefaultMode()`. If a user has `~/.config/caveman/config.json` set to `{"defaultMode":"lite"}`, typing `/caveman full` writes `lite` to the flag file. The statusline (and any consumer of `.caveman-active`) keeps showing `lite`. There is no way to switch to full via the slash command.
2. **`/caveman off` is impossible** for the same reason. Off-switching only works via the natural-language regex (`stop caveman` / `normal mode`).
3. **Typos silently clobber state.** `/caveman fulll` (typo) overwrites the flag with the default mode rather than no-op'ing. A user on `ultra` gets bumped to `full` by a stray keystroke.

## Fix

- Use the existing `VALID_MODES` whitelist from `caveman-config.js` as the source of truth instead of a hand-maintained `if/else` chain that has already drifted.
- Explicit branches for the cases that need special handling: bare `/caveman` (default), `off|stop|disable` (delete flag), `wenyan-full` alias (canonicalize to `wenyan`).
- Unknown arg, `mode` stays `null`, flag untouched (no silent overwrite).
- Hoist `INDEPENDENT_MODES` to module scope so the dispatch can reject `/caveman commit` (those modes have their own `/caveman-commit` etc. commands and should not be selectable as args).

## Why this matters beyond the plugin

Anything that consumes `~/.claude/.caveman-active` is at the mercy of this hook. Example: [securacore/kanagawa-statusline](https://github.com/securacore/kanagawa-statusline) renders a `caveman <level>` badge by reading the flag directly (`statusline.sh:230-244`, with proper symlink/size/whitelist hardening matching `readFlag`). When the user runs `/caveman full` and the hook writes `lite` instead, the statusline correctly displays `lite`, so the bug looks like a statusline bug to the user. Multiply across every downstream reader.

## Test plan

- [x] Existing `tests/test_hooks.py` passes.
- [x] All `/caveman <arg>` transitions verified manually:
  - `lite/full/ultra/wenyan-lite/wenyan/wenyan-full/wenyan-ultra` write expected mode
  - `off` deletes flag
  - bare `/caveman` writes configured default
  - typo / unknown arg leaves flag unchanged (no silent overwrite)
  - `/caveman commit` leaves flag unchanged (independent mode, not selectable as arg)
- [x] Natural-language regression: `activate caveman` / `talk like caveman` / `stop caveman` / `normal mode` / `caveman mode please` all behave as before.

## Notes

- One behavioral change worth flagging: the old code wrote the default mode for any unknown arg. The new code no-ops. If a user was relying on `/caveman whatever` to "reset to default," they will need `/caveman` (no arg) instead, which is the documented form.
- `INDEPENDENT_MODES` was already defined inline at the bottom of the file for the per-turn reinforcement check. Hoisting it makes both call sites use the same set instead of duplicating literals.