### PR TITLE
fix: Fix TOML parsing error in caveman-init.toml for Gemini CLI

### DIFF
--- a/commands/caveman-init.toml
+++ b/commands/caveman-init.toml
@@ -1,4 +1,2 @@
----
 description = "Drop the always-on caveman activation rule into the current repo for every IDE agent"
 prompt = "Run `node src/tools/caveman-init.js {{args}}` in the current repo and report the result. Use --dry-run first if the user did not pass --force, so we never silently overwrite an existing rule file."
----


### PR DESCRIPTION
## Issue
Gemini CLI v0.41.2 fails to load the `caveman-init.toml` command with the error:
```
✕ [FileCommandLoader] Failed to parse TOML file
  /Users/linwang/.gemini/extensions/caveman/commands/caveman-init.toml
```

## Root Cause
The `caveman-init.toml` file used YAML frontmatter delimiters (`---`), which is invalid TOML syntax. Other command files (`caveman.toml`, `caveman-commit.toml`, `caveman-review.toml`) correctly use pure TOML format.

## Fix
Remove the YAML frontmatter delimiters from `caveman-init.toml` and convert to standard TOML format, consistent with other command files.

## Changes
- `commands/caveman-init.toml`: Removed `---` delimiters and converted to valid TOML format