### PR TITLE
fix(install): avoid reserved Args parameter in PowerShell

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -17,7 +17,7 @@
 [CmdletBinding()]
 param(
   [Parameter(ValueFromRemainingArguments = $true)]
-  [string[]]$Args
+  [string[]]$ScriptArgs
 )
 
 $ErrorActionPreference = "Stop"
@@ -44,7 +44,7 @@ if ($nodeMajor -lt 18) {
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $local = Join-Path $here "bin/install.js"
 if (Test-Path $local) {
-  & node $local @Args
+  & node $local @ScriptArgs
   exit $LASTEXITCODE
 }
 
@@ -58,5 +58,5 @@ if (-not $npx) {
 # Do NOT pass `--` here — npm 7+ npx already forwards trailing args to the
 # package, and a literal `--` was tripping bin/install.js's parseArgs as an
 # unknown flag.
-& npx -y "github:$Repo" @Args
+& npx -y "github:$Repo" @ScriptArgs
 exit $LASTEXITCODE


### PR DESCRIPTION
## Summary
- Rename the PowerShell installer's remaining-arguments parameter from `Args` to `ScriptArgs`.
- Forward `ScriptArgs` to both local `bin/install.js` and `npx` paths.

## Problem
Running the Windows one-line installer currently fails under PowerShell:

```powershell
irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 | iex
```

Error:

```text
Cannot overwrite variable Args because the variable has been optimized.
```

PowerShell's automatic `$Args` variable can be optimized/read-only in this pipeline execution path, so declaring a script parameter named `$Args` causes `Invoke-Expression` to fail before the installer can run.

## Validation
- Parsed `install.ps1` with PowerShell's parser successfully.