### PR TITLE
feat: add Kimi CLI plugin

### DIFF
--- a/.github/workflows/sync-skill.yml
+++ b/.github/workflows/sync-skill.yml
@@ -36,6 +36,8 @@ jobs:
           cp skills/caveman/SKILL.md .cursor/skills/caveman/SKILL.md
           mkdir -p .windsurf/skills/caveman
           cp skills/caveman/SKILL.md .windsurf/skills/caveman/SKILL.md
+          mkdir -p plugins/caveman-kimi
+          cp skills/caveman/SKILL.md plugins/caveman-kimi/SKILL.md
 
       - name: Sync compress skill
         run: |
@@ -91,6 +93,7 @@ jobs:
             plugins/caveman/skills/caveman/SKILL.md \
             .cursor/skills/caveman/SKILL.md \
             .windsurf/skills/caveman/SKILL.md \
+            plugins/caveman-kimi/SKILL.md \
             caveman.skill \
             .clinerules/caveman.md \
             .github/copilot-instructions.md \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ Overwritten by CI on push to main when sources change. Edits here lost.
 | `.cursor/skills/caveman/SKILL.md` | `skills/caveman/SKILL.md` |
 | `.windsurf/skills/caveman/SKILL.md` | `skills/caveman/SKILL.md` |
 | `caveman.skill` | ZIP of `skills/caveman/` directory |
+| `plugins/caveman-kimi/SKILL.md` | `skills/caveman/SKILL.md` |
 | `.clinerules/caveman.md` | `rules/caveman-activate.md` |
 | `.github/copilot-instructions.md` | `rules/caveman-activate.md` |
 | `.cursor/rules/caveman.mdc` | `rules/caveman-activate.md` + Cursor frontmatter |
@@ -172,6 +173,7 @@ How caveman reaches each agent type:
 | Windsurf | `.windsurf/rules/caveman.md` with `trigger: always_on` | Yes — always-on rule |
 | Cline | `.clinerules/caveman.md` (auto-discovered) | Yes — Cline injects all .clinerules files |
 | Copilot | `.github/copilot-instructions.md` + `AGENTS.md` | Yes — repo-wide instructions |
+| Kimi CLI | Plugin in `plugins/caveman-kimi/` (`plugin.json` + `SKILL.md`), installed via `kimi plugin install <path>` | Yes — Kimi auto-discovers bundled `SKILL.md` on startup |
 | Others | `npx skills add JuliusBrussee/caveman` | No — user must say `/caveman` each session |
 
 For agents without hook systems, minimal always-on snippet lives in README under "Want it always on?" — keep current with `rules/caveman-activate.md`.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Pick your agent. One command. Done.
 | **Windsurf** | `npx skills add JuliusBrussee/caveman -a windsurf` |
 | **Copilot** | `npx skills add JuliusBrussee/caveman -a github-copilot` |
 | **Cline** | `npx skills add JuliusBrussee/caveman -a cline` |
+| **Kimi CLI** | `git clone https://github.com/JuliusBrussee/caveman /tmp/caveman && kimi plugin install /tmp/caveman/plugins/caveman-kimi` |
 | **Any other** | `npx skills add JuliusBrussee/caveman` |
 
 Install once. Use in every session for that install target after that. One rock. That it.
@@ -148,17 +149,17 @@ Install once. Use in every session for that install target after that. One rock.
 
 Auto-activation is built in for Claude Code, Gemini CLI, and the repo-local Codex setup below. `npx skills add` installs the skill for other agents, but does **not** install repo rule/instruction files, so Caveman does not auto-start there unless you add the always-on snippet below.
 
-| Feature | Claude Code | Codex | Gemini CLI | Cursor | Windsurf | Cline | Copilot |
-|---------|:-----------:|:-----:|:----------:|:------:|:--------:|:-----:|:-------:|
-| Caveman mode | Y | Y | Y | Y | Y | Y | Y |
-| Auto-activate every session | Y | Y¹ | Y | —² | —² | —² | —² |
-| `/caveman` command | Y | Y¹ | Y | — | — | — | — |
-| Mode switching (lite/full/ultra) | Y | Y¹ | Y | Y³ | Y³ | — | — |
-| Statusline badge | Y⁴ | — | — | — | — | — | — |
-| caveman-commit | Y | — | Y | Y | Y | Y | Y |
-| caveman-review | Y | — | Y | Y | Y | Y | Y |
-| caveman-compress | Y | Y | Y | Y | Y | Y | Y |
-| caveman-help | Y | — | Y | Y | Y | Y | Y |
+| Feature | Claude Code | Codex | Gemini CLI | Cursor | Windsurf | Cline | Copilot | Kimi CLI |
+|---------|:-----------:|:-----:|:----------:|:------:|:--------:|:-----:|:-------:|:--------:|
+| Caveman mode | Y | Y | Y | Y | Y | Y | Y | Y |
+| Auto-activate every session | Y | Y¹ | Y | —² | —² | —² | —² | Y⁵ |
+| `/caveman` command | Y | Y¹ | Y | — | — | — | — | — |
+| Mode switching (lite/full/ultra) | Y | Y¹ | Y | Y³ | Y³ | — | — | Y³ |
+| Statusline badge | Y⁴ | — | — | — | — | — | — | — |
+| caveman-commit | Y | — | Y | Y | Y | Y | Y | — |
+| caveman-review | Y | — | Y | Y | Y | Y | Y | — |
+| caveman-compress | Y | Y | Y | Y | Y | Y | Y | — |
+| caveman-help | Y | — | Y | Y | Y | Y | Y | — |
 
 > [!NOTE]
 > Auto-activation works differently per agent: Claude Code uses SessionStart hooks, this repo's Codex dogfood setup uses `.codex/hooks.json`, Gemini uses context files. Cursor/Windsurf/Cline/Copilot can be made always-on, but `npx skills add` installs only the skill, not the repo rule/instruction files.
@@ -167,6 +168,7 @@ Auto-activation is built in for Claude Code, Gemini CLI, and the repo-local Code
 > ² Add the "Want it always on?" snippet below to those agents' system prompt or rule file if you want session-start activation.
 > ³ Cursor and Windsurf receive the full SKILL.md with all intensity levels. Mode switching works on-demand via the skill; no slash command.
 > ⁴ Available in Claude Code, but plugin install only nudges setup. Standalone `install.sh` / `install.ps1` configures it automatically when no custom `statusLine` exists.
+> ⁵ Kimi CLI auto-discovers `SKILL.md` bundled with the plugin on startup — no slash command needed. Sub-skills (commit/review/compress/help) are not bundled in the Kimi plugin yet.
 
 <details>
 <summary><strong>Claude Code — full details</strong></summary>
@@ -251,6 +253,24 @@ Auto-activates via `GEMINI.md` context file. Also ships custom Gemini commands:
 Uninstall: `npx skills remove caveman`
 
 Copilot works with Chat, Edits, and Coding Agent.
+
+</details>
+
+<details>
+<summary><strong>Kimi CLI — full details</strong></summary>
+
+[Kimi Code CLI](https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html) plugins live in `~/.kimi/plugins/<name>/`. The repo ships a Kimi-compatible plugin at `plugins/caveman-kimi/` with `plugin.json` + `SKILL.md`. Kimi auto-discovers the `SKILL.md` on every startup, so caveman activates without a slash command.
+
+```bash
+git clone https://github.com/JuliusBrussee/caveman /tmp/caveman
+kimi plugin install /tmp/caveman/plugins/caveman-kimi
+```
+
+Verify: `kimi plugin list` should show `caveman`. Inspect: `kimi plugin info caveman`. Remove: `kimi plugin remove caveman`.
+
+The `kimi plugin install <git-url>` shortcut expects `plugin.json` at the repo root, which this repo does not have (it ships multiple plugin formats). Path-based install above is the supported route.
+
+Sub-skills (caveman-commit, caveman-review, caveman-compress, caveman-help) are not yet bundled in the Kimi plugin — Kimi's `tools` array would be the right slot for slash-command equivalents, contributions welcome.
 
 </details>
 

--- a/plugins/caveman-kimi/SKILL.md
+++ b/plugins/caveman-kimi/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
+  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
+  wenyan-lite, wenyan-full, wenyan-ultra.
+  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
+  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+
+Default: **full**. Switch: `/caveman lite|full|ultra`.
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
+| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
+| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
+| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
+| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+
+Example — "Why React component re-render?"
+- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
+- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+- wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
+- wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
+- wenyan-ultra: "新參照→重繪。useMemo Wrap。"
+
+Example — "Explain database connection pooling."
+- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
+- wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
+- wenyan-ultra: "池reuse conn。skip handshake → fast。"
+
+## Auto-Clarity
+
+Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.
+
+Example — destructive op:
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> ```sql
+> DROP TABLE users;
+> ```
+> Caveman resume. Verify backup exist first.
+
+## Boundaries
+
+Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.

--- a/plugins/caveman-kimi/plugin.json
+++ b/plugins/caveman-kimi/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "caveman",
+  "version": "1.0.0",
+  "description": "Ultra-compressed communication mode. Cuts ~75% of output tokens while keeping full technical accuracy."
+}


### PR DESCRIPTION
## Summary

Ships caveman as a [Kimi Code CLI](https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html) plugin under `plugins/caveman-kimi/`. Validated against the official Kimi plugin docs:

- `plugin.json` carries the required `name` + semver `version` plus `description`. `tools` omitted (optional per schema; sub-skills are future work).
- Bundled `SKILL.md` lives alongside `plugin.json`. Kimi auto-discovers it on startup, so caveman activates without a slash command.
- Install path: `kimi plugin install <path>`. The `kimi plugin install <git-url>` shortcut assumes `plugin.json` at repo root, which this repo intentionally does not have (multi-plugin layout) — path-based install after `git clone` is the supported route and is what the README documents.

## Changes

- `plugins/caveman-kimi/plugin.json` + `plugins/caveman-kimi/SKILL.md`
- `.github/workflows/sync-skill.yml` — adds `cp skills/caveman/SKILL.md plugins/caveman-kimi/SKILL.md` to the existing sync step and includes the file in the staged path list, matching the Cursor/Windsurf/Claude/Codex pattern
- `README.md` — Kimi row in the install table, Kimi column in the "What You Get" capability matrix with note ⁵, full `<details>` install block
- `CLAUDE.md` — entry added to the auto-synced sync hygiene table and to the agent distribution table

## Notes

- Sub-skills (caveman-commit / caveman-review / caveman-compress / caveman-help) are intentionally **not** bundled in the Kimi plugin yet. Kimi exposes commands via the `tools[]` array in `plugin.json` (script-backed, not skill-backed), so wiring them up properly is its own piece of work — happy to follow up if the maintainer wants it.
- Hooks: Kimi has a separate "Hooks (Beta)" system not covered by the plugin format. SKILL.md auto-discovery on startup gives equivalent behaviour for the always-on use case here, so no Kimi-side hook is needed for parity with Gemini's context-file approach.

## Test plan

- [x] `plugin.json` parses as JSON, fields match Kimi schema (`name`, `version` semver, optional `description`)
- [x] `SKILL.md` byte-identical to `skills/caveman/SKILL.md` (sync source)
- [x] CI workflow YAML still parses; new `cp` line and new staged path live in the same blocks as existing sync targets
- [ ] (Maintainer) Run `kimi plugin install plugins/caveman-kimi` in a Kimi CLI install and confirm `kimi plugin list` shows `caveman` and the SKILL activates on next session
- [ ] (Maintainer) Confirm CI sync job still runs green on next push touching `skills/caveman/SKILL.md`