### PR TITLE
fix(opencode): ship missing caveman-compress.md (fixes ENOENT install)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ __pycache__/
 *.pyc
 .venv/
 .env.local
-caveman-compress.md
 **/.DS_Store
 .claude/worktrees/
 evals/snapshots/*.html

--- a/src/plugins/opencode/commands/caveman-compress.md
+++ b/src/plugins/opencode/commands/caveman-compress.md
@@ -1,0 +1,15 @@
+---
+description: Compress a markdown/text file into caveman format to save tokens
+---
+Compress the file at: $ARGUMENTS
+
+Run the `caveman-compress` skill against the given filepath. The skill rewrites
+prose into terse caveman style — drops articles, filler, hedging — while
+preserving code blocks, inline code, URLs, file paths, commands, and markdown
+structure exactly. Original is backed up as `<file>.original.md` before
+overwrite.
+
+Only compress natural-language files (`.md`, `.txt`, `.typ`, `.tex`,
+extensionless). Refuse source/config files (`.py`, `.js`, `.ts`, `.json`,
+`.yaml`, `.toml`, `.sh`, etc.). Never compress an existing `*.original.md`
+backup.


### PR DESCRIPTION
## Summary

- Closes #367 and #391 — every opencode install (via `npx`, `install.sh`, `install.ps1`) currently aborts with `ENOENT: copyfile .../src/plugins/opencode/commands/caveman-compress.md`.
- Root cause: `.gitignore` contained an unscoped `caveman-compress.md` rule, so the slash-command file referenced by `OPENCODE_COMMAND_FILES` in `bin/install.js` was never tracked or shipped in the published npm package.
- Fix is two lines: remove the ignore rule, add the missing command file matching the style of the other opencode commands (`caveman.md`, `caveman-commit.md`, `caveman-review.md`, `caveman-help.md`, `caveman-stats.md`).

## What changed

- `.gitignore`: drop the line `caveman-compress.md`. Verified via `find` that no other file by that name exists anywhere in the tree, so this rule had no legitimate target.
- `src/plugins/opencode/commands/caveman-compress.md`: new file. Single-line `description:` frontmatter + short body that points at the `caveman-compress` skill and re-states the file-type guardrails. Matches the format used by all sibling command files.

## Why this happened

`b685570 Update .gitignore` shows `caveman-compress.md` was already present in `.gitignore` before that commit. Looks like a leftover from a previous workflow where a `caveman-compress.md` was being generated locally and accidentally tracked. The ignore rule outlived the original reason, and silently blocked the legitimate plugin file from ever being committed.

## Secondary impact noted in the issues

Even after this fix, the installer's copy loop aborts on the first ENOENT, so any future missing command would leave `~/.config/opencode/commands/` half-populated. Out of scope for this PR, but worth a follow-up: wrap the copy in try/catch and report skipped files at the end, plus a CI check that every entry in `OPENCODE_COMMAND_FILES` exists on disk before publish.

## Test plan

- [ ] `npx caveman-installer` with this branch → opencode install completes without ENOENT
- [ ] `ls ~/.config/opencode/commands/` shows all six files: `caveman.md`, `caveman-commit.md`, `caveman-review.md`, `caveman-compress.md`, `caveman-stats.md`, `caveman-help.md`
- [ ] `/caveman-compress <file>` slash command is discoverable in opencode after install