### PR TITLE
fix(install): use --skill '*' instead of --all in per-provider path (fixes #389)

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -443,13 +443,17 @@ function installViaSkills(ctx, prov) {
   const { say, opts, results } = ctx;
   results.detected++;
   say(`→ ${prov.label} detected`);
-  // --yes --all: skip the upstream skill-selection TUI and confirmation prompts.
-  // Without these, `curl|bash` (no TTY on stdin) renders an empty checkbox list
-  // the user can't interact with, then exits 0 with zero skills installed —
-  // and our installer happily reports success. See issue #370.
-  // We've already decided which agent to install for via auto-detect / --only;
-  // making the user re-select 7 skills inside skills CLI would be redundant.
-  const args = ['-y', 'skills', 'add', REPO, '-a', prov.profile, '--yes', '--all'];
+  // --skill '*' --yes: skip the upstream skill-selection TUI and confirmation
+  // prompts. Without --skill, `curl|bash` (no TTY on stdin) renders an empty
+  // checkbox list the user can't interact with, then exits 0 with zero skills
+  // installed — and our installer happily reports success. See issue #370.
+  //
+  // We pass `--skill '*'` rather than `--all` because the upstream `skills` CLI
+  // interprets `--all` as "all skills from the source to *all* agents", which
+  // ignores the `-a prov.profile` selection and writes every skill through
+  // every agent adapter (see issue #389). `--skill '*' -a <agent>` is the
+  // documented form for "install every skill into a specific agent".
+  const args = ['-y', 'skills', 'add', REPO, '--skill', '*', '-a', prov.profile, '--yes'];
   const r = runSpawn('npx', args, null, opts.dryRun);
   if ((r.status || 0) === 0) results.installed.push(prov.id);
   else results.failed.push([prov.id, `npx skills add (${prov.profile}) failed`]);


### PR DESCRIPTION
## Summary

Fixes #389 — `installViaSkills()` in `bin/install.js` was passing `--all` for every per-provider call, which the upstream `skills` CLI interprets as *all* skills to *all* agents (ignoring the `-a <profile>` selection). So every detected agent triggered a fan-out across all 55 supported agent adapters; the same caveman skills got re-applied dozens of times.

Switched to the documented `--skill '*' -a <agent>` form, which is what "all skills, one specific agent" actually means in upstream `skills`. `--yes` stays (suppresses the upstream TUI when `curl|bash` has no TTY — see comment in code and issue #370).

## Changes

- `bin/install.js` `installViaSkills()`:
  ```diff
  - const args = ['-y', 'skills', 'add', REPO, '-a', prov.profile, '--yes', '--all'];
  + const args = ['-y', 'skills', 'add', REPO, '--skill', '*', '-a', prov.profile, '--yes'];
  ```
- Updated the surrounding comment to explain *why* `--skill '*'` and not `--all`, citing the #389 root cause so future maintainers don't undo it.

## Verification

- `node --check bin/install.js` — clean.
- `tests/installer/unit.argv.test.mjs` — 13/13 pass.
- `tests/installer/e2e.dryrun.test.mjs` — 2/2 pass.
- Confirmed only one `--all` occurrence in an `npx skills add` argv vector exists in the file; the `--all` in argv parsing at L65 is the installer's own flag and unrelated.

## Out of scope

The auto-detect fallback path that genuinely wants all-agents behavior (the issue body notes this as "distinct from the per-provider call") is unchanged — it doesn't use `installViaSkills()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)