### PR TITLE
fix: address code review issues in hook infrastructure

### DIFF
--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -9,7 +9,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { getDefaultMode, safeWriteFlag } = require('./caveman-config');
+const { getDefaultMode, safeWriteFlag, INDEPENDENT_MODES } = require('./caveman-config');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');
@@ -34,10 +34,6 @@ safeWriteFlag(flagPath, mode);
 //
 //    Reads SKILL.md at runtime so edits to the source of truth propagate
 //    automatically — no hardcoded duplication to go stale.
-
-// Modes that have their own independent skill files — not caveman intensity levels.
-// For these, emit a short activation line; the skill itself handles behavior.
-const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
 
 if (INDEPENDENT_MODES.has(mode)) {
   process.stdout.write('CAVEMAN MODE ACTIVE — level: ' + mode + '. Behavior defined by /caveman-' + mode + ' skill.');

--- a/src/hooks/caveman-config.js
+++ b/src/hooks/caveman-config.js
@@ -15,9 +15,14 @@ const os = require('os');
 
 const VALID_MODES = [
   'off', 'lite', 'full', 'ultra',
-  'wenyan-lite', 'wenyan', 'wenyan-full', 'wenyan-ultra',
+  'wenyan-lite', 'wenyan', 'wenyan-ultra',
   'commit', 'review', 'compress'
 ];
+
+// Modes handled by their own slash commands (/caveman-commit, etc.) — not
+// selectable via /caveman <arg>. Exported so activate + mode-tracker share
+// the same definition rather than each maintaining a local copy.
+const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
 
 function getConfigDir() {
   if (process.env.XDG_CONFIG_HOME) {
@@ -249,8 +254,10 @@ function appendFlag(filePath, line) {
 }
 
 // Symlink-safe history read. Returns lines (untrimmed) or empty array on any
-// anomaly. Caller is responsible for parsing JSON. Does NOT enforce a size cap
-// the way readFlag does — history is expected to grow with use.
+// anomaly. Caller is responsible for parsing JSON.
+// Capped at MAX_HISTORY_BYTES to prevent an oversized file from causing OOM.
+const MAX_HISTORY_BYTES = 10 * 1024 * 1024; // 10 MB
+
 function readHistory(filePath) {
   try {
     const st = fs.lstatSync(filePath);
@@ -261,7 +268,11 @@ function readHistory(filePath) {
     let raw;
     try {
       fd = fs.openSync(filePath, flags);
-      raw = fs.readFileSync(fd, 'utf8');
+      // Read up to the cap; anything beyond is silently truncated.
+      const readSize = Math.min(st.size, MAX_HISTORY_BYTES);
+      const buf = Buffer.alloc(readSize);
+      const n = fs.readSync(fd, buf, 0, readSize, 0);
+      raw = buf.slice(0, n).toString('utf8');
     } finally {
       if (fd !== undefined) fs.closeSync(fd);
     }
@@ -271,4 +282,4 @@ function readHistory(filePath) {
   }
 }
 
-module.exports = { getDefaultMode, getConfigDir, getConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory };
+module.exports = { getDefaultMode, getConfigDir, getConfigPath, VALID_MODES, INDEPENDENT_MODES, safeWriteFlag, readFlag, appendFlag, readHistory };

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -6,11 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { execFileSync } = require('child_process');
-const { getDefaultMode, safeWriteFlag, readFlag, VALID_MODES } = require('./caveman-config');
-
-// Modes handled by their own slash commands (/caveman-commit, etc.) — not
-// selectable via /caveman <arg>.
-const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
+const { getDefaultMode, safeWriteFlag, readFlag, VALID_MODES, INDEPENDENT_MODES } = require('./caveman-config');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');

--- a/src/hooks/caveman-stats.js
+++ b/src/hooks/caveman-stats.js
@@ -52,9 +52,12 @@ function findRecentSession(claudeDir) {
   catch { return null; }
 
   let best = null;
+  let visited = 0;
+  const MAX_ENTRIES = 10_000;
   const stack = entries.map(e => path.join(projectsDir, e.name));
-  while (stack.length) {
+  while (stack.length && visited < MAX_ENTRIES) {
     const p = stack.pop();
+    visited++;
     let st;
     try { st = fs.statSync(p); } catch { continue; }
     if (st.isDirectory()) {

--- a/src/hooks/install.sh
+++ b/src/hooks/install.sh
@@ -189,6 +189,9 @@ CAVEMAN_SETTINGS="$SETTINGS" CAVEMAN_HOOKS_DIR="$HOOKS_DIR" node -e "
   console.log('  Hooks wired in settings.json');
 "
 
+# Remove the backup now that the merge succeeded
+rm -f "$SETTINGS.bak"
+
 echo ""
 echo "Done! Restart Claude Code to activate."
 echo ""


### PR DESCRIPTION
## Summary

Five targeted fixes from a code review of the hook infrastructure:

- **Export `INDEPENDENT_MODES` from `caveman-config.js`** — `caveman-activate.js` and `caveman-mode-tracker.js` each maintained a local `new Set(['commit', 'review', 'compress'])`. Adding a new independent mode required updating two files and was easy to miss. Now one definition, exported alongside `VALID_MODES`.

- **Remove phantom `'wenyan-full'` from `VALID_MODES`** — `'wenyan-full'` was never written to the flag file (the mode-tracker aliases `/caveman wenyan-full` → stored as `'wenyan'`). Having it in the whitelist meant `readFlag` would accept it, but no writer would ever produce it — a ghost entry that could cause confusion on a direct equality check. Removed; the special-case alias in `caveman-mode-tracker.js` continues to handle the `/caveman wenyan-full` command.

- **Cap `readHistory` at 10 MB** — `readFlag` already enforces `MAX_FLAG_BYTES = 64`. `readHistory` was the only uncapped reader; an unusually large history file could cause OOM in `caveman-stats.js`. Now reads at most 10 MB; lines beyond that are silently truncated (same graceful-fail pattern as the rest of the module).

- **Guard `findRecentSession` DFS at 10 000 entries** — the stack-based traversal of `~/.claude/projects/` had no depth or count limit. Added a `visited` counter capped at `MAX_ENTRIES = 10_000`; bails out and returns the best match found so far.

- **Remove `settings.json.bak` after successful `install.sh` merge** — the backup was created before the Node merge script ran but never cleaned up. Repeated `--force` reinstalls accumulated stale backup files. Now deleted on success; if the merge fails, the script exits before the `rm` and the backup is preserved for recovery.

## Test plan

- [ ] `node src/hooks/caveman-activate.js` exits cleanly (SessionStart hook smoke test)
- [ ] `echo '{"prompt":"/caveman ultra"}' | node src/hooks/caveman-mode-tracker.js` writes `ultra` to flag
- [ ] `echo '{"prompt":"/caveman wenyan-full"}' | node src/hooks/caveman-mode-tracker.js` writes `wenyan` to flag (alias preserved)
- [ ] `node src/hooks/caveman-stats.js` runs without error
- [ ] Existing test suite: `node tests/test_hooks.py` / `node tests/test_symlink_flag.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)