### PR TITLE
fix: skip hook injection for non-interactive (sdk-cli) sessions

### DIFF
--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -9,12 +9,43 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { getDefaultMode, safeWriteFlag } = require('./caveman-config');
+const { getDefaultMode, safeWriteFlag, isNonInteractiveSession } = require('./caveman-config');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');
 const settingsPath = path.join(claudeDir, 'settings.json');
 
+// SessionStart hooks receive {session_id, transcript_path, source, ...} on stdin.
+// If entrypoint is not "cli" (e.g. sdk-cli probe from CodexBar), skip all
+// injection so the probing tool sees a clean response.
+//
+// Per Claude Code hooks spec, stdin is reliably closed after the JSON is
+// delivered. When invoked manually (TTY attached), no JSON is coming — skip
+// the read entirely instead of hanging.
+if (process.stdin.isTTY) {
+  activate('');
+} else {
+  let stdinBuf = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => { stdinBuf += chunk; });
+  process.stdin.on('end', () => { activate(stdinBuf); });
+}
+
+function activate(raw) {
+  let data = {};
+  try {
+    if (raw && raw.trim()) data = JSON.parse(raw.trim());
+  } catch (e) { /* not JSON — fall through */ }
+
+  if (isNonInteractiveSession(data, claudeDir)) {
+    process.stdout.write('OK');
+    process.exit(0);
+  }
+
+  run();
+}
+
+function run() {
 const mode = getDefaultMode();
 
 // "off" mode — skip activation entirely, don't write flag or emit rules
@@ -141,3 +172,4 @@ try {
 }
 
 process.stdout.write(output);
+} // end run()

--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -36,7 +36,7 @@ if (process.stdin.isTTY) {
     process.stdin.pause();
     activate(raw);
   };
-  const fallback = setTimeout(() => { activateOnce(''); }, 200);
+  const fallback = setTimeout(() => { activateOnce(stdinBuf); }, 200);
   process.stdin.setEncoding('utf8');
   process.stdin.on('data', chunk => { stdinBuf += chunk; });
   process.stdin.on('end', () => { activateOnce(stdinBuf); });

--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -19,16 +19,27 @@ const settingsPath = path.join(claudeDir, 'settings.json');
 // If entrypoint is not "cli" (e.g. sdk-cli probe from CodexBar), skip all
 // injection so the probing tool sees a clean response.
 //
-// Per Claude Code hooks spec, stdin is reliably closed after the JSON is
-// delivered. When invoked manually (TTY attached), no JSON is coming — skip
-// the read entirely instead of hanging.
+// Per Claude Code hooks spec, stdin is normally closed after the JSON is
+// delivered. Some launchers leave the pipe open, so fall back quickly instead
+// of blocking session startup.
 if (process.stdin.isTTY) {
   activate('');
 } else {
   let stdinBuf = '';
+  let activated = false;
+  const activateOnce = raw => {
+    if (activated) return;
+    activated = true;
+    clearTimeout(fallback);
+    process.stdin.removeAllListeners('data');
+    process.stdin.removeAllListeners('end');
+    process.stdin.pause();
+    activate(raw);
+  };
+  const fallback = setTimeout(() => { activateOnce(''); }, 200);
   process.stdin.setEncoding('utf8');
   process.stdin.on('data', chunk => { stdinBuf += chunk; });
-  process.stdin.on('end', () => { activate(stdinBuf); });
+  process.stdin.on('end', () => { activateOnce(stdinBuf); });
 }
 
 function activate(raw) {

--- a/src/hooks/caveman-config.js
+++ b/src/hooks/caveman-config.js
@@ -271,4 +271,50 @@ function readHistory(filePath) {
   }
 }
 
-module.exports = { getDefaultMode, getConfigDir, getConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory };
+// Detects sdk-cli (and other non-interactive) sessions so the hooks can skip
+// injecting caveman context. External tools (e.g. CodexBar) spawn sdk-cli
+// sessions to probe Claude — if caveman rules leak in, their parsing breaks.
+//
+// Uses the guaranteed `session_id` field from the hook stdin payload to look
+// up the corresponding `$CLAUDE_CONFIG_DIR/sessions/<pid>.json` record and
+// read its `entrypoint`. Scans newest-first and short-circuits on match so
+// typical cases touch one file regardless of sessions/ size.
+//
+// Returns false (= fall through, inject normally) when:
+//   - session_id is absent,
+//   - sessions/ is unreadable,
+//   - no session file matches the id (theoretical race at first SessionStart,
+//     not observed in practice — sessions/<pid>.json is written before hooks
+//     fire).
+function isNonInteractiveSession(data, claudeDir) {
+  const sessionId = data && data.session_id;
+  if (!sessionId) return false;
+
+  const sessionsDir = path.join(claudeDir, 'sessions');
+  let entries;
+  try {
+    entries = fs.readdirSync(sessionsDir)
+      .filter(f => f.endsWith('.json'))
+      .map(f => {
+        const full = path.join(sessionsDir, f);
+        let mtime = 0;
+        try { mtime = fs.statSync(full).mtimeMs; } catch (e) {}
+        return { full, mtime };
+      })
+      .sort((a, b) => b.mtime - a.mtime);
+  } catch (e) {
+    return false;
+  }
+
+  for (const { full } of entries) {
+    try {
+      const sess = JSON.parse(fs.readFileSync(full, 'utf8'));
+      if (sess.sessionId === sessionId) {
+        return sess.entrypoint !== 'cli';
+      }
+    } catch (e) { /* skip */ }
+  }
+  return false;
+}
+
+module.exports = { getDefaultMode, getConfigDir, getConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory, isNonInteractiveSession };

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { execFileSync } = require('child_process');
-const { getDefaultMode, safeWriteFlag, readFlag, VALID_MODES } = require('./caveman-config');
+const { getDefaultMode, safeWriteFlag, readFlag, VALID_MODES, isNonInteractiveSession } = require('./caveman-config');
 
 // Modes handled by their own slash commands (/caveman-commit, etc.) — not
 // selectable via /caveman <arg>.
@@ -20,6 +20,13 @@ process.stdin.on('data', chunk => { input += chunk; });
 process.stdin.on('end', () => {
   try {
     const data = JSON.parse(input);
+
+    // Skip hook entirely for non-interactive sessions (e.g. sdk-cli probes from CodexBar).
+    if (isNonInteractiveSession(data, claudeDir)) {
+      process.stdout.write('{}');
+      return;
+    }
+
     const prompt = (data.prompt || '').trim().toLowerCase();
 
     // Natural language activation (e.g. "activate caveman", "turn on caveman mode",

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -156,6 +156,43 @@ class HookScriptTests(unittest.TestCase):
             self.assertNotIn("STATUSLINE SETUP NEEDED", result.stdout)
             self.assertEqual((claude_dir / ".caveman-active").read_text(), "full")
 
+    def test_activate_falls_back_when_stdin_stays_open(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-open-stdin-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["USERPROFILE"] = str(home)
+
+            proc = subprocess.Popen(
+                ["node", "src/hooks/caveman-activate.js"],
+                cwd=REPO_ROOT,
+                env=env,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                proc.wait(timeout=2)
+                stdout = proc.stdout.read()
+                stderr = proc.stderr.read()
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                self.fail("activate hook hung with open stdin pipe")
+            finally:
+                if proc.stdin:
+                    proc.stdin.close()
+                if proc.stdout:
+                    proc.stdout.close()
+                if proc.stderr:
+                    proc.stderr.close()
+
+            self.assertEqual(proc.returncode, 0, stderr)
+            self.assertIn("CAVEMAN MODE ACTIVE", stdout)
+            self.assertEqual((claude_dir / ".caveman-active").read_text(), "full")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -193,6 +193,49 @@ class HookScriptTests(unittest.TestCase):
             self.assertIn("CAVEMAN MODE ACTIVE", stdout)
             self.assertEqual((claude_dir / ".caveman-active").read_text(), "full")
 
+    def test_activate_fallback_uses_buffered_stdin(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-open-json-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            sessions_dir = claude_dir / "sessions"
+            sessions_dir.mkdir(parents=True)
+            (sessions_dir / "123.json").write_text(
+                json.dumps({"sessionId": "sdk-probe", "entrypoint": "sdk-cli"}) + "\n"
+            )
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["USERPROFILE"] = str(home)
+
+            proc = subprocess.Popen(
+                ["node", "src/hooks/caveman-activate.js"],
+                cwd=REPO_ROOT,
+                env=env,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                proc.stdin.write(json.dumps({"session_id": "sdk-probe"}))
+                proc.stdin.flush()
+                proc.wait(timeout=2)
+                stdout = proc.stdout.read()
+                stderr = proc.stderr.read()
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                self.fail("activate hook hung with buffered open stdin pipe")
+            finally:
+                if proc.stdin:
+                    proc.stdin.close()
+                if proc.stdout:
+                    proc.stdout.close()
+                if proc.stderr:
+                    proc.stderr.close()
+
+            self.assertEqual(proc.returncode, 0, stderr)
+            self.assertEqual(stdout, "OK")
+            self.assertFalse((claude_dir / ".caveman-active").exists())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
NGL claude did all of this so if this is gibberish I can close it :) I installed caveman + CodexBar in the same hour with the same intention of monitoring / reducing token usage, so I wager others would do the same.

**Problem:**
Tools like CodexBar probe Claude usage by spawning sdk-cli sessions and sending commands like "show usage". The SessionStart and UserPromptSubmit hooks were firing on these sessions, injecting the full caveman ruleset and skill listing. Claude would then invoke caveman:caveman-stats instead of returning usable output, causing the probe to fail silently.

**Solution:**
Both hooks now read transcript_path from stdin, extract the session ID, look up the corresponding session file in ~/.claude/sessions/, and check the entrypoint field. If entrypoint is not "cli", the hooks exit early without injecting any caveman context.

The SessionStart hook uses async stdin reading with a 200ms fallback timeout so it does not block on sessions that send no stdin data.

Bigger summary: https://gist.github.com/haydenholligan/b676acb48d250490787a9a83feb8923b

**Known review note:**
from codex /review
A P2 review comment flagged a potential performance regression: on every UserPromptSubmit, the hook stats and sorts all ~/.claude/sessions/*.json files before reading candidates. For users with large session directories, that can add prompt latency even though only one matching session_id is needed. Suggested follow-up is to iterate newest candidates without a full sort or cache the matched session entrypoint per session.
