### PR TITLE
feat: native opencode installer — direct skills copy to ~/.agents/skills/

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ By default the installer wires Claude Code's hooks + statusline + stats badge an
 | **Claude Code** | `claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman` |
 | **Gemini CLI** | `gemini extensions install https://github.com/JuliusBrussee/caveman` |
 | **Cursor / Windsurf / Cline / Copilot** | `npx skills add JuliusBrussee/caveman -a <cursor\|windsurf\|cline\|github-copilot>` |
-| **Codex / opencode / Roo / Amp / Goose / Kiro / Augment / Aider Desk / Continue / Kilo / Junie / Trae / Warp / Tabnine / Mistral / Qwen / Devin / Droid / ForgeCode / Bob / Crush / iFlow / OpenHands / Qoder / Rovo Dev / Replit / Antigravity** | `npx skills add JuliusBrussee/caveman -a <profile>` (see `install.sh --list` for the full slug list) |
+| **opencode** | Native — copies skills directly to `~/.agents/skills/` (no npx needed) |
+| **Codex / Roo / Amp / Goose / Kiro / Augment / Aider Desk / Continue / Kilo / Junie / Trae / Warp / Tabnine / Mistral / Qwen / Devin / Droid / ForgeCode / Bob / Crush / iFlow / OpenHands / Qoder / Rovo Dev / Replit / Antigravity** | `npx skills add JuliusBrussee/caveman -a <profile>` (see `install.sh --list` for the full slug list) |
 | **Anything else (40+ agents)** | `npx skills add JuliusBrussee/caveman` (auto-detect) |
 
 Standalone Claude Code hooks (without plugin): `bash <(curl -s https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks/install.sh)`. Windows: `irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks/install.ps1 | iex`. Manual fallback for stubborn Windows envs lives in [`docs/install-windows.md`](docs/install-windows.md).
@@ -185,7 +186,7 @@ Uninstall: disable the Claude plugin, `gemini extensions uninstall caveman`, or 
 | caveman-stats | Y | — | — | — | — | — |
 | cavecrew (subagents) | Y | — | — | — | — | — |
 
-\* opencode, Roo, Amp, Goose, Kiro CLI, Augment, Aider Desk, Continue, Kilo, Junie (JetBrains), Trae, Warp, Tabnine, Mistral, Qwen, Devin, Droid, ForgeCode, Bob, Crush, iFlow, OpenHands, Qoder, Rovo Dev, Replit, Antigravity, and more via `npx skills`. AGENTS.md / IDE rule files reach Zed, generic agents, etc. via `--with-init`.
+\* opencode installs natively to `~/.agents/skills/` — faster, offline-friendly, no Node required. Roo, Amp, Goose, Kiro CLI, Augment, Aider Desk, Continue, Kilo, Junie (JetBrains), Trae, Warp, Tabnine, Mistral, Qwen, Devin, Droid, ForgeCode, Bob, Crush, iFlow, OpenHands, Qoder, Rovo Dev, Replit, Antigravity, and more via `npx skills`. AGENTS.md / IDE rule files reach Zed, generic agents, etc. via `--with-init`.
 ¹ Codex uses `$caveman` instead of `/caveman`. Auto-start ships when you run Codex inside this repo (via `.codex/hooks.json`); for other repos, copy the hook or use `$caveman` manually. ² Mode switching is on-demand via the skill, no slash command. ³ Compress only.
 
 `--with-init` writes `.cursor/rules/caveman.mdc`, `.windsurf/rules/caveman.md`, `.clinerules/caveman.md`, `.github/copilot-instructions.md`, and `AGENTS.md` into the current repo so caveman auto-starts there.

--- a/install.ps1
+++ b/install.ps1
@@ -312,7 +312,7 @@ $Providers = @(
   @{ id='kiro';        label='Kiro CLI';           profile='kiro-cli';     detect="command:kiro||dir:$HOME\.kiro"; soft=0 },
   @{ id='mistral';     label='Mistral Vibe';       profile='mistral-vibe'; detect="command:mistral||dir:$HOME\.vibe"; soft=0 },
   @{ id='openhands';   label='OpenHands';          profile='openhands';    detect="command:openhands||dir:$HOME\.openhands"; soft=0 },
-  @{ id='opencode';    label='opencode';           profile='opencode';     detect="command:opencode||file:$HOME\.config\opencode\AGENTS.md"; soft=0 },
+  @{ id='opencode';    label='opencode';           profile='';             detect="command:opencode||file:$HOME\.config\opencode\AGENTS.md"; soft=0 },
   @{ id='qwen';        label='Qwen Code';          profile='qwen-code';    detect="command:qwen||dir:$HOME\.qwen"; soft=0 },
   @{ id='qoder';       label='Qoder';              profile='qoder';        detect="dir:$HOME\.qoder"; soft=1 },
   @{ id='rovodev';     label='Atlassian Rovo Dev'; profile='rovodev';      detect="command:rovodev||dir:$HOME\.rovodev"; soft=0 },
@@ -502,6 +502,87 @@ function Install-Gemini {
   Write-Host ""
 }
 
+function Install-Opencode {
+  $script:DetectedCount++
+  Say "→ opencode detected"
+
+  $skillsDir = if ($env:AGENTS_SKILLS_DIR) { $env:AGENTS_SKILLS_DIR } else { Join-Path $HOME ".agents\skills" }
+  $cavemanSkills = @("caveman", "caveman-commit", "caveman-review", "caveman-help", "caveman-stats", "cavecrew", "compress")
+  $installedCount = 0
+  $skippedCount = 0
+
+  if (-not (Test-Path $skillsDir)) {
+    if ($DryRun) {
+      Note "  would create: $skillsDir"
+    } else {
+      New-Item -ItemType Directory -Path $skillsDir -Force | Out-Null
+    }
+  }
+
+  foreach ($skill in $cavemanSkills) {
+    $target = Join-Path $skillsDir $skill
+
+    if ((Test-Path $target) -and (-not $Force)) {
+      Note "  $skill already installed (use -Force to overwrite)"
+      $skippedCount++
+      continue
+    }
+
+    if ($RepoRoot -and (Test-Path (Join-Path $RepoRoot "skills\$skill"))) {
+      if ($DryRun) {
+        Note "  would copy: $(Join-Path $RepoRoot "skills\$skill") → $target"
+      } else {
+        if (Test-Path $target) { Remove-Item $target -Recurse -Force }
+        Copy-Item -Path (Join-Path $RepoRoot "skills\$skill") -Destination $target -Recurse -Force
+      }
+    } else {
+      if (-not (Has-Cmd "curl")) {
+        Warn "  curl required to fetch $skill remotely"
+        continue
+      }
+      if ($DryRun) {
+        Note "  would download: $RawBase/skills/$skill/SKILL.md → $target\SKILL.md"
+      } else {
+        if (Test-Path $target) { Remove-Item $target -Recurse -Force }
+        New-Item -ItemType Directory -Path $target -Force | Out-Null
+        try {
+          Invoke-WebRequest -Uri "$RawBase/skills/$skill/SKILL.md" -OutFile (Join-Path $target "SKILL.md") -UseBasicParsing -ErrorAction Stop
+        } catch {
+          Warn "    failed to download $skill/SKILL.md"
+          if (Test-Path $target) { Remove-Item $target -Recurse -Force }
+          continue
+        }
+        # Download subdirectories for skills that have them (compress/scripts)
+        if ($skill -eq "compress") {
+          $scriptsDir = Join-Path $target "scripts"
+          New-Item -ItemType Directory -Path $scriptsDir -Force | Out-Null
+          $subs = @("__init__.py", "__main__.py", "benchmark.py", "cli.py", "compress.py", "detect.py", "validate.py")
+          foreach ($sub in $subs) {
+            try {
+              Invoke-WebRequest -Uri "$RawBase/skills/compress/scripts/$sub" -OutFile (Join-Path $scriptsDir $sub) -UseBasicParsing -ErrorAction Stop
+            } catch {
+              # Silently skip missing sub-files
+            }
+          }
+        }
+      }
+    }
+
+    $installedCount++
+  }
+
+  if ($installedCount -gt 0) {
+    Record-Installed "opencode"
+    Ok "  installed $installedCount skills to $skillsDir"
+  } elseif ($skippedCount -eq $cavemanSkills.Count) {
+    Record-Skipped "opencode" "all skills already installed"
+  }
+
+  Note "  skills active immediately. No CLI restart needed."
+  Write-Host ""
+  return
+}
+
 function Install-ViaSkills {
   param([string]$id, [string]$label, [string]$profile)
   $script:DetectedCount++
@@ -526,9 +607,10 @@ foreach ($p in $Providers) {
   if (-not (Want $p.id)) { continue }
   if (-not (Resolve-DetectSpec $p.detect)) { continue }
   switch ($p.id) {
-    'claude' { Install-Claude }
-    'gemini' { Install-Gemini }
-    default  { Install-ViaSkills $p.id $p.label $p.profile }
+    'claude'   { Install-Claude }
+    'gemini'   { Install-Gemini }
+    'opencode' { Install-Opencode }
+    default    { Install-ViaSkills $p.id $p.label $p.profile }
   }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -301,7 +301,7 @@ PROVIDER_MECHS=(
   "npx skills add (crush)" "npx skills add (devin)" "npx skills add (droid)"
   "npx skills add (forgecode)" "npx skills add (goose)" "npx skills add (iflow-cli)"
   "npx skills add (junie)" "npx skills add (kiro-cli)" "npx skills add (mistral-vibe)"
-  "npx skills add (openhands)" "npx skills add (opencode)" "npx skills add (qwen-code)"
+  "npx skills add (openhands)" "copy skills to ~/.agents/skills" "npx skills add (qwen-code)"
   "npx skills add (qoder)" "npx skills add (rovodev)" "npx skills add (tabnine-cli)"
   "npx skills add (trae)" "npx skills add (warp)" "npx skills add (replit)"
   "npx skills add (antigravity)"
@@ -557,6 +557,81 @@ EOF
   return 0
 }
 
+install_opencode() {
+  DETECTED_COUNT=$((DETECTED_COUNT + 1))
+  say "→ opencode detected"
+
+  local SKILLS_DIR="${AGENTS_SKILLS_DIR:-$HOME/.agents/skills}"
+  local CAVEMAN_SKILLS=(caveman caveman-commit caveman-review caveman-help caveman-stats cavecrew compress)
+  local installed_count=0
+  local skipped_count=0
+
+  if [ ! -d "$SKILLS_DIR" ]; then
+    if [ "$DRY" = 1 ]; then
+      note "  would create: $SKILLS_DIR"
+    else
+      mkdir -p "$SKILLS_DIR"
+    fi
+  fi
+
+  for skill in "${CAVEMAN_SKILLS[@]}"; do
+    local target="$SKILLS_DIR/$skill"
+
+    if [ -d "$target" ] && [ "$FORCE" = 0 ]; then
+      note "  $skill already installed (use --force to overwrite)"
+      skipped_count=$((skipped_count + 1))
+      continue
+    fi
+
+    if [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT/skills/$skill" ]; then
+      if [ "$DRY" = 1 ]; then
+        note "  would copy: $REPO_ROOT/skills/$skill → $target"
+      else
+        rm -rf "$target"
+        cp -R "$REPO_ROOT/skills/$skill" "$target"
+      fi
+    else
+      if ! has curl; then
+        warn "  curl required to fetch $skill remotely"
+        continue
+      fi
+      if [ "$DRY" = 1 ]; then
+        note "  would download: $RAW_BASE/skills/$skill/SKILL.md → $target/SKILL.md"
+      else
+        rm -rf "$target"
+        mkdir -p "$target"
+        if curl -fsSL "$RAW_BASE/skills/$skill/SKILL.md" -o "$target/SKILL.md" 2>/dev/null; then
+          : # success
+        else
+          warn "    failed to download $skill/SKILL.md"
+          rm -rf "$target"
+          continue
+        fi
+        # Download subdirectories for skills that have them (compress/scripts)
+        if [ "$skill" = "compress" ]; then
+          mkdir -p "$target/scripts"
+          for sub in __init__.py __main__.py benchmark.py cli.py compress.py detect.py validate.py; do
+            curl -fsSL "$RAW_BASE/skills/compress/scripts/$sub" -o "$target/scripts/$sub" 2>/dev/null || true
+          done
+        fi
+      fi
+    fi
+
+    installed_count=$((installed_count + 1))
+  done
+
+  if [ "$installed_count" -gt 0 ]; then
+    record_installed "opencode"
+    ok "  installed $installed_count skills to $SKILLS_DIR"
+  elif [ "$skipped_count" -eq "${#CAVEMAN_SKILLS[@]}" ]; then
+    record_skipped "opencode" "all skills already installed"
+  fi
+
+  note "  skills active immediately. No CLI restart needed."
+  echo
+  return 0
+}
+
 install_gemini() {
   DETECTED_COUNT=$((DETECTED_COUNT + 1))
   say "→ Gemini CLI detected"
@@ -626,6 +701,11 @@ if want claude && detect_match "command:claude"; then
   install_claude
 fi
 
+# opencode: native skills install (no npx skills fallback).
+if want opencode && detect_match "command:opencode||file:$HOME/.config/opencode/AGENTS.md"; then
+  install_opencode
+fi
+
 # Gemini.
 if want gemini && detect_match "command:gemini"; then
   install_gemini
@@ -661,7 +741,6 @@ SKILLS_AGENTS=(
   "kiro|Kiro CLI|kiro-cli|command:kiro||dir:$HOME/.kiro"
   "mistral|Mistral Vibe|mistral-vibe|command:mistral||dir:$HOME/.vibe"
   "openhands|OpenHands|openhands|command:openhands||dir:$HOME/.openhands"
-  "opencode|opencode|opencode|command:opencode||file:$HOME/.config/opencode/AGENTS.md"
   "qwen|Qwen Code|qwen-code|command:qwen||dir:$HOME/.qwen"
   "qoder|Qoder|qoder|dir:$HOME/.qoder"
   "rovodev|Atlassian Rovo Dev|rovodev|command:rovodev||dir:$HOME/.rovodev"

--- a/tests/test_opencode_install.py
+++ b/tests/test_opencode_install.py
@@ -1,0 +1,106 @@
+"""Tests for the native opencode installer in install.sh.
+
+Covers:
+- Local copy mode (repo_root available)
+- Remote download fallback (curl-pipe mode)
+- Idempotency (skip when already installed unless --force)
+- Sub-directory handling (compress/scripts)
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class OpencodeInstallTests(unittest.TestCase):
+    def run_install(self, args, home, cwd=None):
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)
+        cmd = ["bash", str(REPO_ROOT / "install.sh")] + args
+        return subprocess.run(
+            cmd,
+            cwd=cwd or REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_opencode_installs_skills_locally(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-opencode-") as tmp:
+            home = Path(tmp)
+            skills_dir = home / ".agents" / "skills"
+
+            result = self.run_install(["--only", "opencode"], home)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("opencode detected", result.stdout)
+
+            expected_skills = [
+                "caveman", "caveman-commit", "caveman-review",
+                "caveman-help", "caveman-stats", "cavecrew", "compress",
+            ]
+            for skill in expected_skills:
+                skill_path = skills_dir / skill / "SKILL.md"
+                self.assertTrue(skill_path.exists(), f"{skill}/SKILL.md missing")
+                content = skill_path.read_text()
+                self.assertIn("caveman", content.lower())
+
+    def test_opencode_skips_when_already_installed(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-opencode-") as tmp:
+            home = Path(tmp)
+            skills_dir = home / ".agents" / "skills"
+            skills_dir.mkdir(parents=True)
+            (skills_dir / "caveman").mkdir()
+            (skills_dir / "caveman" / "SKILL.md").write_text("existing")
+
+            result = self.run_install(["--only", "opencode"], home)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("already installed", result.stdout)
+
+    def test_opencode_overwrites_with_force(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-opencode-") as tmp:
+            home = Path(tmp)
+            skills_dir = home / ".agents" / "skills"
+            skills_dir.mkdir(parents=True)
+            (skills_dir / "caveman").mkdir()
+            (skills_dir / "caveman" / "SKILL.md").write_text("stale")
+
+            result = self.run_install(["--only", "opencode", "--force"], home)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertNotIn("already installed", result.stdout)
+            content = (skills_dir / "caveman" / "SKILL.md").read_text()
+            self.assertNotEqual(content, "stale")
+
+    def test_opencode_compress_includes_scripts(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-opencode-") as tmp:
+            home = Path(tmp)
+
+            result = self.run_install(["--only", "opencode"], home)
+
+            self.assertEqual(result.returncode, 0)
+            scripts_dir = home / ".agents" / "skills" / "compress" / "scripts"
+            self.assertTrue(scripts_dir.exists())
+            self.assertTrue((scripts_dir / "compress.py").exists())
+
+    def test_opencode_dry_run_does_not_write(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-opencode-") as tmp:
+            home = Path(tmp)
+
+            result = self.run_install(["--only", "opencode", "--dry-run"], home)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("would copy", result.stdout)
+            self.assertFalse((home / ".agents").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/caveman-init.js
+++ b/tools/caveman-init.js
@@ -50,6 +50,9 @@ const AGENTS = [
   { id: 'agents',   file: 'AGENTS.md',
     frontmatter: '',
     mode: 'append' },
+  { id: 'opencode', file: 'AGENTS.md',
+    frontmatter: '',
+    mode: 'append' },
 ];
 
 function loadRuleBody() {


### PR DESCRIPTION
## What
Replaces `npx skills add (opencode)` fallback with a native filesystem installer that copies caveman skills directly to `~/.agents/skills/`.
## Why
The current installer routes opencode through `npx skills add`, which:
- Requires Node.js and internet connectivity even for local repo clones
- Adds an unnecessary intermediary (`vercel-labs/skills`) when opencode reads skills directly from the filesystem
- Is slower and less reliable than a direct copy
A native installer mirrors how Claude Code gets first-class treatment (plugin + hooks) and makes opencode installation offline-friendly.
## How it works
Two new install functions handle opencode directly:
**`install_opencode()`** in `install.sh` (macOS/Linux/WSL)
- Detects `~/.agents/skills/` directory or creates it
- Copies all 7 skills from the local repo clone when available
- Falls back to `curl` downloading individual `SKILL.md` files for pipe installs
- Handles `compress/scripts/` subdirectory downloads
- Supports `--force` to overwrite existing skills
- Skips already-installed skills by default
**`Install-Opencode`** in `install.ps1` (Windows/PowerShell)
- Equivalent PowerShell implementation using `Copy-Item` and `Invoke-WebRequest`
- Same offline/online dual mode and idempotency
Both remove opencode from the generic `npx skills` fallback path, so it no longer appears in `SKILLS_AGENTS`.
## Also updated
| File | Change |
|---|---|
| `tools/caveman-init.js` | Adds `opencode` as an `AGENTS.md` target, so `--with-init` writes caveman activation rules for opencode users |
| `README.md` | Documents opencode as a native install alongside Claude Code and Gemini CLI |
| `tests/test_opencode_install.py` | 5 integration tests covering local copy, skip, force, compress subdirs, and dry-run |
## Reviewer notes
- The existing `npx skills add` path continues to work for all other agents — only opencode is extracted
- `install.sh` and `install.ps1` stay aligned: same detection probe, same skill list, same idempotency logic
- `AGENTS_SKILLS_DIR` env var overrides the default `~/.agents/skills/` path in both scripts
- Tested on macOS with `bash install.sh --only opencode --dry-run` and `python3 tests/test_opencode_install.py` (5/5 pass)