### PR TITLE
Align caveman docs, hooks, and test coverage

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,25 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
 @./skills/caveman/SKILL.md
 @./skills/caveman-commit/SKILL.md
 @./skills/caveman-review/SKILL.md
+@./skills/caveman-help/SKILL.md
 @./caveman-compress/SKILL.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- Added mode-tracker support for natural-language activation via `less tokens please` and for the `/caveman:compress` alias.
+- Aligned README and related docs with the current command set, activation behavior, and compress workflow.
+- Exposed the help surface consistently in `GEMINI.md` and `AGENTS.md`.
+- Hardened `verify_repo` coverage to validate mode tracking, reinforcement output, and compress-mode behavior.
+- Added unit coverage for `XDG_CONFIG_HOME` default mode resolution in `tests/test_hooks.py`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,4 +1,5 @@
 @./skills/caveman/SKILL.md
 @./skills/caveman-commit/SKILL.md
 @./skills/caveman-review/SKILL.md
+@./skills/caveman-help/SKILL.md
 @./caveman-compress/SKILL.md

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ---
 
-A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin and Codex plugin that makes agent talk like caveman — cutting **~75% of output tokens** while keeping full technical accuracy. Now with [文言文 mode](#文言文-wenyan-mode), [terse commits](#caveman-commit), [one-line code reviews](#caveman-review), and a [compression tool](#caveman-compress) that cuts **~46% of input tokens** every session.
+A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin and Codex plugin that makes agent talk like caveman — cutting **~75% of output tokens** while keeping full technical accuracy. Now with [文言文 mode](#文言文-wenyan-mode), [terse commits](#caveman-commit), [one-line code reviews](#caveman-review), and an optional [compression tool](#caveman-compress) for memory/context files that averages **~46% fewer input tokens** in the included examples.
 
 Based on the viral observation that caveman-speak dramatically reduces LLM token usage without losing technical substance. So we made it a one-line install.
 
@@ -173,6 +173,9 @@ Auto-activation is built in for Claude Code, Gemini CLI, and the repo-local Code
 
 The plugin install gives you skills + auto-loading hooks. If no custom `statusLine` is configured, Caveman nudges Claude to offer badge setup on first session.
 
+- SessionStart hook activates caveman and injects the rules as hidden context
+- UserPromptSubmit hook reinforces caveman instructions on each prompt while standard caveman modes are active, reducing drift
+
 ```bash
 claude plugin marketplace add JuliusBrussee/caveman
 claude plugin install caveman@caveman
@@ -233,6 +236,8 @@ Auto-activates via `GEMINI.md` context file. Also ships custom Gemini commands:
 - `/caveman` — switch intensity level (lite/full/ultra/wenyan)
 - `/caveman-commit` — generate terse commit message
 - `/caveman-review` — one-line code review
+- `/caveman-compress` — compress a memory/context file
+- `/caveman-help` — quick-reference card
 
 </details>
 
@@ -273,7 +278,7 @@ Uninstall: `npx skills remove caveman`
 
 > **Windows note:** `npx skills` uses symlinks by default. If symlinks fail, add `--copy`: `npx skills add JuliusBrussee/caveman --copy`
 
-**Important:** These agents don't have a hook system, so caveman won't auto-start. Say `/caveman` or "talk like caveman" to activate each session.
+**Important:** These agents don't have a hook system, so caveman won't auto-start. Use your agent's caveman command each session, like `/caveman` or Codex `$caveman`. Natural-language triggers like "talk like caveman" may work, but are not guaranteed outside hook-based installs.
 
 **Want it always on?** Paste this into your agent's system prompt or rules file — caveman will be active from the first message, every session:
 
@@ -299,10 +304,10 @@ Where to put it:
 ## Usage
 
 Trigger with:
-- `/caveman` or Codex `$caveman`
-- "talk like caveman"
-- "caveman mode"
-- "less tokens please"
+- Claude/Gemini: `/caveman`
+- Codex: `$caveman`
+- Claude hook installs also support natural-language activation: "talk like caveman", "caveman mode", or "less tokens please".
+- `less tokens please` activates the configured default caveman mode.
 
 Stop with: "stop caveman" or "normal mode"
 
@@ -321,7 +326,7 @@ Classical Chinese literary compression — same technical accuracy, but in the m
 | Level | Trigger | What it do |
 |-------|---------|------------|
 | **Wenyan-Lite** | `/caveman wenyan-lite` | Semi-classical. Grammar intact, filler gone |
-| **Wenyan-Full** | `/caveman wenyan` | Full 文言文. Maximum classical terseness |
+| **Wenyan-Full** | `/caveman wenyan` or `/caveman wenyan-full` | Full 文言文. Maximum classical terseness |
 | **Wenyan-Ultra** | `/caveman wenyan-ultra` | Extreme. Ancient scholar on a budget |
 
 Level stick until you change it or session end.
@@ -342,12 +347,13 @@ Level stick until you change it or session end.
 
 ### caveman-compress
 
-`/caveman:compress <filepath>` — caveman make Claude *speak* with fewer tokens. **Compress** make Claude *read* fewer tokens.
+`/caveman-compress <filepath>` or alias `/caveman:compress <filepath>` — caveman make Claude *speak* with fewer tokens. **Compress** make Claude *read* fewer tokens.
 
 Your `CLAUDE.md` loads on **every session start**. Caveman Compress rewrites memory files into caveman-speak so Claude reads less — without you losing the human-readable original.
 
 ```
-/caveman:compress CLAUDE.md
+/caveman-compress CLAUDE.md
+# alias: /caveman:compress CLAUDE.md
 ```
 
 ```

--- a/caveman-compress/README.md
+++ b/caveman-compress/README.md
@@ -10,7 +10,7 @@
 
 ---
 
-A Claude Code skill that compresses your project memory files (`CLAUDE.md`, todos, preferences) into caveman format — so every session loads fewer tokens automatically.
+A caveman skill/tool that compresses your project memory files (`CLAUDE.md`, todos, preferences) into caveman format — so compatible agents load fewer tokens on each session.
 
 Claude read `CLAUDE.md` on every session start. If file big, cost big. Caveman make file small. Cost go down forever.
 
@@ -71,7 +71,7 @@ All validations passed ✅ — headings, code blocks, URLs, file paths preserved
 
 ## Install
 
-Compress is built in with the `caveman` plugin. Install `caveman` once, then use `/caveman:compress`.
+Compress ships with `caveman`. Depending on agent surface, use `/caveman-compress` or the alias `/caveman:compress`.
 
 If you need local files, the compress skill lives at:
 
@@ -84,14 +84,16 @@ caveman-compress/
 ## Usage
 
 ```
-/caveman:compress <filepath>
+/caveman-compress <filepath>
+# alias: /caveman:compress <filepath>
 ```
 
 Examples:
 ```
-/caveman:compress CLAUDE.md
-/caveman:compress docs/preferences.md
-/caveman:compress todos.md
+/caveman-compress CLAUDE.md
+/caveman-compress docs/preferences.md
+/caveman-compress todos.md
+# alias still works: /caveman:compress ...
 ```
 
 ### What files work

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -15,8 +15,10 @@ If you installed caveman standalone (without the plugin), you can use `bash hook
 
 ### `caveman-mode-tracker.js` — UserPromptSubmit hook
 
-- Fires on every user prompt, checks for `/caveman` commands
-- Writes the active mode to the flag file when a caveman command is detected
+- Fires on every user prompt
+- Detects `/caveman` commands plus natural-language activation/deactivation phrases like `talk like caveman`, `caveman mode`, `less tokens please`, `stop caveman`, and `normal mode`
+- Writes the active mode to the flag file when caveman is activated or switched
+- Emits structured `hookSpecificOutput` JSON with per-turn caveman reinforcement while standard caveman modes are active
 - Supports: `full`, `lite`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-ultra`, `commit`, `review`, `compress`
 
 ### `caveman-statusline.sh` / `caveman-statusline.ps1` — Statusline badge script
@@ -56,21 +58,7 @@ If you already have a custom statusline, caveman does not overwrite it and Claud
 
 Replace the path with the actual script location (e.g. `~/.claude/hooks/` for standalone installs, or the plugin install directory for plugin installs).
 
-**Custom statusline:** If you already have a statusline script, add this snippet to it:
-
-```bash
-caveman_text=""
-caveman_flag="$HOME/.claude/.caveman-active"
-if [ -f "$caveman_flag" ]; then
-  caveman_mode=$(cat "$caveman_flag" 2>/dev/null)
-  if [ "$caveman_mode" = "full" ] || [ -z "$caveman_mode" ]; then
-    caveman_text=$'\033[38;5;172m[CAVEMAN]\033[0m'
-  else
-    caveman_suffix=$(echo "$caveman_mode" | tr '[:lower:]' '[:upper:]')
-    caveman_text=$'\033[38;5;172m[CAVEMAN:'"${caveman_suffix}"$']\033[0m'
-  fi
-fi
-```
+**Custom statusline:** Prefer calling the shipped `caveman-statusline.sh` / `caveman-statusline.ps1` from your existing statusline script so you inherit future fixes. If you must inline the logic, copy it from the current script in this repo or plugin install directory rather than using an older snippet.
 
 Badge examples:
 - `/caveman` → `[CAVEMAN]`

--- a/hooks/caveman-mode-tracker.js
+++ b/hooks/caveman-mode-tracker.js
@@ -21,7 +21,8 @@ process.stdin.on('end', () => {
     // "talk like caveman"). README tells users they can say these, but the hook
     // only matched /caveman commands — flag file and statusline stayed out of sync.
     if (/\b(activate|enable|turn on|start|talk like)\b.*\bcaveman\b/i.test(prompt) ||
-        /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt)) {
+        /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt) ||
+        /\bless tokens please\b/i.test(prompt)) {
       if (!/\b(stop|disable|turn off|deactivate)\b/i.test(prompt)) {
         const mode = getDefaultMode();
         if (mode !== 'off') {
@@ -42,7 +43,7 @@ process.stdin.on('end', () => {
         mode = 'commit';
       } else if (cmd === '/caveman-review') {
         mode = 'review';
-      } else if (cmd === '/caveman-compress' || cmd === '/caveman:caveman-compress') {
+      } else if (cmd === '/caveman-compress' || cmd === '/caveman:caveman-compress' || cmd === '/caveman:compress') {
         mode = 'compress';
       } else if (cmd === '/caveman' || cmd === '/caveman:caveman') {
         if (arg === 'lite') mode = 'lite';

--- a/skills/caveman-help/SKILL.md
+++ b/skills/caveman-help/SKILL.md
@@ -29,7 +29,7 @@ Mode stick until changed or session end.
 |-------|---------|-----------|
 | **caveman-commit** | `/caveman-commit` | Terse commit messages. Conventional Commits. ≤50 char subject. |
 | **caveman-review** | `/caveman-review` | One-line PR comments: `L42: bug: user null. Add guard.` |
-| **caveman-compress** | `/caveman:compress <file>` | Compress .md files to caveman prose. Saves ~46% input tokens. |
+| **caveman-compress** | `/caveman-compress <file>` or `/caveman:compress <file>` | Compress .md files to caveman prose. Saves ~46% input tokens. |
 | **caveman-help** | `/caveman-help` | This card. |
 
 ## Deactivate

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -156,6 +156,37 @@ class HookScriptTests(unittest.TestCase):
             self.assertNotIn("STATUSLINE SETUP NEEDED", result.stdout)
             self.assertEqual((claude_dir / ".caveman-active").read_text(), "full")
 
+    def test_activate_uses_xdg_config_default_mode(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-config-") as tmp:
+            root = Path(tmp)
+            home = root / "home"
+            xdg = root / "xdg"
+            claude_dir = home / ".claude"
+            config_dir = xdg / "caveman"
+
+            claude_dir.mkdir(parents=True)
+            config_dir.mkdir(parents=True)
+            (config_dir / "config.json").write_text(
+                json.dumps({"defaultMode": "ultra"}) + "\n"
+            )
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["USERPROFILE"] = str(home)
+            env["XDG_CONFIG_HOME"] = str(xdg)
+
+            result = subprocess.run(
+                ["node", "hooks/caveman-activate.js"],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+            self.assertIn("CAVEMAN MODE ACTIVE", result.stdout)
+            self.assertEqual((claude_dir / ".caveman-active").read_text(), "ultra")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/verify_repo.py
+++ b/tests/verify_repo.py
@@ -225,7 +225,7 @@ def verify_hook_install_flow() -> None:
             ["node", "hooks/caveman-activate.js"],
             env={"HOME": str(home)},
         )
-        ensure("CAVEMAN MODE ACTIVE." in activate.stdout, "activation output missing caveman banner")
+        ensure("CAVEMAN MODE ACTIVE" in activate.stdout, "activation output missing caveman banner")
         ensure("STATUSLINE SETUP NEEDED" not in activate.stdout, "activation should stay quiet when custom statusline exists")
         ensure((claude_dir / ".caveman-active").read_text() == "full", "activation flag should default to full")
 
@@ -234,14 +234,14 @@ def verify_hook_install_flow() -> None:
             ["node", "hooks/caveman-activate.js"],
             env={"HOME": str(home), "CAVEMAN_DEFAULT_MODE": "ultra"},
         )
-        ensure("CAVEMAN MODE ACTIVE." in activate_custom.stdout, "activation with custom default missing banner")
+        ensure("CAVEMAN MODE ACTIVE" in activate_custom.stdout, "activation with custom default missing banner")
         ensure((claude_dir / ".caveman-active").read_text() == "ultra", "CAVEMAN_DEFAULT_MODE=ultra should set flag to ultra")
         # Test "off" mode — activation skipped, flag removed
         activate_off = run(
             ["node", "hooks/caveman-activate.js"],
             env={"HOME": str(home), "CAVEMAN_DEFAULT_MODE": "off"},
         )
-        ensure("CAVEMAN MODE ACTIVE." not in activate_off.stdout, "off mode should not emit caveman banner")
+        ensure("CAVEMAN MODE ACTIVE" not in activate_off.stdout, "off mode should not emit caveman banner")
         ensure(not (claude_dir / ".caveman-active").exists(), "off mode should remove flag file")
 
         # Test mode tracker with /caveman when default is off — should NOT write flag
@@ -274,8 +274,106 @@ def verify_hook_install_flow() -> None:
             capture_output=True,
             check=True,
         )
-        ensure(ultra_prompt.stdout == "", "mode tracker should stay silent")
+        ultra_payload = json.loads(ultra_prompt.stdout)
+        ensure("hookSpecificOutput" in ultra_payload, "mode tracker should emit hookSpecificOutput payload")
+        ensure(
+            ultra_payload["hookSpecificOutput"].get("hookEventName") == "UserPromptSubmit",
+            "mode tracker should label UserPromptSubmit output",
+        )
+        ensure(
+            "CAVEMAN MODE ACTIVE (ultra)" in ultra_payload["hookSpecificOutput"].get("additionalContext", ""),
+            "mode tracker reinforcement output missing",
+        )
         ensure((claude_dir / ".caveman-active").read_text() == "ultra", "mode tracker did not record ultra")
+
+        compress_prompt = subprocess.run(
+            ["node", "hooks/caveman-mode-tracker.js"],
+            cwd=ROOT,
+            env={**os.environ, "HOME": str(home)},
+            text=True,
+            input='{"prompt":"/caveman:compress CLAUDE.md"}',
+            capture_output=True,
+            check=True,
+        )
+        ensure(compress_prompt.stdout == "", "independent compress mode should not emit reinforcement output")
+        ensure((claude_dir / ".caveman-active").read_text() == "compress", "/caveman:compress should record compress mode")
+
+        try:
+            os.unlink(claude_dir / ".caveman-active")
+        except FileNotFoundError:
+            pass
+
+        less_tokens_prompt = subprocess.run(
+            ["node", "hooks/caveman-mode-tracker.js"],
+            cwd=ROOT,
+            env={**os.environ, "HOME": str(home)},
+            text=True,
+            input='{"prompt":"less tokens please"}',
+            capture_output=True,
+            check=True,
+        )
+        less_tokens_payload = json.loads(less_tokens_prompt.stdout)
+        ensure((claude_dir / ".caveman-active").read_text() == "full", '"less tokens please" should reactivate default caveman mode')
+        ensure(
+            "CAVEMAN MODE ACTIVE (full)" in less_tokens_payload["hookSpecificOutput"].get("additionalContext", ""),
+            '"less tokens please" should emit reinforcement output for default mode',
+        )
+
+        talk_like_prompt = subprocess.run(
+            ["node", "hooks/caveman-mode-tracker.js"],
+            cwd=ROOT,
+            env={**os.environ, "HOME": str(home)},
+            text=True,
+            input='{"prompt":"talk like caveman"}',
+            capture_output=True,
+            check=True,
+        )
+        talk_like_payload = json.loads(talk_like_prompt.stdout)
+        ensure((claude_dir / ".caveman-active").read_text() == "full", '"talk like caveman" should activate default caveman mode')
+        ensure(
+            "CAVEMAN MODE ACTIVE (full)" in talk_like_payload["hookSpecificOutput"].get("additionalContext", ""),
+            '"talk like caveman" should emit reinforcement output',
+        )
+
+        wenyan_prompt = subprocess.run(
+            ["node", "hooks/caveman-mode-tracker.js"],
+            cwd=ROOT,
+            env={**os.environ, "HOME": str(home)},
+            text=True,
+            input='{"prompt":"/caveman wenyan-full"}',
+            capture_output=True,
+            check=True,
+        )
+        wenyan_payload = json.loads(wenyan_prompt.stdout)
+        ensure((claude_dir / ".caveman-active").read_text() == "wenyan", '"/caveman wenyan-full" should map to wenyan mode')
+        ensure(
+            "CAVEMAN MODE ACTIVE (wenyan)" in wenyan_payload["hookSpecificOutput"].get("additionalContext", ""),
+            '"/caveman wenyan-full" should emit wenyan reinforcement output',
+        )
+
+        commit_prompt = subprocess.run(
+            ["node", "hooks/caveman-mode-tracker.js"],
+            cwd=ROOT,
+            env={**os.environ, "HOME": str(home)},
+            text=True,
+            input='{"prompt":"/caveman-commit"}',
+            capture_output=True,
+            check=True,
+        )
+        ensure(commit_prompt.stdout == "", "commit mode should not emit reinforcement output")
+        ensure((claude_dir / ".caveman-active").read_text() == "commit", '"/caveman-commit" should record commit mode')
+
+        review_prompt = subprocess.run(
+            ["node", "hooks/caveman-mode-tracker.js"],
+            cwd=ROOT,
+            env={**os.environ, "HOME": str(home)},
+            text=True,
+            input='{"prompt":"/caveman-review"}',
+            capture_output=True,
+            check=True,
+        )
+        ensure(review_prompt.stdout == "", "review mode should not emit reinforcement output")
+        ensure((claude_dir / ".caveman-active").read_text() == "review", '"/caveman-review" should record review mode')
 
         subprocess.run(
             ["node", "hooks/caveman-mode-tracker.js"],


### PR DESCRIPTION
Problem
The caveman docs, hook behavior, and test coverage had drifted from the current command surface. In particular, natural-language activation and the `/caveman:compress` alias were not consistently reflected, and hook validation did not fully cover default-mode resolution and reinforcement output.

Changes
- Align README and related docs with the current commands, aliases, and activation behavior
- Update the mode tracker to recognize `less tokens please` and `/caveman:compress`
- Expose the help surface consistently in `AGENTS.md` and `GEMINI.md`
- Harden repo verification around hook output, mode persistence, compress mode, and Wenyan/commit/review flows
- Add unit coverage for resolving the default mode from `XDG_CONFIG_HOME`

Validation
- `python3 tests/verify_repo.py`
- `python3 -m unittest tests/test_hooks.py`

Notes
- Backwards-compatible: `/caveman:compress` remains supported while the newer command surface is documented consistently
- Changes were pushed to the fork first and are ready for upstream review
