### PR TITLE
Rename codex_hooks to hooks in config.toml

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,2 @@
 [features]
-codex_hooks = true
+hooks = true


### PR DESCRIPTION
rename deprecated `codex_hooks` to `hooks` as per latest codex config syntax.