### PR TITLE
fix(compress): pin claude CLI subprocess to utf-8 (addresses #152)

### DIFF
--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -73,6 +73,18 @@ MAX_RETRIES = 2
 
 
 def call_claude(prompt: str) -> str:
+    """Send a prompt to Claude.
+
+    Prefers the Anthropic SDK when ANTHROPIC_API_KEY is set; otherwise falls
+    back to the ``claude --print`` CLI (which handles desktop auth).
+
+    On Windows the CLI subprocess decoding defaults to the system codepage
+    (cp1251 / cp1252) and crashes on UTF-8 output — see issue #152. Pinning
+    ``encoding="utf-8"`` with ``errors="replace"`` matches the CLI's actual
+    native I/O and prevents the UnicodeDecodeError before validation can
+    report. Windows users with non-ASCII content can also set
+    ``ANTHROPIC_API_KEY`` to route through the SDK and skip the subprocess.
+    """
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if api_key:
         try:
@@ -95,6 +107,8 @@ def call_claude(prompt: str) -> str:
             text=True,
             capture_output=True,
             check=True,
+            encoding="utf-8",
+            errors="replace",
         )
         return strip_llm_wrapper(result.stdout.strip())
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Addresses #152.

## Symptom

Windows 11, RU locale (cp1251). Compressing a Markdown prompt with Russian content:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 19707: character maps to <undefined>
...
❌ Error: 'NoneType' object has no attribute 'strip'
```

The compression aborts before validation can report anything, so the user only sees the misleading second error.

## Root cause

`subprocess.run([\"claude\",\"--print\"], text=True, capture_output=True, check=True)` decodes stdout using the system codepage. The `claude` CLI emits UTF-8 to the pipe, so any non-ASCII content trips the decoder. Same class on cp1252 (per #152 title).

## Fix

```diff
     result = subprocess.run(
         ['claude', '--print'],
         input=prompt,
         text=True,
         capture_output=True,
         check=True,
+        encoding='utf-8',
+        errors='replace',
     )
```

Plus a docstring note pointing Windows users at `ANTHROPIC_API_KEY` (which routes through the SDK and skips the subprocess entirely) as a 1-second workaround.

## Scope

- Covers the **stdout decoding** crash path in #152.
- A separate Node-side stdin decoding bug inside the `claude` CLI itself still trips on large Cyrillic prompts even after this PR; a temp-file path would fix that. Deliberately split off as a follow-up to keep this PR atomic.

## POSIX

Behavior unchanged — UTF-8 is already the locale default on macOS and Linux.

## Verified

Manually on Windows 11 RU: a Russian-language prompt that previously crashed now reaches the validation stage of `caveman-compress`. Short prompts compress successfully end-to-end.