### PR TITLE
fix(commands): strip YAML fences from caveman-init.toml

### DIFF
--- a/commands/caveman-init.toml
+++ b/commands/caveman-init.toml
@@ -1,4 +1,2 @@
----
 description = "Drop the always-on caveman activation rule into the current repo for every IDE agent"
 prompt = "Run `node tools/caveman-init.js {{args}}` in the current repo and report the result. Use --dry-run first if the user did not pass --force, so we never silently overwrite an existing rule file."
----


### PR DESCRIPTION
## Summary
- `commands/caveman-init.toml` was wrapped in YAML `---` fences, making it invalid TOML.
- Gemini CLI's `FileCommandLoader` rejects it on extension install/load:
  ```
  × [FileCommandLoader] Failed to parse TOML file
    .../caveman/commands/caveman-init.toml
  ```
- The other three command files (`caveman.toml`, `caveman-commit.toml`, `caveman-review.toml`) are already clean — only `caveman-init.toml` had the stray fences.
- Fix: drop both fence lines. The TOML body itself was valid.

Refs #325 (the umbrella issue covers two more loader errors in `agents/cavecrew-*.md` that need a design call before patching, so this PR is scoped to the unambiguous bug.)

## Test plan
- [x] `python3 -c "import tomllib; tomllib.loads(open('commands/caveman-init.toml').read())"` — parses clean (was raising before).
- [ ] Reinstall the extension in Gemini CLI: `gemini extensions install https://github.com/JuliusBrussee/caveman` and confirm the `FileCommandLoader` error no longer appears.