### PR TITLE
fix: Fix TOML parsing error in caveman-init.toml for Gemini CLI

### DIFF
--- a/commands/caveman-init.toml
+++ b/commands/caveman-init.toml
@@ -1,4 +1,2 @@
----
 description = "Drop the always-on caveman activation rule into the current repo for every IDE agent"
 prompt = "Run `node src/tools/caveman-init.js {{args}}` in the current repo and report the result. Use --dry-run first if the user did not pass --force, so we never silently overwrite an existing rule file."
----


### PR DESCRIPTION
## 问题
Gemini CLI v0.41.2 在加载 `caveman-init.toml` 命令时失败，错误信息：
```
✕ [FileCommandLoader] Failed to parse TOML file
  /Users/linwang/.gemini/extensions/caveman/commands/caveman-init.toml
```

## 原因
`caveman-init.toml` 文件使用了 YAML 前置标记 (`---`)，这在 TOML 语法中是无效的。其他命令文件（`caveman.toml`、`caveman-commit.toml`、`caveman-review.toml`）都正确使用纯 TOML 格式。

## 修复
移除 `caveman-init.toml` 中的 YAML 前置标记分隔符，保留纯 TOML 格式，与其他命令文件保持一致。

## 修改内容
- `commands/caveman-init.toml`: 移除 `---` 分隔符，转换为标准 TOML 格式