### PR TITLE
fix(opencode): resolve Windows config dir resolution

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -464,7 +464,7 @@ function installViaSkills(ctx, prov) {
 // (opencode's TUI exposes no plugin-writable badge).
 const OPENCODE_SKILL_DIRS  = ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'cavecrew'];
 const OPENCODE_AGENT_FILES = ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md'];
-const OPENCODE_COMMAND_FILES = ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-compress.md', 'caveman-stats.md', 'caveman-help.md'];
+const OPENCODE_COMMAND_FILES = ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-stats.md', 'caveman-help.md'];
 const OPENCODE_PLUGIN_REL = './plugins/caveman/plugin.js';
 const OPENCODE_AGENTS_MD_SENTINEL = 'Respond terse like smart caveman';
 // Marker fence for the opencode AGENTS.md ruleset block. Same convention as
@@ -475,7 +475,6 @@ const OPENCODE_AGENTS_MD_END = '<!-- caveman-end -->';
 
 function opencodeConfigDir() {
   if (process.env.XDG_CONFIG_HOME) return path.join(process.env.XDG_CONFIG_HOME, 'opencode');
-  if (IS_WIN) return path.join(process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'), 'opencode');
   return path.join(os.homedir(), '.config', 'opencode');
 }
 

--- a/src/plugins/opencode/plugin.js
+++ b/src/plugins/opencode/plugin.js
@@ -47,16 +47,8 @@ const { getDefaultMode, safeWriteFlag, readFlag, VALID_MODES } = config;
 const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
 
 function opencodeConfigDir() {
-  if (process.env.XDG_CONFIG_HOME) {
-    return path.join(process.env.XDG_CONFIG_HOME, 'opencode');
-  }
-  if (process.platform === 'win32') {
-    return path.join(
-      process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'),
-      'opencode'
-    );
-  }
-  return path.join(os.homedir(), '.config', 'opencode');
+  if (process.env.XDG_CONFIG_HOME) return join(process.env.XDG_CONFIG_HOME, 'opencode');
+  return join(os.homedir(), '.config', 'opencode');
 }
 
 const flagPath = path.join(opencodeConfigDir(), '.caveman-active');

--- a/tests/installer/opencode.test.mjs
+++ b/tests/installer/opencode.test.mjs
@@ -69,7 +69,7 @@ test('opencode fresh install drops plugin, commands, agents, skills, AGENTS.md, 
     assert.ok(fs.existsSync(path.join(ocDir, 'plugins', 'caveman', 'package.json')), 'plugin package.json missing');
     assert.ok(fs.existsSync(path.join(ocDir, 'plugins', 'caveman', 'caveman-config.cjs')), 'caveman-config.cjs sibling missing');
 
-    for (const f of ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-compress.md', 'caveman-stats.md', 'caveman-help.md']) {
+    for (const f of ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-stats.md', 'caveman-help.md']) {
       assert.ok(fs.existsSync(path.join(ocDir, 'commands', f)), `command ${f} missing`);
     }
     for (const f of ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md']) {


### PR DESCRIPTION
## Summary

opencodeConfigDir() on Windows unconditionally returned %APPDATA%\opencode, but opencode'\''s canonical global config path is `~/.config/opencode/` on ALL platforms per https://opencode.ai/docs/config/. The %APPDATA% path was based on an opencode docs bug that has since been fixed (sst/opencode@c73d4a1).

Also removed `caveman-compress.md` from OPENCODE_COMMAND_FILES — the plugin natively handles `/caveman-compress` at the hook level; no command template needed. The source file was gitignored and never existed, causing the installer to crash with ENOENT.

## Changes

| File | Change |
|---|---|
| `bin/install.js` | Remove APPDATA fallback from opencodeConfigDir(); remove caveman-compress.md from command list |
| `src/plugins/opencode/plugin.js` | Remove APPDATA fallback from opencodeConfigDir() |
| `tests/installer/opencode.test.mjs` | Remove caveman-compress.md from expected command files |

opencodeConfigDir() now simply: `XDG_CONFIG_HOME` → `$XDG_CONFIG_HOME/opencode`, else `~/.config/opencode/` — no platform branches. OPENCODE_CONFIG_DIR intentionally excluded (it is an additional search path for agents/commands/plugins, not the install target).

## Tests

All 7 opencode installer tests pass.

Fixes #375