### PR TITLE
fix: add opencode caveman-compress command

### DIFF
--- a/src/plugins/opencode/commands/caveman-compress.md
+++ b/src/plugins/opencode/commands/caveman-compress.md
@@ -1,0 +1,19 @@
+---
+description: Compress a memory/context file into terse caveman style while preserving code, URLs, and paths.
+---
+
+# caveman-compress
+
+Compress a file using the `caveman-compress` skill.
+
+Usage:
+- `/caveman-compress <file>`
+
+Steps:
+1. Load `caveman-compress` skill.
+2. Run its validator/detector first if available.
+3. Rewrite prose terse, keep technical meaning.
+4. Preserve code blocks, URLs, paths, commands, JSON/YAML/TOML, and frontmatter byte-for-byte unless the skill says otherwise.
+5. Report original tokens, compressed tokens, and percent saved.
+
+If no file path supplied, ask for one concise question.


### PR DESCRIPTION
## Problem

The opencode installer test suite expects `src/plugins/opencode/commands/caveman-compress.md` to exist, but the file was missing. This caused test #13 to fail:

not ok 13 - opencode fresh install drops plugin, commands, agents, skills, AGENTS.md, opencode.json
error: 'command caveman-compress.md missing'

## Fix

Added the missing `caveman-compress.md` command file that loads the caveman-compress skill and rewrites context/memory files to terse caveman style.

## Test


npm test
tests 51
pass 51
fail 0

All 51 tests now pass (was 47 pass, 4 fail before this fix).
