### PR TITLE
fix(install): skip standalone hook wiring when plugin manifest already handles it

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -90,9 +90,14 @@ function parseArgs(argv) {
     }
   }
   if (opts.all && opts.minimal) die('error: --all and --minimal are mutually exclusive');
-  if (opts.all) { opts.withHooks = true; opts.withInit = true; opts.withMcpShrink = true; }
+  // --all / --minimal set the explicit knobs they imply. We deliberately leave
+  // opts.withHooks at 'auto' for --all so installClaude() can detect when the
+  // Claude Code plugin manifest already wires SessionStart + UserPromptSubmit
+  // and skip the standalone settings.json wiring — duplicate registration
+  // makes both hooks fire twice per event (issue #392). Users who want the
+  // standalone wiring on top of the plugin can still pass --with-hooks.
+  if (opts.all) { opts.withInit = true; opts.withMcpShrink = true; }
   if (opts.minimal) { opts.withHooks = false; opts.withInit = false; opts.withMcpShrink = false; }
-  if (opts.withHooks === 'auto') opts.withHooks = true;
   if (opts.withMcpShrink === 'auto') opts.withMcpShrink = true;
   // Validate --only ids against the provider matrix. PROVIDERS is defined later
   // in the file but is in scope by the time this function runs.
@@ -390,18 +395,55 @@ async function installClaude(ctx) {
     const r = captureSpawn('claude', ['plugin', 'list']);
     if (r.status === 0 && /caveman/i.test(r.stdout || '')) alreadyInstalled = true;
   }
+  let pluginInstallSucceeded = false;
   if (alreadyInstalled) {
     note('  caveman plugin already installed (use --force to reinstall)');
     results.skipped.push(['claude', 'plugin already installed']);
+    pluginInstallSucceeded = true;
   } else {
     const r1 = runSpawn('claude', ['plugin', 'marketplace', 'add', REPO], null, opts.dryRun);
     const r2 = runSpawn('claude', ['plugin', 'install', 'caveman@caveman'], null, opts.dryRun);
-    if ((r1.status || 0) === 0 && (r2.status || 0) === 0) results.installed.push('claude');
-    else results.failed.push(['claude', 'claude plugin install failed']);
+    if ((r1.status || 0) === 0 && (r2.status || 0) === 0) {
+      results.installed.push('claude');
+      pluginInstallSucceeded = true;
+    } else {
+      results.failed.push(['claude', 'claude plugin install failed']);
+    }
   }
 
-  if (opts.withHooks) {
-    say('  → installing hooks (--with-hooks)');
+  // Hook wiring decision matrix:
+  //   --no-hooks            → opts.withHooks === false           → skip
+  //   --with-hooks          → opts.withHooks === true            → wire (warn if duplicate)
+  //   default / --all       → opts.withHooks === 'auto'          → wire only if plugin install failed
+  //
+  // The plugin manifest at plugins/caveman/.claude-plugin/plugin.json already
+  // wires SessionStart + UserPromptSubmit when the plugin install succeeds.
+  // Wiring the same hooks again into settings.json makes both fire every event
+  // (issue #392 — two CAVEMAN MODE ACTIVE blocks per session start, two
+  // UserPromptSubmit reinforcement lines per turn). Skip the duplicate.
+  let shouldWireHooks;
+  if (opts.withHooks === false) {
+    shouldWireHooks = false;
+  } else if (opts.withHooks === true) {
+    shouldWireHooks = true;
+    if (pluginInstallSucceeded) {
+      warn('  --with-hooks wires hooks in settings.json alongside the plugin manifest.');
+      warn('  Both will fire on every event. Pass --no-hooks to keep only the plugin path.');
+    }
+  } else {
+    // 'auto'
+    shouldWireHooks = !pluginInstallSucceeded;
+    if (!shouldWireHooks) {
+      note('  hooks: plugin manifest handles SessionStart + UserPromptSubmit');
+      note('  (pass --with-hooks to also wire standalone hooks in settings.json)');
+      results.skipped.push(['claude-hooks', 'plugin manifest handles hooks']);
+    } else {
+      note('  hooks: plugin install did not succeed; falling back to standalone wiring');
+    }
+  }
+
+  if (shouldWireHooks) {
+    say('  → installing hooks');
     const r = await installHooks(ctx);
     if (r === 'ok') results.installed.push('claude-hooks');
     else if (r === 'skip') results.skipped.push(['claude-hooks', 'already wired']);


### PR DESCRIPTION
## Summary

Fixes [#392](https://github.com/JuliusBrussee/caveman/issues/392) — `SessionStart` and `UserPromptSubmit` hooks fire twice on every Claude Code session because `installClaude()` registers them once through the plugin manifest *and* once through `installHooks()` writing into `~/.claude/settings.json`.

`SETTINGS.hasCavemanHook()` only inspects `settings.hooks[event]`; plugin-manifest registrations live outside `settings.json`, so the existing idempotency probe can't catch the duplicate.

## What changed

- `parseArgs()`: stop force-flipping `opts.withHooks` to `true` for both `--all` and the default branch. `'auto'` now propagates into `installClaude()`.
- `installClaude()`: track whether the plugin install actually landed (`pluginInstallSucceeded`). Then make the wiring decision explicit:

| `opts.withHooks` | Behavior |
|---|---|
| `false` (`--no-hooks`, `--minimal`) | Skip standalone wiring (unchanged). |
| `true` (`--with-hooks`) | Wire standalone. If the plugin also wired hooks, print a warning that both will fire. |
| `'auto'` (default, `--all`) | Wire standalone *only* when the plugin install path didn't succeed. |

Result: the default install no longer produces duplicate registrations, and users who genuinely want the belt-and-suspenders setup can still pass `--with-hooks` explicitly (with a clear warning).

## Why not a narrower fix?

Extending `hasCavemanHook()` to probe `enabledPlugins` + walk the plugin manifest was the other option, but it's brittle — it has to know the plugin's install path layout, parse `enabledPlugins` from `settings.json` after Claude Code may have mutated it, and stay in sync if the plugin manifest's event list ever expands. Making `installClaude()` aware of *its own* plugin-install result is the simpler invariant.

## Test plan

- [x] `node -c bin/install.js` — syntax OK
- [x] Manual run on macOS with `caveman@caveman` already installed: installer now prints `hooks: plugin manifest handles SessionStart + UserPromptSubmit` and leaves `settings.json` untouched.
- [x] Verified parsed shape of `settings.json` after a manual cleanup matches what the patched installer would produce on a fresh install.
- [ ] Fresh-install regression: run `bin/install.js --only claude` against a clean `~/.claude/`, confirm one `CAVEMAN MODE ACTIVE` SessionStart block and one `UserPromptSubmit additionalContext` per turn. (Pending — needs a clean profile; happy to take a maintainer's word that this matches the test infra you already have.)
- [ ] `bin/install.js --only claude --with-hooks` — confirm warning prints, both paths wired (intentional opt-in).
- [ ] `bin/install.js --only claude --no-hooks` — confirm only plugin path wired.
- [ ] `bin/install.js --all` — confirm hooks wired exactly once via plugin manifest.

## Notes for reviewers

- The decision matrix is documented inline above the new `if/else` so future readers don't have to reverse-engineer the intent.
- `--all` now subtly changes meaning: it no longer adds standalone hooks on top of the plugin's hooks. I think this is correct — the README copy "Plugin + hooks + statusline + MCP shrink + per-repo rule files. The full ride." reads naturally as "everything wired once", not "everything wired twice". Happy to revert that piece if you'd rather keep `--all` as a literal force-on for every knob.
- I did not touch `INSTALL.md`. If the maintainer wants the README to call this out, I can amend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
