### PR TITLE
fix: windows contributor verification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Shell scripts must stay LF even when contributors use core.autocrlf=true on Windows.
+*.sh text eol=lf
+*.bash text eol=lf
+*.zsh text eol=lf

--- a/caveman-compress/scripts/compress.py
+++ b/caveman-compress/scripts/compress.py
@@ -9,8 +9,17 @@ Usage:
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 from typing import List
+
+for _stream in (sys.stdout, sys.stderr):
+    reconfigure = getattr(_stream, "reconfigure", None)
+    if callable(reconfigure):
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
 
 OUTER_FENCE_REGEX = re.compile(
     r"\A\s*(`{3,}|~{3,})[^\n]*\n(.*)\n\1\s*\Z", re.DOTALL

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -31,6 +31,28 @@ $marketplace | ConvertTo-Json -Depth 10 | Set-Content -Path $MarketplaceFile -En
 
 Verify: `Test-Path "$PluginSkillDir\SKILL.md"` should print `True`. Restart Claude Code, then run `/caveman` to confirm the skill loads.
 
+## Contributor checkout
+
+This repo includes Bash scripts used by local verification and CI. They must stay LF-terminated on Windows; CRLF makes Bash fail with errors like `syntax error near unexpected token $'do\r'`.
+
+Fresh clone recommended:
+
+```powershell
+git config --global core.autocrlf false
+git clone https://github.com/JuliusBrussee/caveman.git
+```
+
+For an existing checkout that already has CRLF shell scripts, save your local work first, then re-clone after changing the setting. If you cannot re-clone, refresh the affected shell scripts only after committing or stashing your edits.
+
+```powershell
+git config --global core.autocrlf false
+git ls-files --eol *.sh
+```
+
+The repo's `.gitattributes` pins `*.sh`, `*.bash`, and `*.zsh` to LF for future checkouts.
+
+For local hook verification, install Git for Windows and use Git Bash. WSL's `bash.exe` can be first on PATH, but it may not see Windows `node.exe` or Windows-style temp paths. The verification runner prefers Git Bash automatically when it is installed; set `CAVEMAN_BASH` to a specific `bash.exe` path if you need to override it.
+
 ## Codex on Windows
 
 1. Enable symlinks first: `git config --global core.symlinks true` (requires Developer Mode or admin).

--- a/plugins/caveman/skills/compress/scripts/compress.py
+++ b/plugins/caveman/skills/compress/scripts/compress.py
@@ -9,8 +9,17 @@ Usage:
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 from typing import List
+
+for _stream in (sys.stdout, sys.stderr):
+    reconfigure = getattr(_stream, "reconfigure", None)
+    if callable(reconfigure):
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
 
 OUTER_FENCE_REGEX = re.compile(
     r"\A\s*(`{3,}|~{3,})[^\n]*\n(.*)\n\1\s*\Z", re.DOTALL

--- a/skills/compress/scripts/compress.py
+++ b/skills/compress/scripts/compress.py
@@ -9,8 +9,17 @@ Usage:
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 from typing import List
+
+for _stream in (sys.stdout, sys.stderr):
+    reconfigure = getattr(_stream, "reconfigure", None)
+    if callable(reconfigure):
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
 
 OUTER_FENCE_REGEX = re.compile(
     r"\A\s*(`{3,}|~{3,})[^\n]*\n(.*)\n\1\s*\Z", re.DOTALL

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -9,16 +10,56 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
+def resolve_bash():
+    candidates = []
+    if override := os.environ.get("CAVEMAN_BASH"):
+        candidates.append(Path(override))
+    if os.name == "nt":
+        candidates.extend(
+            [
+                Path(r"C:\Program Files\Git\bin\bash.exe"),
+                Path(r"C:\Program Files\Git\usr\bin\bash.exe"),
+            ]
+        )
+    if found := shutil.which("bash"):
+        found_path = Path(found)
+        if os.name != "nt" or not is_wsl_bash(found_path):
+            candidates.append(found_path)
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    return "bash"
+
+
+def is_wsl_bash(path):
+    normalized = str(path).lower().replace("/", "\\")
+    return (
+        normalized.endswith(r"\windows\system32\bash.exe")
+        or normalized.endswith(r"\microsoft\windowsapps\bash.exe")
+        or r"\windowsapps\bash.exe" in normalized
+    )
+
+
+def shell_path(path):
+    return str(path).replace("\\", "/") if os.name == "nt" else str(path)
+
+
+BASH = resolve_bash()
+
+
 class HookScriptTests(unittest.TestCase):
     def run_cmd(self, cmd, home):
         env = os.environ.copy()
-        env["HOME"] = str(home)
-        env["USERPROFILE"] = str(home)
+        env["HOME"] = shell_path(home)
+        env["USERPROFILE"] = shell_path(home)
+        env["CLAUDE_CONFIG_DIR"] = shell_path(home / ".claude")
         return subprocess.run(
             cmd,
             cwd=REPO_ROOT,
             env=env,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
             check=True,
         )
@@ -32,14 +73,14 @@ class HookScriptTests(unittest.TestCase):
             (hooks_dir / "caveman-activate.js").write_text("")
             (hooks_dir / "caveman-mode-tracker.js").write_text("")
 
-            self.run_cmd(["bash", "hooks/install.sh"], home)
+            self.run_cmd([BASH, "hooks/install.sh"], home)
 
             statusline = hooks_dir / "caveman-statusline.sh"
             self.assertTrue(statusline.exists(), "upgrade should install statusline script")
 
             settings = json.loads((home / ".claude" / "settings.json").read_text())
             self.assertIn("statusLine", settings)
-            self.assertIn(str(statusline), settings["statusLine"]["command"])
+            self.assertIn(str(statusline).replace("\\", "/"), settings["statusLine"]["command"])
 
     def test_install_reconfigures_missing_statusline(self):
         with tempfile.TemporaryDirectory(prefix="caveman-hooks-statusline-") as tmp:
@@ -77,13 +118,13 @@ class HookScriptTests(unittest.TestCase):
             }
             (claude_dir / "settings.json").write_text(json.dumps(settings, indent=2) + "\n")
 
-            result = self.run_cmd(["bash", "hooks/install.sh"], home)
+            result = self.run_cmd([BASH, "hooks/install.sh"], home)
 
             self.assertNotIn("Nothing to do", result.stdout)
 
             updated = json.loads((claude_dir / "settings.json").read_text())
             self.assertIn("statusLine", updated)
-            self.assertIn(str(hooks_dir / "caveman-statusline.sh"), updated["statusLine"]["command"])
+            self.assertIn(str(hooks_dir / "caveman-statusline.sh").replace("\\", "/"), updated["statusLine"]["command"])
 
     def test_uninstall_preserves_custom_statusline(self):
         with tempfile.TemporaryDirectory(prefix="caveman-hooks-uninstall-") as tmp:
@@ -125,7 +166,7 @@ class HookScriptTests(unittest.TestCase):
             }
             (claude_dir / "settings.json").write_text(json.dumps(settings, indent=2) + "\n")
 
-            self.run_cmd(["bash", "hooks/uninstall.sh"], home)
+            self.run_cmd([BASH, "hooks/uninstall.sh"], home)
 
             updated = json.loads((claude_dir / "settings.json").read_text())
             self.assertEqual(

--- a/tests/verify_repo.py
+++ b/tests/verify_repo.py
@@ -16,6 +16,41 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def resolve_bash() -> str:
+    """Prefer Git Bash on Windows; WSL bash does not handle Windows paths here."""
+    candidates: list[Path] = []
+    if override := os.environ.get("CAVEMAN_BASH"):
+        candidates.append(Path(override))
+    if os.name == "nt":
+        candidates.extend(
+            [
+                Path(r"C:\Program Files\Git\bin\bash.exe"),
+                Path(r"C:\Program Files\Git\usr\bin\bash.exe"),
+            ]
+        )
+    if found := shutil.which("bash"):
+        found_path = Path(found)
+        if os.name != "nt" or not is_wsl_bash(found_path):
+            candidates.append(found_path)
+
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    return "bash"
+
+
+def is_wsl_bash(path: Path) -> bool:
+    normalized = str(path).lower().replace("/", "\\")
+    return (
+        normalized.endswith(r"\windows\system32\bash.exe")
+        or normalized.endswith(r"\microsoft\windowsapps\bash.exe")
+        or r"\windowsapps\bash.exe" in normalized
+    )
+
+
+BASH = resolve_bash()
+
+
 class CheckFailure(RuntimeError):
     pass
 
@@ -176,9 +211,9 @@ def verify_manifests_and_syntax() -> None:
     run(["node", "--check", "hooks/caveman-config.js"])
     run(["node", "--check", "hooks/caveman-activate.js"])
     run(["node", "--check", "hooks/caveman-mode-tracker.js"])
-    run(["bash", "-n", "hooks/install.sh"])
-    run(["bash", "-n", "hooks/uninstall.sh"])
-    run(["bash", "-n", "hooks/caveman-statusline.sh"])
+    run([BASH, "-n", "hooks/install.sh"])
+    run([BASH, "-n", "hooks/uninstall.sh"])
+    run([BASH, "-n", "hooks/caveman-statusline.sh"])
 
     # Ensure install/uninstall scripts include caveman-config.js
     install_sh = (ROOT / "hooks/install.sh").read_text(encoding="utf-8")
@@ -267,7 +302,7 @@ def verify_hook_install_flow() -> None:
     section("Claude Hook Flow")
 
     ensure(shutil.which("node") is not None, "node is required for hook verification")
-    ensure(shutil.which("bash") is not None, "bash is required for hook verification")
+    ensure(Path(BASH).exists() or shutil.which(BASH) is not None, "bash is required for hook verification")
 
     with tempfile.TemporaryDirectory(prefix="caveman-verify-") as temp_root:
         temp_root_path = Path(temp_root)
@@ -282,7 +317,7 @@ def verify_hook_install_flow() -> None:
         (claude_dir / "settings.json").write_text(json.dumps(existing_settings, indent=2) + "\n")
         hook_env = {"HOME": shell_path(home), "CLAUDE_CONFIG_DIR": shell_path(claude_dir)}
 
-        run(["bash", "hooks/install.sh"], env=hook_env)
+        run([BASH, "hooks/install.sh"], env=hook_env)
 
         settings = read_json(claude_dir / "settings.json")
         hooks = settings["hooks"]
@@ -368,15 +403,15 @@ def verify_hook_install_flow() -> None:
 
         (claude_dir / ".caveman-active").write_text("wenyan-ultra")
         statusline = run(
-            ["bash", "hooks/caveman-statusline.sh"],
+            [BASH, "hooks/caveman-statusline.sh"],
             env=hook_env,
         )
         ensure("[CAVEMAN:WENYAN-ULTRA]" in statusline.stdout, "statusline badge output mismatch")
 
-        reinstall = run(["bash", "hooks/install.sh"], env=hook_env)
+        reinstall = run([BASH, "hooks/install.sh"], env=hook_env)
         ensure("Nothing to do" in reinstall.stdout, "install.sh should be idempotent")
 
-        run(["bash", "hooks/uninstall.sh"], env=hook_env)
+        run([BASH, "hooks/uninstall.sh"], env=hook_env)
         settings_after = read_json(claude_dir / "settings.json")
         ensure(settings_after == existing_settings, "uninstall.sh did not restore non-caveman settings")
         ensure(not (claude_dir / ".caveman-active").exists(), "uninstall.sh should remove flag file")
@@ -385,12 +420,12 @@ def verify_hook_install_flow() -> None:
         home = Path(temp_root) / "home"
         claude_dir = home / ".claude"
         hook_env = {"HOME": shell_path(home), "CLAUDE_CONFIG_DIR": shell_path(claude_dir)}
-        run(["bash", "hooks/install.sh"], env=hook_env)
+        run([BASH, "hooks/install.sh"], env=hook_env)
         settings = read_json(claude_dir / "settings.json")
         ensure("statusLine" in settings, "fresh install should configure statusline")
         activate = run(["node", "hooks/caveman-activate.js"], env=hook_env)
         ensure("STATUSLINE SETUP NEEDED" not in activate.stdout, "fresh install should not nudge for statusline")
-        run(["bash", "hooks/uninstall.sh"], env=hook_env)
+        run([BASH, "hooks/uninstall.sh"], env=hook_env)
         ensure(read_json(claude_dir / "settings.json") == {}, "fresh uninstall should leave empty settings")
 
     print("Claude hook install/uninstall flow OK")


### PR DESCRIPTION
## Summary

- Pin shell scripts to LF line endings so Windows checkouts with `core.autocrlf=true` do not break Bash syntax checks.
- Document Windows contributor checkout expectations, Git Bash preference, and `CAVEMAN_BASH` override.
- Make compress module output UTF-8-safe when imported directly, and update hook verification tests to prefer Git Bash on Windows.

## Why

Windows contributors can currently hit CRLF shell scripts, WSL `bash.exe` path/tool mismatches, and CP932 Unicode output failures while running local verification. These issues obscure otherwise valid changes and make the starter contributor path harder than necessary.

## Validation

- `python tests/verify_repo.py`
- `python -m unittest tests.test_compress_safety tests.test_validate_inline tests.test_hooks`
- `node tests/test_caveman_init.js`
- `node tests/test_mcp_shrink.js`
- `node tests/test_symlink_flag.js`
- `node tests/test_caveman_stats.js`