### PR TITLE
feat: add /caveman slash command registration

### DIFF
--- a/commands/caveman.md
+++ b/commands/caveman.md
@@ -1,0 +1,24 @@
+---
+description: Activate caveman mode — ultra-compressed responses that cut ~75% of tokens. Usage: /caveman [lite|full|ultra|off]
+---
+
+Activate caveman communication mode at the requested intensity level.
+
+The user invoked `/caveman $ARGUMENTS`.
+
+Parse $ARGUMENTS:
+- Empty or "on" → activate default (full) caveman mode
+- "lite" → activate lite mode (no filler/hedging, keep full sentences)
+- "full" → activate full mode (drop articles, fragments OK — default)
+- "ultra" → activate ultra mode (abbreviate prose, arrows for causality)
+- "off" / "stop" / "disable" → deactivate caveman mode, return to normal
+- "wenyan" / "wenyan-full" → activate Classical Chinese compression mode
+
+Then apply the selected mode immediately and confirm activation in one terse line.
+
+Caveman rules (full mode):
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms. Technical terms exact. Code blocks unchanged.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Persist this style for the rest of the session until told "stop caveman" or "normal mode".


### PR DESCRIPTION
## What

Adds `commands/caveman.md` so Claude Code recognises `/caveman` as a valid slash command.

## Why

Without this file, the Claude Code CLI intercepts `/caveman` and returns `Unknown command` before the `UserPromptSubmit` hook can process it. Users who try `/caveman` immediately after installing the plugin see the error and assume the plugin is broken.

## How it works

The `commands/caveman.md` file registers `/caveman [lite|full|ultra|off|wenyan]` as a first-class slash command. When invoked, Claude parses the argument and activates the corresponding intensity level, then persists caveman style for the rest of the session.

## Reviewer notes

- The existing `SessionStart` and `UserPromptSubmit` hooks continue to work as before — this file only adds the missing CLI registration.
- Tested on Windows 10 with Claude Code after plugin install.
