### PR TITLE
docs(install): explain how to discover profile slugs via --list (closes #343)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,7 +76,18 @@ If you want to install for one agent (or want to know exactly what command runs 
 
 For "auto-activates? No" agents, type `/caveman` once per session (or use natural-language triggers like "talk like caveman", "caveman mode").
 
-Full agent matrix (with detection rules) is in `bin/install.js` under the `PROVIDERS` array.
+**Finding a profile slug for `npx skills add ... -a <profile>`?** Either read the table above, or print the live matrix from the installer:
+
+```bash
+# Either of these works (install.sh / install.ps1 are thin shims that
+# forward all flags to bin/install.js):
+bash install.sh --list             # macOS / Linux / WSL, from a local clone
+pwsh install.ps1 --list            # Windows / PowerShell, from a local clone
+node bin/install.js --list         # any platform, from a local clone
+npx -y github:JuliusBrussee/caveman -- --list   # no clone needed
+```
+
+Each row prints the agent id, profile slug (where applicable), and whether it was auto-detected on your machine. Full agent matrix (with detection rules) is also defined in `bin/install.js` under the `PROVIDERS` array.
 
 ## Manual install (no `curl | bash`)
 


### PR DESCRIPTION
## Summary

Closes #343 — the original complaint was that the README said *"see install.sh --list for the full slug list"* with no further context, so users were left asking "what install.sh?". The misleading parenthetical was already removed when the README was restructured (commit b67c404e), so the literal text is gone. But INSTALL.md still leaves a gap: the only directive on discovering profile slugs is *"read the `PROVIDERS` array in bin/install.js"*, which is a maintainer move, not a user move.

This PR adds a short, focused subsection right under the agent table that shows the four equivalent ways to print the live agent matrix from the installer.

## Changes

`INSTALL.md`:

```markdown
**Finding a profile slug for `npx skills add ... -a <profile>`?** Either read the table above, or print the live matrix from the installer:

```bash
bash install.sh --list             # macOS / Linux / WSL, from a local clone
pwsh install.ps1 --list            # Windows / PowerShell, from a local clone
node bin/install.js --list         # any platform, from a local clone
npx -y github:JuliusBrussee/caveman -- --list   # no clone needed
```
```

This documents `install.sh` / `install.ps1` as forwarding shims around `bin/install.js` (matching what the shim file headers already say), so the "What install.sh?" confusion can't recur.

## Verification

- `bash install.sh --list` and `node bin/install.js --list` both render the same provider matrix locally — the shim forwards correctly.
- No code changes; INSTALL.md is the only touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)