### PR TITLE
fix(mcp-shrink): allow npx and .cmd upstream on Windows via shell:true

### DIFF
--- a/src/mcp-servers/caveman-shrink/index.js
+++ b/src/mcp-servers/caveman-shrink/index.js
@@ -40,9 +40,9 @@ const debug = process.env.CAVEMAN_SHRINK_DEBUG === '1';
 const fields = (process.env.CAVEMAN_SHRINK_FIELDS || 'description')
   .split(',').map(s => s.trim()).filter(Boolean);
 
-const upstream = spawn(args[0], args.slice(1), {
-  stdio: ['pipe', 'pipe', 'inherit'],
-});
+const { getSpawnOptions } = require('./spawn-options');
+
+const upstream = spawn(args[0], args.slice(1), getSpawnOptions());
 
 upstream.on('error', err => {
   process.stderr.write(`caveman-shrink: failed to spawn upstream: ${err.message}\n`);

--- a/src/mcp-servers/caveman-shrink/spawn-options.js
+++ b/src/mcp-servers/caveman-shrink/spawn-options.js
@@ -1,0 +1,21 @@
+// Spawn options for the upstream MCP child process.
+//
+// Windows: spawn('npx', ...) (and any .cmd shim such as 'gemini') hits ENOENT
+// because PATHEXT resolution only happens when child_process spawns through
+// a shell. POSIX systems resolve fine without a shell. Keep shell:false on
+// POSIX to avoid argv quoting surprises.
+//
+// Exported standalone so the behavior is unit-testable without re-running
+// the CLI entry point (index.js exits immediately when args are empty).
+
+'use strict';
+
+function getSpawnOptions(platform = process.platform) {
+  return {
+    stdio: ['pipe', 'pipe', 'inherit'],
+    shell: platform === 'win32',
+    windowsHide: true,
+  };
+}
+
+module.exports = { getSpawnOptions };

--- a/tests/test_mcp_shrink_spawn_options.js
+++ b/tests/test_mcp_shrink_spawn_options.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Tests for src/mcp-servers/caveman-shrink/spawn-options.js.
+// Confirms that the upstream MCP child process gets shell:true on Windows
+// (so npx and other .cmd shims resolve) and shell:false on POSIX.
+// Run: node tests/test_mcp_shrink_spawn_options.js
+
+const path = require('path');
+const assert = require('assert');
+
+const ROOT = path.resolve(__dirname, '..');
+const { getSpawnOptions } = require(
+  path.join(ROOT, 'src', 'mcp-servers', 'caveman-shrink', 'spawn-options.js')
+);
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`  ✗ ${name}\n    ${e.message}`);
+  }
+}
+
+console.log('mcp-shrink spawn-options tests\n');
+
+test('win32 enables shell so npx and .cmd shims resolve', () => {
+  const opts = getSpawnOptions('win32');
+  assert.equal(opts.shell, true);
+  assert.equal(opts.windowsHide, true);
+  assert.deepEqual(opts.stdio, ['pipe', 'pipe', 'inherit']);
+});
+
+test('linux keeps shell off to avoid argv quoting surprises', () => {
+  const opts = getSpawnOptions('linux');
+  assert.equal(opts.shell, false);
+  assert.deepEqual(opts.stdio, ['pipe', 'pipe', 'inherit']);
+});
+
+test('darwin keeps shell off', () => {
+  const opts = getSpawnOptions('darwin');
+  assert.equal(opts.shell, false);
+});
+
+test('defaults to current platform when no arg passed', () => {
+  const opts = getSpawnOptions();
+  assert.equal(opts.shell, process.platform === 'win32');
+  assert.equal(opts.windowsHide, true);
+  assert.deepEqual(opts.stdio, ['pipe', 'pipe', 'inherit']);
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Symptom

On Windows 11:

```
$ echo '...' | npx -y caveman-shrink npx -y @modelcontextprotocol/server-everything
caveman-shrink: failed to spawn upstream: spawn npx ENOENT
```

Same class of failure for any `.cmd` shim used as the upstream (e.g. `gemini.cmd`).

## Root cause

`child_process.spawn('npx', ...)` without `shell: true` cannot resolve `.cmd` shims on Windows. PATHEXT is only consulted when spawning through a shell. POSIX systems resolve fine without a shell.

## Fix

- Extract spawn options into `src/mcp-servers/caveman-shrink/spawn-options.js` (`getSpawnOptions(platform)`) so the behavior is unit-testable without reentering the CLI entry point.
- Set `shell: process.platform === 'win32'`. POSIX unchanged (no quoting surprises).
- Add `windowsHide: true` to avoid a flash of console window.

## Diff size

4 lines of behavior change; 3 files (one new tiny module, one new test, one require swap).

## Tests

New `tests/test_mcp_shrink_spawn_options.js` (mirrors `tests/test_mcp_shrink.js` style — Node `assert`, plain `node tests/<file>.js` invocation):

- `win32` → `shell:true`, `windowsHide:true`
- `linux` / `darwin` → `shell:false`
- default arg uses `process.platform`

```
$ node tests/test_mcp_shrink_spawn_options.js
mcp-shrink spawn-options tests

  ✓ win32 enables shell so npx and .cmd shims resolve
  ✓ linux keeps shell off to avoid argv quoting surprises
  ✓ darwin keeps shell off
  ✓ defaults to current platform when no arg passed

4 passed, 0 failed
```

Existing `tests/test_mcp_shrink.js` still passes (12/12).

## Verified locally

Windows 11, wrapping a Node-based MCP server end-to-end. Compression debug output intact: e.g. `[caveman-shrink] tools.run_command.description: 98→92 bytes`. No regression on Linux smoke either (`shell:false` keeps existing behavior).

## Notes for the maintainer

- POSIX path is unchanged on purpose — `shell: true` there would re-introduce argv quoting risks.
- Args still come from `.mcp.json`; trust boundary is the same as before. `shell: true` does not widen it because `npx` and `.cmd` shims are the normal way Windows users invoke Node tools; users could already inject by editing `.mcp.json`.