### PR TITLE
fix: Skip MCP Shrink by Default

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ What it does:
 
 - Auto-detects every supported agent installed on your machine (Claude Code, Cursor, Codex, etc.).
 - For each one, runs that agent's native install path (plugin / extension / rule file / `npx skills add`).
-- Wires Claude Code hooks, statusline badge, and the `caveman-shrink` MCP middleware on top.
+- Wires Claude Code hooks and statusline badge on top. (`caveman-shrink` MCP middleware is opt-in via `--with-mcp-shrink` — see flag table below.)
 - Skips anything you don't have. Safe to re-run. ~30 seconds end-to-end.
 
 Want to preview before installing? Use `--dry-run`:
@@ -101,13 +101,13 @@ Useful flags:
 
 | Flag | What |
 |---|---|
-| `--all` | Plugin + hooks + statusline + MCP shrink + per-repo rule files in `$PWD`. The full ride. |
+| `--all` | Plugin + hooks + statusline + per-repo rule files in `$PWD`. (MCP shrink is opt-in — see `--with-mcp-shrink` below.) |
 | `--minimal` | Plugin / extension only. No hooks, no MCP shrink, no per-repo rules. |
 | `--only <id>` | One agent only. Repeatable: `--only claude --only cursor`. |
 | `--dry-run` | Print every command. Write nothing. |
 | `--with-init` | Drop always-on rule files into the current repo (`.cursor/`, `.windsurf/`, `.clinerules/`, `.github/copilot-instructions.md`, `.opencode/AGENTS.md`, `AGENTS.md`) and, if OpenClaw is on the box, append the bootstrap block to `~/.openclaw/workspace/SOUL.md`. |
-| `--with-mcp-shrink` | Register `caveman-shrink` MCP proxy. **On by default.** |
-| `--no-mcp-shrink` | Skip MCP-shrink registration. |
+| `--with-mcp-shrink="<upstream cmd>"` | Register `caveman-shrink` MCP proxy wrapping the given upstream MCP server. **Off by default.** A value is required — caveman-shrink is a proxy and exits immediately without one. Example: `--with-mcp-shrink="npx @modelcontextprotocol/server-filesystem /tmp"`. The value is split on whitespace; for paths-with-spaces, install via `node bin/install.js` from a clone or edit `~/.claude.json` after a stub install. |
+| `--no-mcp-shrink` | Skip MCP-shrink registration. (Default.) |
 | `--with-hooks` / `--no-hooks` | Force-on or force-off the Claude Code hook installer. (Default: on.) |
 | `--skip-skills` | Don't run the npx-skills auto-detect fallback when nothing else matched. |
 | `--config-dir <path>` | Claude Code config dir for hook files + `settings.json`. **Does NOT scope** `claude plugin install`, `gemini extensions install`, opencode (`XDG_CONFIG_HOME`), or openclaw (`OPENCLAW_WORKSPACE`) — those use their own paths. Default: `$CLAUDE_CONFIG_DIR` or `~/.claude`. `~` is expanded. |

--- a/bin/install.js
+++ b/bin/install.js
@@ -46,13 +46,27 @@ const HOOK_FILES = [
 function parseArgs(argv) {
   const opts = {
     dryRun: false, force: false, skipSkills: false,
-    withHooks: 'auto', withInit: false, withMcpShrink: 'auto',
+    withHooks: 'auto', withInit: false, withMcpShrink: false,
     all: false, minimal: false, listOnly: false, noColor: false,
     only: [], uninstall: false, nonInteractive: false,
     configDir: null, help: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
+    // --with-mcp-shrink=<upstream cmd>  (handled before the switch so the
+    // GNU-style =value form is recognized). Bare --with-mcp-shrink falls
+    // through to the switch and is rejected — caveman-shrink is a proxy
+    // and a stub registration just lands the user in a broken-MCP loop.
+    if (a.startsWith('--with-mcp-shrink=')) {
+      const raw = a.slice('--with-mcp-shrink='.length);
+      const tokens = raw.trim().split(/\s+/).filter(Boolean);
+      if (tokens.length === 0) {
+        die('error: --with-mcp-shrink requires an upstream command\n' +
+            '  example: --with-mcp-shrink="npx @modelcontextprotocol/server-filesystem /path"');
+      }
+      opts.withMcpShrink = tokens;
+      continue;
+    }
     switch (a) {
       case '--dry-run': opts.dryRun = true; break;
       case '--force': opts.force = true; break;
@@ -60,7 +74,23 @@ function parseArgs(argv) {
       case '--with-hooks': opts.withHooks = true; break;
       case '--no-hooks': opts.withHooks = false; break;
       case '--with-init': opts.withInit = true; break;
-      case '--with-mcp-shrink': opts.withMcpShrink = true; break;
+      case '--with-mcp-shrink': {
+        const v = argv[i + 1];
+        if (v && !v.startsWith('--')) {
+          i++;
+          const tokens = v.trim().split(/\s+/).filter(Boolean);
+          if (tokens.length === 0) {
+            die('error: --with-mcp-shrink requires an upstream command\n' +
+                '  example: --with-mcp-shrink "npx @modelcontextprotocol/server-filesystem /path"');
+          }
+          opts.withMcpShrink = tokens;
+        } else {
+          die('error: --with-mcp-shrink requires an upstream command — caveman-shrink\n' +
+              '  is a proxy and exits immediately without one. Pass the upstream:\n' +
+              '  --with-mcp-shrink="npx @modelcontextprotocol/server-filesystem /path"');
+        }
+        break;
+      }
       case '--no-mcp-shrink': opts.withMcpShrink = false; break;
       case '--all': opts.all = true; break;
       case '--minimal': opts.minimal = true; break;
@@ -90,10 +120,12 @@ function parseArgs(argv) {
     }
   }
   if (opts.all && opts.minimal) die('error: --all and --minimal are mutually exclusive');
-  if (opts.all) { opts.withHooks = true; opts.withInit = true; opts.withMcpShrink = true; }
+  // --all does not touch withMcpShrink. caveman-shrink needs an upstream
+  // command, so there's no sensible "everything on" default. Users opt in
+  // explicitly with --with-mcp-shrink="<upstream cmd>".
+  if (opts.all) { opts.withHooks = true; opts.withInit = true; }
   if (opts.minimal) { opts.withHooks = false; opts.withInit = false; opts.withMcpShrink = false; }
   if (opts.withHooks === 'auto') opts.withHooks = true;
-  if (opts.withMcpShrink === 'auto') opts.withMcpShrink = true;
   // Validate --only ids against the provider matrix. PROVIDERS is defined later
   // in the file but is in scope by the time this function runs.
   if (opts.only.length) {
@@ -633,14 +665,17 @@ function installOpencode(ctx) {
       cfg.plugin.push(OPENCODE_PLUGIN_REL);
     }
     if (opts.withMcpShrink) {
+      // opts.withMcpShrink is the array of upstream-cmd tokens parseArgs
+      // produced. caveman-shrink is a proxy — it crashes without an upstream,
+      // so we always wire one through.
       if (!cfg.mcp || typeof cfg.mcp !== 'object') cfg.mcp = {};
       if (!cfg.mcp['caveman-shrink']) {
         cfg.mcp['caveman-shrink'] = {
           type: 'local',
-          command: ['npx', '-y', MCP_SHRINK_PKG],
+          command: ['npx', '-y', MCP_SHRINK_PKG, ...opts.withMcpShrink],
           enabled: true,
         };
-        process.stdout.write('  registered caveman-shrink MCP server\n');
+        process.stdout.write(`  registered caveman-shrink MCP server (wraps: ${opts.withMcpShrink.join(' ')})\n`);
       }
     }
     SETTINGS.writeSettings(opencodeJson, cfg);
@@ -801,10 +836,21 @@ function installMcpShrink(ctx) {
     note('    src/hooks/README.md to your Claude Code MCP config manually.');
     return { kind: 'skip', why: 'manual config required' };
   }
-  const r = runSpawn('claude', ['mcp', 'add', 'caveman-shrink', '--', 'npx', '-y', MCP_SHRINK_PKG], null, opts.dryRun);
+  // opts.withMcpShrink is always an array of upstream-cmd tokens by the
+  // time we get here; parseArgs rejects bare --with-mcp-shrink. The proxy
+  // gets `npx -y caveman-shrink <upstream tokens...>` so it has something
+  // to wrap.
+  const upstream = opts.withMcpShrink;
+  const r = runSpawn(
+    'claude',
+    ['mcp', 'add', 'caveman-shrink', '--', 'npx', '-y', MCP_SHRINK_PKG, ...upstream],
+    null, opts.dryRun
+  );
   if ((r.status || 0) === 0) {
-    note('    registered. Wrap an upstream by editing the mcpServers entry — see:');
-    note(`    https://github.com/${REPO}/tree/main/src/mcp-servers/caveman-shrink`);
+    note(`    registered, wrapping: ${upstream.join(' ')}`);
+    note(`    Edit ~/.claude.json mcpServers["caveman-shrink"] to change the upstream,`);
+    note('    or `claude mcp remove caveman-shrink` to drop it.');
+    note(`    Docs: https://github.com/${REPO}/tree/main/src/mcp-servers/caveman-shrink`);
     return { kind: 'ok' };
   }
   return { kind: 'fail', why: 'claude mcp add failed' };
@@ -1055,8 +1101,9 @@ function printList(noColor) {
     process.stdout.write(`  ${pad(p.id, 13)} ${pad(p.label, 22)} ${p.mech}${tag}\n`);
   }
   process.stdout.write('\n');
-  process.stdout.write(c.dim('  Defaults: --with-hooks ON, --with-mcp-shrink ON, --with-init OFF.\n'));
-  process.stdout.write(c.dim('  --all turns all three on, --minimal turns all three off.\n'));
+  process.stdout.write(c.dim('  Defaults: --with-hooks ON, --with-init OFF, --with-mcp-shrink OFF.\n'));
+  process.stdout.write(c.dim('  --all = hooks + init (mcp-shrink needs an upstream — opt in explicitly).\n'));
+  process.stdout.write(c.dim('  --minimal turns hooks + init + mcp-shrink off.\n'));
 }
 
 function pad(s, n) { s = String(s); return s + ' '.repeat(Math.max(0, n - s.length)); }
@@ -1077,14 +1124,20 @@ FLAGS
   --only <agent>        Install only for the named agent. Repeatable.
                         See --list for valid ids.
   --skip-skills         Don't run the npx-skills auto-detect fallback.
-  --all                 Turn on hooks + init + mcp-shrink.
+  --all                 Turn on hooks + init. (mcp-shrink needs an upstream;
+                        pass --with-mcp-shrink="<cmd>" to add it.)
   --minimal             Just the plugin/extension install.
   --with-hooks          Claude Code: install SessionStart/UserPromptSubmit hooks
                         + statusline badge. (Default ON.)
   --no-hooks            Skip the hooks installer.
   --with-init           Write per-repo IDE rule files into \$PWD.
-  --with-mcp-shrink     Claude Code: register caveman-shrink MCP proxy. (Default ON.)
-  --no-mcp-shrink       Skip MCP shrink.
+  --with-mcp-shrink="<upstream cmd>"
+                        Claude Code (and opencode): register caveman-shrink MCP
+                        proxy wrapping the given upstream. Default OFF.
+                        caveman-shrink crashes without an upstream, so a value
+                        is required. The value is whitespace-tokenized.
+                        Example: --with-mcp-shrink="npx @modelcontextprotocol/server-filesystem /tmp"
+  --no-mcp-shrink       Skip MCP shrink. (Default.)
   --uninstall, -u       Remove caveman from this machine.
   --config-dir <path>   Claude Code config dir for hook files + settings.json.
                         Default: \$CLAUDE_CONFIG_DIR or ~/.claude. Does NOT

--- a/tests/installer/unit.argv.test.mjs
+++ b/tests/installer/unit.argv.test.mjs
@@ -106,6 +106,59 @@ test('bare -- (POSIX end-of-options) is accepted and ignored', () => {
   assert.equal(r.status, 0);
 });
 
+test('bare --with-mcp-shrink (no upstream) exits 2 with hint', () => {
+  // Regression for issue where --with-mcp-shrink registered a stub MCP entry
+  // that crashed on every Claude Code startup. caveman-shrink is a proxy and
+  // requires an upstream command — we now refuse the bare flag.
+  const r = run('--with-mcp-shrink', '--non-interactive', '--dry-run');
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /requires an upstream command/);
+  assert.match(r.stderr, /server-filesystem/);
+});
+
+test('--with-mcp-shrink followed by another flag (no value) exits 2', () => {
+  // The next-token form must distinguish "no value" from "value happens to
+  // start with --". A user typing `--with-mcp-shrink --dry-run` clearly
+  // forgot the upstream; refuse.
+  const r = run('--with-mcp-shrink', '--dry-run', '--non-interactive');
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /requires an upstream command/);
+});
+
+test('--with-mcp-shrink="<cmd>" registers wrapping that upstream', () => {
+  const r = run(
+    '--with-mcp-shrink=npx @modelcontextprotocol/server-filesystem /tmp',
+    '--only', 'claude', '--dry-run', '--non-interactive',
+    '--config-dir', '/tmp/__cm_shrink_test'
+  );
+  assert.equal(r.status, 0);
+  // Dry-run only emits the planned `claude mcp add` line if claude is
+  // detected on PATH. Skip the positive assertion otherwise.
+  if (/Claude Code detected/.test(r.stdout)) {
+    assert.match(r.stdout, /claude mcp add caveman-shrink .* npx -y caveman-shrink npx @modelcontextprotocol\/server-filesystem \/tmp/);
+  }
+});
+
+test('--with-mcp-shrink "<cmd>" (space-separated) also accepted', () => {
+  const r = run(
+    '--with-mcp-shrink', 'npx @modelcontextprotocol/server-filesystem /tmp',
+    '--only', 'claude', '--dry-run', '--non-interactive',
+    '--config-dir', '/tmp/__cm_shrink_space'
+  );
+  assert.equal(r.status, 0);
+  if (/Claude Code detected/.test(r.stdout)) {
+    assert.match(r.stdout, /caveman-shrink npx @modelcontextprotocol\/server-filesystem \/tmp/);
+  }
+});
+
+test('--all does NOT auto-enable mcp-shrink (no sensible default upstream)', () => {
+  const r = run('--all', '--only', 'claude', '--dry-run', '--non-interactive', '--config-dir', '/tmp/__cm_all_no_shrink');
+  assert.equal(r.status, 0);
+  // Whether or not claude is on PATH, the wiring banner should not appear
+  // because withMcpShrink stays false under --all alone.
+  assert.doesNotMatch(r.stdout, /wiring caveman-shrink MCP proxy/);
+});
+
 test('--help discloses --config-dir scope', () => {
   const r = run('--help');
   assert.equal(r.status, 0);


### PR DESCRIPTION
closes #353 

This is my quicktake on this issue.

## Problem
caveman-shrink is an MCP proxy that requires an upstream MCP server command as args. The installer was registering it via `claude mcp add caveman-shrink -- npx -y caveman-shrink` with no upstream during installation, causing [/src/mcp-servers/caveman-shrink/index.js#L33](https://github.com/JuliusBrussee/caveman/blob/63a91ecadbf4c4719a4602a5abb00883f9966034/src/mcp-servers/caveman-shrink/index.js#L33) to immediately exit with code 2. As a result, the server fails in Claude Code on every startup. `--with-mcp-shrink` was ON by default, so every fresh install contained this broken entry (assuming no upstream provided).

## Fix:
  - Install caveman with `--with-mcp-shrink` argument set to FALSE (rather than auto) by default.
  - Change to `--with-mcp-shrink="<upstream cmd>"` to enforce `mcp shrink + provide upstream`
  - Hints at upstream requirement at install
  - Attempting to register caveman-shrink alone results in an error (+ hint i.e. must add upstream.)
  - (+ a few UT for updated behavior)