### PR TITLE
docs: add human-facing README.md to each skill

### DIFF
--- a/skills/cavecrew/README.md
+++ b/skills/cavecrew/README.md
@@ -1,0 +1,41 @@
+# cavecrew
+
+Decision guide. When to delegate to caveman subagents instead of doing the work inline.
+
+## What it does
+
+Tells the main thread when to spawn a caveman-style subagent versus the vanilla equivalent. The win: subagent tool-results inject back into main context verbatim, and caveman output is roughly 1/3 the size of vanilla prose. Across 20 delegations in one session, that is the difference between context exhaustion and finishing the task.
+
+Three subagents:
+
+| Subagent | Job | Use when |
+|----------|-----|----------|
+| `cavecrew-investigator` | Locate code (read-only) | "Where is X defined / what calls Y / list uses of Z" |
+| `cavecrew-builder` | Surgical edit, 1-2 files | Scope is obvious, ≤2 files. Refuses 3+ file scope. |
+| `cavecrew-reviewer` | Diff/file review | One-line findings with severity emoji |
+
+Use vanilla `Explore` or `Code Reviewer` when you want prose, architecture commentary, or rationale. Use main thread directly for one-line answers and 3+ file refactors.
+
+This skill is a decision guide, not a slash command. It activates when the conversation mentions delegation.
+
+## How to invoke
+
+Triggers on phrases like "delegate to subagent", "use cavecrew", "spawn investigator", "save context", "compressed agent output".
+
+## Example chaining
+
+Locate → fix → verify (most common):
+
+1. `cavecrew-investigator` returns site list (`path:line — symbol — note`)
+2. Main thread picks 1-2 sites, hands paths to `cavecrew-builder`
+3. `cavecrew-reviewer` audits the resulting diff
+
+Parallel scout: spawn 2-3 `cavecrew-investigator` calls in one message with different angles (defs, callers, tests). Aggregate in main.
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — full decision matrix and output contracts
+- [`agents/cavecrew-investigator.md`](../../agents/cavecrew-investigator.md)
+- [`agents/cavecrew-builder.md`](../../agents/cavecrew-builder.md)
+- [`agents/cavecrew-reviewer.md`](../../agents/cavecrew-reviewer.md)
+- [Caveman README](../../README.md) — repo overview

--- a/skills/caveman-commit/README.md
+++ b/skills/caveman-commit/README.md
@@ -1,0 +1,44 @@
+# caveman-commit
+
+Terse Conventional Commits. Why over what.
+
+## What it does
+
+Generates commit messages in Conventional Commits format. Subject ≤50 chars, hard cap 72. Imperative mood. Body only when the *why* is non-obvious or there are breaking changes. No AI attribution, no "this commit does X", no emoji unless the project uses them. Body always required for breaking changes, security fixes, data migrations, and reverts — future debuggers need the context.
+
+Outputs only the message. Does not stage, commit, or amend.
+
+## How to invoke
+
+```
+/caveman-commit
+```
+
+Also triggers on phrases like "write a commit", "commit message", "generate commit".
+
+## Example output
+
+Diff: new endpoint for user profile.
+
+```
+feat(api): add GET /users/:id/profile
+
+Mobile client needs profile data without the full user payload
+to reduce LTE bandwidth on cold-launch screens.
+
+Closes #128
+```
+
+Diff: breaking API rename.
+
+```
+feat(api)!: rename /v1/orders to /v1/checkout
+
+BREAKING CHANGE: clients on /v1/orders must migrate to /v1/checkout
+before 2026-06-01. Old route returns 410 after that date.
+```
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — full LLM-facing instructions
+- [Caveman README](../../README.md) — repo overview

--- a/skills/caveman-help/README.md
+++ b/skills/caveman-help/README.md
@@ -1,0 +1,38 @@
+# caveman-help
+
+Quick-reference card. One shot, no mode change.
+
+## What it does
+
+Prints a cheat sheet of all caveman modes, sibling skills, deactivation triggers, and how to set the default mode via env var or config file. One-shot display — does not flip the active mode, write flag files, or persist anything. Use when you forget the slash commands.
+
+## How to invoke
+
+```
+/caveman-help
+```
+
+Also triggers on "caveman help", "what caveman commands", "how do I use caveman".
+
+## Example output
+
+```
+Modes:
+  /caveman              full (default)
+  /caveman lite         lighter
+  /caveman ultra        extreme
+  /caveman wenyan       classical Chinese
+
+Skills:
+  /caveman-commit       terse Conventional Commits
+  /caveman-review       one-line PR comments
+  /caveman-stats        session token savings
+
+Deactivate:
+  "stop caveman" or "normal mode"
+```
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — full reference card
+- [Caveman README](../../README.md) — repo overview

--- a/skills/caveman-review/README.md
+++ b/skills/caveman-review/README.md
@@ -1,0 +1,33 @@
+# caveman-review
+
+One-line PR comments. Location, problem, fix. No throat-clearing.
+
+## What it does
+
+Generates code review comments in `L<line>: <severity> <problem>. <fix>.` format. One line per finding. Severity emoji: 🔴 bug, 🟡 risk, 🔵 nit, ❓ question. Drops "I noticed that...", hedging, and restating what the diff already shows. Keeps exact line numbers, backticked symbols, and concrete fixes.
+
+Auto-clarity: drops terse mode for CVE-class security findings, architectural disagreements, and onboarding contexts where the author needs the *why*. Resumes terse for the rest.
+
+Output only — does not approve, request changes, or run linters.
+
+## How to invoke
+
+```
+/caveman-review
+```
+
+Also triggers on "review this PR", "code review", "review the diff".
+
+## Example output
+
+```
+L42: 🔴 bug: user can be null after .find(). Add guard before .email.
+L88-140: 🔵 nit: 50-line fn does 4 things. Extract validate/normalize/persist.
+L23: 🟡 risk: no retry on 429. Wrap in withBackoff(3).
+L107: ❓ q: why drop the cache here? Reads on next request will miss.
+```
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — full LLM-facing instructions
+- [Caveman README](../../README.md) — repo overview

--- a/skills/caveman-stats/README.md
+++ b/skills/caveman-stats/README.md
@@ -1,0 +1,30 @@
+# caveman-stats
+
+Real session token receipts. No AI estimation.
+
+## What it does
+
+Reads the current Claude Code session log directly and reports actual input/output token usage plus estimated savings versus a non-caveman baseline. Numbers come from the JSONL session log on disk — the model itself does not compute or estimate them. Output is injected by the `caveman-mode-tracker` hook, which intercepts `/caveman-stats` and returns the formatted stats as a blocked-decision reason.
+
+Each run also writes a lifetime-savings suffix file used by the statusline badge (`⛏ 12.4k`).
+
+## How to invoke
+
+```
+/caveman-stats
+```
+
+## Example output
+
+```
+Session: 47 turns
+Input:   12,304 tokens
+Output:   3,891 tokens (caveman)
+Baseline: 11,247 tokens (estimated without caveman)
+Saved:    7,356 tokens (~65%)
+```
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — hook contract and mechanics
+- [Caveman README](../../README.md) — repo overview

--- a/skills/caveman/README.md
+++ b/skills/caveman/README.md
@@ -1,0 +1,48 @@
+# caveman
+
+Talk like smart caveman. Same brain, fewer tokens.
+
+## What it does
+
+Compress every model response to caveman-style prose. Drops articles, filler, pleasantries, and hedging. Keeps every technical detail, code block, error string, and symbol exact. Cuts ~65-75% of output tokens with full accuracy preserved. Mode persists for the whole session until changed or stopped.
+
+Six intensity levels:
+
+| Level | What change |
+|-------|-------------|
+| `lite` | Drop filler/hedging. Sentences stay full. Professional but tight. |
+| `full` | Default. Drop articles, fragments OK, short synonyms. |
+| `ultra` | Bare fragments. Abbreviations (DB, auth, fn). Arrows for causality. |
+| `wenyan-lite` | Classical Chinese register, light compression. |
+| `wenyan-full` | Maximum 文言文. 80-90% character reduction. |
+| `wenyan-ultra` | Extreme classical compression. |
+
+Auto-clarity rule: caveman drops to normal prose for security warnings, irreversible-action confirmations, multi-step sequences where fragment ambiguity risks misread, and when user repeats a question. Resumes after the clear part.
+
+## How to invoke
+
+```
+/caveman              # full mode (default)
+/caveman lite         # lighter compression
+/caveman ultra        # extreme compression
+/caveman wenyan       # classical Chinese
+stop caveman          # back to normal prose
+```
+
+## Example output
+
+Question: "Why does my React component re-render?"
+
+Normal prose:
+> Your component re-renders because you create a new object reference each render. Wrapping it in `useMemo` will fix the issue.
+
+Caveman (full):
+> New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`.
+
+Caveman (ultra):
+> Inline obj prop → new ref → re-render. `useMemo`.
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — full LLM-facing instructions
+- [Caveman README](../../README.md) — repo overview, install, benchmarks

--- a/skills/compress/README.md
+++ b/skills/compress/README.md
@@ -1,0 +1,42 @@
+# compress
+
+Squeeze prose files into caveman speak. Save input tokens forever.
+
+## What it does
+
+Compresses natural language memory files (CLAUDE.md, todos, preferences) into caveman-style prose to cut input tokens on every future session. The compressed version overwrites the original; a human-readable backup is saved as `<filename>.original.md`.
+
+Preserves exactly: code blocks, inline backticks, URLs, file paths, commands, technical terms, proper nouns, version numbers, environment variables, and all markdown structure (headings, bullets, tables, frontmatter). Compresses only the prose around them.
+
+The skill shells out to a Python CLI (`python3 -m scripts <filepath>`) that calls Claude to compress, validates the output, and cherry-picks targeted fixes if validation fails. Retries up to 2 times. If still failing, the original file is left untouched.
+
+Requires Python 3.10+.
+
+## How to invoke
+
+```
+/caveman:compress /absolute/path/to/CLAUDE.md
+```
+
+Also triggers on "compress memory file" or similar.
+
+## Example output
+
+Original:
+> You should always make sure to run the test suite before pushing any changes to the main branch. This is important because it helps catch bugs early and prevents broken builds from being deployed to production.
+
+Compressed:
+> Run tests before push to main. Catch bugs early, prevent broken prod deploys.
+
+Typical input-token savings: ~46% on long memory files.
+
+## Boundaries
+
+- Only compresses prose files: `.md`, `.txt`, `.typ`, `.typst`, `.tex`, extensionless
+- Never modifies code files: `.py`, `.js`, `.ts`, `.json`, `.yaml`, `.toml`, `.sh`, etc.
+- Skips `*.original.md` files (its own backups)
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — full compression rules and validation logic
+- [Caveman README](../../README.md) — repo overview


### PR DESCRIPTION
## Summary

- Adds a `README.md` to each directory in `skills/`, matching the per-skill README pattern used by upstream skill libraries (vercel-labs/skills, claude-code-sdk).
- Each README is a short human-facing summary: what the skill does, how to invoke it, an example, and a `See also` link to `SKILL.md` plus the repo README.
- `SKILL.md` stays the LLM-facing system prompt; `README.md` is the front door for humans browsing `skills/`.

Files added (7):
- `skills/caveman/README.md` — covers the six intensity levels (lite/full/ultra/wenyan-*), Before/After example, auto-clarity rule
- `skills/caveman-commit/README.md` — Conventional Commits, ≤50-char subject, example commit
- `skills/caveman-review/README.md` — `L<line>: <severity> ...` format, severity emoji legend, examples
- `skills/caveman-help/README.md` — quick-reference card, one-shot
- `skills/caveman-stats/README.md` — session token-savings receipts read from JSONL
- `skills/cavecrew/README.md` — decision guide for delegating to cavecrew-investigator/builder/reviewer
- `skills/compress/README.md` — compress prose memory files, Python 3.10+ CLI, `<file>.original.md` backup

Voice matches the README ("Brain still big.", caveman tone) but stays technical and useful. Read each `SKILL.md` first to make sure described behavior is accurate.

## Test plan

- [x] All 7 files start with an `#` H1 and have non-empty bodies (`for f in skills/*/README.md; do head -1 "$f" | grep -qE '^#' && test -s "$f"; done`)
- [x] Each README links back to `./SKILL.md` and `../../README.md` with correct relative paths
- [x] Purely additive — no existing files modified, so installer/hook/eval paths are untouched
- [ ] Visual review of rendered Markdown on GitHub (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)