### PR TITLE
fix(agents): use YAML array for `tools` so Gemini CLI accepts agents

### DIFF
--- a/agents/cavecrew-builder.md
+++ b/agents/cavecrew-builder.md
@@ -6,7 +6,7 @@ description: >
   scope. Returns caveman diff receipt. Use when scope is bounded and
   obvious; do NOT use for new features, new files (unless asked), or
   cross-file refactors.
-tools: Read, Edit, Write, Grep, Glob
+tools: [Read, Edit, Write, Grep, Glob]
 ---
 
 Caveman-ultra. Drop articles/filler. Code/paths exact, backticked. No narration.

--- a/agents/cavecrew-investigator.md
+++ b/agents/cavecrew-investigator.md
@@ -5,7 +5,7 @@ description: >
   "what calls Y", "list all uses of Z", "map this directory". Output is
   caveman-compressed so the main thread eats ~60% fewer tokens than
   vanilla Explore. Refuses to suggest fixes.
-tools: Read, Grep, Glob, Bash
+tools: [Read, Grep, Glob, Bash]
 model: haiku
 ---
 

--- a/agents/cavecrew-reviewer.md
+++ b/agents/cavecrew-reviewer.md
@@ -5,7 +5,7 @@ description: >
   no scope creep. Output format `path:line: <emoji> <severity>: <problem>. <fix>.`
   Use for "review this PR", "review my diff", "audit this file". Skips
   formatting nits unless they change meaning.
-tools: Read, Grep, Bash
+tools: [Read, Grep, Bash]
 model: haiku
 ---
 

--- a/plugins/caveman/agents/cavecrew-builder.md
+++ b/plugins/caveman/agents/cavecrew-builder.md
@@ -6,7 +6,7 @@ description: >
   scope. Returns caveman diff receipt. Use when scope is bounded and
   obvious; do NOT use for new features, new files (unless asked), or
   cross-file refactors.
-tools: Read, Edit, Write, Grep, Glob
+tools: [Read, Edit, Write, Grep, Glob]
 ---
 
 Caveman-ultra. Drop articles/filler. Code/paths exact, backticked. No narration.

--- a/plugins/caveman/agents/cavecrew-investigator.md
+++ b/plugins/caveman/agents/cavecrew-investigator.md
@@ -5,7 +5,7 @@ description: >
   "what calls Y", "list all uses of Z", "map this directory". Output is
   caveman-compressed so the main thread eats ~60% fewer tokens than
   vanilla Explore. Refuses to suggest fixes.
-tools: Read, Grep, Glob, Bash
+tools: [Read, Grep, Glob, Bash]
 model: haiku
 ---
 

--- a/plugins/caveman/agents/cavecrew-reviewer.md
+++ b/plugins/caveman/agents/cavecrew-reviewer.md
@@ -5,7 +5,7 @@ description: >
   no scope creep. Output format `path:line: <emoji> <severity>: <problem>. <fix>.`
   Use for "review this PR", "review my diff", "audit this file". Skips
   formatting nits unless they change meaning.
-tools: Read, Grep, Bash
+tools: [Read, Grep, Bash]
 model: haiku
 ---
 


### PR DESCRIPTION
Gemini CLI's Zod validator rejects the comma-separated string form (`tools: Read, Edit, Write`) with "Expected array, received string", blocking extension install. Claude Code tolerated both; the array form works for both runtimes.

Closes #330, 
Closes #335, 
Closes #328,
Closes #325 