### PR TITLE
feat: project-scope gating for the SessionStart hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,42 @@ A March 2026 paper ["Brevity Constraints Reverse Performance Hierarchies in Lang
 
 Maintainer detail (hook architecture, file ownership, CI sync) live in [CLAUDE.md](./CLAUDE.md).
 
+## Project-Scope Gating
+
+Sometimes caveman activate global. User want caveman only some project. Add file or config — caveman skip activation that CWD only. Global default not change.
+
+**Marker files (cheapest path)** — drop zero-byte file in project root:
+
+```bash
+# In project where you want caveman OFF:
+touch .caveman-disable
+
+# Or, with global default=off, opt one project IN:
+touch .caveman-enable
+```
+
+**Env var (single session)**:
+
+```bash
+CAVEMAN_PROJECT_SCOPE=disabled claude   # this session only
+```
+
+**Config-driven allow / deny lists** (`~/.config/caveman/config.json`):
+
+```json
+{
+  "defaultMode": "full",
+  "projectScope": {
+    "deny":  ["/Users/me/work/client-xyz"],
+    "allow": ["/Users/me/code/flow", "/Users/me/code/api"]
+  }
+}
+```
+
+Resolution order (first match wins): `.caveman-disable` marker → `.caveman-enable` marker → `CAVEMAN_PROJECT_SCOPE` env → config `deny[]` prefix match → config `allow[]` prefix match (when `allow` set, anything not in it is denied) → global default. Path prefixes resolve symlinks so `/tmp` ↔ `/private/tmp` style setups Just Work.
+
+When disabled, caveman hook exit early with `OK (project-scope disabled)` — no flag file written, no ruleset emitted, no compression that CWD. Session behave like caveman not installed.
+
 ## Lobster, Meet Rock 🦞🪨
 
 [**OpenClaw**](https://openclaw.ai) the self-host gateway. One box, many agent inside (Claude Code, Codex, Pi, OpenCode), wired to your Slack / Discord / iMessage / Telegram / whatever. Tagline: *"The lobster way."* Lobster strong. Lobster smart. Lobster also talk a lot.

--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -15,14 +15,7 @@ const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.cla
 const flagPath = path.join(claudeDir, '.caveman-active');
 const settingsPath = path.join(claudeDir, 'settings.json');
 
-const mode = getDefaultMode();
-
-// "off" mode — skip activation entirely, don't write flag or emit rules
-if (mode === 'off') {
-  try { fs.unlinkSync(flagPath); } catch (e) {}
-  process.stdout.write('OK');
-  process.exit(0);
-}
+let mode = getDefaultMode();
 
 // Project-scope gating — caveman fires globally by default, but the user may
 // opt specific projects out (or, with an allowlist, opt specific projects in).
@@ -31,13 +24,28 @@ if (mode === 'off') {
 // CAVEMAN_PROJECT_SCOPE env var, or config.json projectScope.allow/deny lists.
 // See getProjectScope() in caveman-config.js for the full precedence chain.
 //
-// When 'disabled', behave the same way as global 'off' mode: clear the flag,
-// don't emit the ruleset. This stops caveman from compressing responses in
-// the current session without changing the user's global default.
+// Checked BEFORE the global 'off' branch so that an explicit per-project
+// enable can override a global default of 'off' (allowlist mode). When
+// scope is 'enabled' but the global default is 'off', promote mode to
+// 'full' — the user explicitly opted this project in, so we need SOME
+// active mode.
 const projectScope = getProjectScope(process.cwd());
+
 if (projectScope === 'disabled') {
   try { fs.unlinkSync(flagPath); } catch (e) {}
   process.stdout.write('OK (project-scope disabled)');
+  process.exit(0);
+}
+
+if (projectScope === 'enabled' && mode === 'off') {
+  mode = 'full';
+}
+
+// "off" mode — skip activation entirely, don't write flag or emit rules.
+// Only reached when scope is 'inherit' AND global default is 'off'.
+if (mode === 'off') {
+  try { fs.unlinkSync(flagPath); } catch (e) {}
+  process.stdout.write('OK');
   process.exit(0);
 }
 

--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -9,7 +9,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { getDefaultMode, safeWriteFlag } = require('./caveman-config');
+const { getDefaultMode, getProjectScope, safeWriteFlag } = require('./caveman-config');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');
@@ -21,6 +21,23 @@ const mode = getDefaultMode();
 if (mode === 'off') {
   try { fs.unlinkSync(flagPath); } catch (e) {}
   process.stdout.write('OK');
+  process.exit(0);
+}
+
+// Project-scope gating — caveman fires globally by default, but the user may
+// opt specific projects out (or, with an allowlist, opt specific projects in).
+//
+// Resolution: .caveman-disable / .caveman-enable marker files in CWD,
+// CAVEMAN_PROJECT_SCOPE env var, or config.json projectScope.allow/deny lists.
+// See getProjectScope() in caveman-config.js for the full precedence chain.
+//
+// When 'disabled', behave the same way as global 'off' mode: clear the flag,
+// don't emit the ruleset. This stops caveman from compressing responses in
+// the current session without changing the user's global default.
+const projectScope = getProjectScope(process.cwd());
+if (projectScope === 'disabled') {
+  try { fs.unlinkSync(flagPath); } catch (e) {}
+  process.stdout.write('OK (project-scope disabled)');
   process.exit(0);
 }
 

--- a/src/hooks/caveman-config.js
+++ b/src/hooks/caveman-config.js
@@ -58,6 +58,88 @@ function getDefaultMode() {
   return 'full';
 }
 
+// Project-scope gating — decides whether caveman should activate in a given CWD.
+//
+// Caveman's SessionStart hook fires globally on every Claude Code session,
+// which means caveman behavior leaks into projects the user never intended
+// (a random repo opened for read-only browsing, an unrelated client project,
+// non-coding work). This function lets callers opt projects in or out without
+// flipping the global mode.
+//
+// Resolution order (first match wins):
+//   1. CWD/.caveman-disable file exists → 'disabled'
+//   2. CWD/.caveman-enable  file exists → 'enabled'
+//   3. CAVEMAN_PROJECT_SCOPE env var ('disabled' | 'enabled') → that value
+//   4. config.projectScope.deny[] contains a path prefix of CWD → 'disabled'
+//   5. config.projectScope.allow[] exists AND no entry is a path prefix of CWD → 'disabled'
+//      (allowlist mode: when allow is set, only listed dirs are enabled)
+//   6. config.projectScope.allow[] contains a path prefix of CWD → 'enabled'
+//   7. Otherwise → 'inherit' (use the global default from getDefaultMode())
+//
+// Returns one of: 'disabled' | 'enabled' | 'inherit'
+//
+// The marker files are zero-byte sentinels. Path checks use case-sensitive
+// prefix matching with normalized path separators. Errors fall through to
+// 'inherit' silently — project-scope is a convenience, not a security boundary.
+function getProjectScope(cwd) {
+  if (!cwd || typeof cwd !== 'string') return 'inherit';
+
+  // 1 + 2: marker files in CWD (cheapest check, runs first)
+  try {
+    if (fs.existsSync(path.join(cwd, '.caveman-disable'))) return 'disabled';
+  } catch (e) { /* ignore */ }
+  try {
+    if (fs.existsSync(path.join(cwd, '.caveman-enable'))) return 'enabled';
+  } catch (e) { /* ignore */ }
+
+  // 3: env var override (covers ad-hoc disable for a single session)
+  const envScope = process.env.CAVEMAN_PROJECT_SCOPE;
+  if (envScope === 'disabled' || envScope === 'enabled') return envScope;
+
+  // 4 + 5 + 6: config-driven allow/deny lists. Resolve through symlinks so
+  // macOS /tmp → /private/tmp (and similar setups) don't produce false misses.
+  try {
+    const configPath = getConfigPath();
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    const ps = config.projectScope || {};
+    const normalizedCwd = safeRealpath(cwd);
+
+    if (Array.isArray(ps.deny)) {
+      for (const entry of ps.deny) {
+        if (typeof entry !== 'string') continue;
+        if (isPathPrefix(safeRealpath(entry), normalizedCwd)) return 'disabled';
+      }
+    }
+
+    if (Array.isArray(ps.allow) && ps.allow.length > 0) {
+      for (const entry of ps.allow) {
+        if (typeof entry !== 'string') continue;
+        if (isPathPrefix(safeRealpath(entry), normalizedCwd)) return 'enabled';
+      }
+      // Allowlist set but CWD not in it → disabled
+      return 'disabled';
+    }
+  } catch (e) { /* fall through */ }
+
+  return 'inherit';
+}
+
+function isPathPrefix(prefix, target) {
+  if (prefix === target) return true;
+  return target.startsWith(prefix + path.sep);
+}
+
+// Resolve through symlinks to a canonical path. Falls back to path.resolve()
+// for non-existent paths (e.g. allowlist entries the user typed before the
+// directory exists). Never throws.
+function safeRealpath(p) {
+  try {
+    return fs.realpathSync(p);
+  } catch (e) {
+    return path.resolve(p);
+  }
+}
+
 // Symlink-safe flag file write.
 // Uses O_NOFOLLOW where available, writes atomically via temp + rename with
 // 0600 permissions. Protects against local attackers replacing the predictable
@@ -271,4 +353,4 @@ function readHistory(filePath) {
   }
 }
 
-module.exports = { getDefaultMode, getConfigDir, getConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory };
+module.exports = { getDefaultMode, getProjectScope, getConfigDir, getConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory };

--- a/tests/test_project_scope.py
+++ b/tests/test_project_scope.py
@@ -1,0 +1,164 @@
+"""Tests for caveman's project-scope gating.
+
+caveman's SessionStart hook fires globally on every Claude Code session.
+Project-scope gating lets users opt specific directories out of caveman
+without flipping the global mode. Resolution order (first match wins):
+
+  1. CWD/.caveman-disable file → disabled
+  2. CWD/.caveman-enable  file → enabled
+  3. CAVEMAN_PROJECT_SCOPE env var (disabled | enabled)
+  4. config.projectScope.deny[] contains a path prefix of CWD → disabled
+  5. config.projectScope.allow[] set but no entry matches CWD → disabled
+  6. config.projectScope.allow[] contains a path prefix of CWD → enabled
+  7. Otherwise → inherit (use global default)
+
+When 'disabled', the activate hook exits early with 'OK (project-scope disabled)'
+and does NOT write the .caveman-active flag, mirroring the behavior of global
+'off' mode but scoped to one CWD.
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ACTIVATE_HOOK = REPO_ROOT / "src" / "hooks" / "caveman-activate.js"
+
+
+def run_activate(*, cwd, home, env_extra=None):
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
+    env["CLAUDE_CONFIG_DIR"] = str(home / ".claude")
+    # Force default mode so we always know what we'd activate with absent gating.
+    env.setdefault("CAVEMAN_DEFAULT_MODE", "full")
+    # Don't let the test inherit the host's project-scope env.
+    env.pop("CAVEMAN_PROJECT_SCOPE", None)
+    if env_extra:
+        env.update(env_extra)
+
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+
+    return subprocess.run(
+        ["node", str(ACTIVATE_HOOK)],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class ProjectScopeTests(unittest.TestCase):
+    def test_no_markers_no_config_activates_normally(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            cwd = Path(tmp) / "cwd"
+            cwd.mkdir()
+            result = run_activate(cwd=cwd, home=home)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("CAVEMAN MODE ACTIVE", result.stdout)
+            # Flag file should have been written by safeWriteFlag.
+            self.assertTrue((home / ".claude" / ".caveman-active").exists())
+
+    def test_disable_marker_skips_activation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            cwd = Path(tmp) / "cwd"
+            cwd.mkdir()
+            (cwd / ".caveman-disable").write_text("")
+            result = run_activate(cwd=cwd, home=home)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "OK (project-scope disabled)")
+            # No flag should be written when disabled.
+            self.assertFalse((home / ".claude" / ".caveman-active").exists())
+
+    def test_enable_marker_activates_even_with_default_full(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            cwd = Path(tmp) / "cwd"
+            cwd.mkdir()
+            (cwd / ".caveman-enable").write_text("")
+            result = run_activate(cwd=cwd, home=home)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("CAVEMAN MODE ACTIVE", result.stdout)
+
+    def test_disable_marker_beats_enable_marker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            cwd = Path(tmp) / "cwd"
+            cwd.mkdir()
+            (cwd / ".caveman-disable").write_text("")
+            (cwd / ".caveman-enable").write_text("")
+            result = run_activate(cwd=cwd, home=home)
+
+            self.assertEqual(result.stdout, "OK (project-scope disabled)")
+
+    def test_env_var_disabled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            cwd = Path(tmp) / "cwd"
+            cwd.mkdir()
+            result = run_activate(
+                cwd=cwd,
+                home=home,
+                env_extra={"CAVEMAN_PROJECT_SCOPE": "disabled"},
+            )
+
+            self.assertEqual(result.stdout, "OK (project-scope disabled)")
+
+    def test_config_denylist_prefix_match(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            cwd = Path(tmp) / "deny-me" / "subdir"
+            cwd.mkdir(parents=True)
+
+            config_dir = home / ".config" / "caveman"
+            config_dir.mkdir(parents=True)
+            (config_dir / "config.json").write_text(json.dumps({
+                "projectScope": {
+                    "deny": [str(Path(tmp) / "deny-me")]
+                }
+            }))
+
+            env_extra = {"XDG_CONFIG_HOME": str(home / ".config")}
+            result = run_activate(cwd=cwd, home=home, env_extra=env_extra)
+
+            self.assertEqual(result.stdout, "OK (project-scope disabled)")
+
+    def test_config_allowlist_only_enables_listed_dirs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            allowed = Path(tmp) / "allowed"
+            other = Path(tmp) / "other"
+            allowed.mkdir()
+            other.mkdir()
+
+            config_dir = home / ".config" / "caveman"
+            config_dir.mkdir(parents=True)
+            (config_dir / "config.json").write_text(json.dumps({
+                "projectScope": {
+                    "allow": [str(allowed)]
+                }
+            }))
+
+            env_extra = {"XDG_CONFIG_HOME": str(home / ".config")}
+
+            # In the allowlisted dir → activates
+            r_allowed = run_activate(cwd=allowed, home=home, env_extra=env_extra)
+            self.assertIn("CAVEMAN MODE ACTIVE", r_allowed.stdout)
+
+            # Elsewhere → disabled
+            r_other = run_activate(cwd=other, home=home, env_extra=env_extra)
+            self.assertEqual(r_other.stdout, "OK (project-scope disabled)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_scope.py
+++ b/tests/test_project_scope.py
@@ -159,6 +159,51 @@ class ProjectScopeTests(unittest.TestCase):
             r_other = run_activate(cwd=other, home=home, env_extra=env_extra)
             self.assertEqual(r_other.stdout, "OK (project-scope disabled)")
 
+    def test_global_off_plus_enable_marker_activates(self):
+        # The canonical "allowlist mode": user flips global default to off so
+        # caveman is silent everywhere, then drops .caveman-enable markers in
+        # projects where they want it. Without this, the .caveman-enable
+        # marker is useless — the global 'off' branch fires first.
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            cwd = Path(tmp) / "cwd"
+            cwd.mkdir()
+            (cwd / ".caveman-enable").write_text("")
+
+            # Flip global default to off via config file.
+            config_dir = home / ".config" / "caveman"
+            config_dir.mkdir(parents=True)
+            (config_dir / "config.json").write_text(json.dumps({"defaultMode": "off"}))
+
+            env_extra = {
+                "XDG_CONFIG_HOME": str(home / ".config"),
+                # Drop the test's default CAVEMAN_DEFAULT_MODE so config.json wins.
+                "CAVEMAN_DEFAULT_MODE": "",
+            }
+
+            result = run_activate(cwd=cwd, home=home, env_extra=env_extra)
+            self.assertIn("CAVEMAN MODE ACTIVE", result.stdout)
+
+    def test_global_off_without_marker_stays_silent(self):
+        # Counterpart to the above: same global off config, but no marker →
+        # silent. This is the failure mode the reorder fixes.
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            cwd = Path(tmp) / "cwd"
+            cwd.mkdir()
+
+            config_dir = home / ".config" / "caveman"
+            config_dir.mkdir(parents=True)
+            (config_dir / "config.json").write_text(json.dumps({"defaultMode": "off"}))
+
+            env_extra = {
+                "XDG_CONFIG_HOME": str(home / ".config"),
+                "CAVEMAN_DEFAULT_MODE": "",
+            }
+
+            result = run_activate(cwd=cwd, home=home, env_extra=env_extra)
+            self.assertEqual(result.stdout, "OK")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Adds opt-in/opt-out gating on top of the existing global mode so the SessionStart hook can be silenced (or, with an allowlist, only fired) in specific directories.

## Why

Today the only way to keep caveman off in a project you don't want it in is to set the global default to `off` — which also kills caveman in the projects you DO want it in. Several downstream consumers (notably [Flow](https://github.com/mhd-ghaith-abtah/flow), which orchestrates per-story workflows around BMad + ECC + caveman) hit this and have to document a manual workaround. Native project-scope detection is much cleaner.

## How

Resolution order (first match wins):

1. `CWD/.caveman-disable` file → `disabled`
2. `CWD/.caveman-enable` file → `enabled`
3. `CAVEMAN_PROJECT_SCOPE` env var (`disabled` | `enabled`) → that value
4. `config.projectScope.deny[]` contains a path prefix of CWD → `disabled`
5. `config.projectScope.allow[]` is set AND no entry matches CWD → `disabled` (allowlist mode)
6. `config.projectScope.allow[]` contains a path prefix of CWD → `enabled`
7. Otherwise → `inherit` (use the existing global default — current behavior unchanged)

When `disabled`, the activate hook exits with `OK (project-scope disabled)` — no flag file, no ruleset emitted. Same end-state as `mode === 'off'`, scoped to one CWD.

Path prefix matching resolves symlinks via `fs.realpathSync()` so macOS `/tmp` ↔ `/private/tmp` setups work cleanly. Non-existent allow-entries fall back to `path.resolve()` so users can stage config before the directory exists.

## Compatibility

**Default behavior is unchanged for existing users.** Without marker files, env var, or config entries, activation proceeds exactly as before. The new logic only runs when explicitly opted into.

`getProjectScope()` is exported from `caveman-config.js` in case other hooks (e.g., `caveman-mode-tracker.js`) want to honor the same gating in the future — not wired in here to keep the diff minimal.

## Tests

- 7 new cases in `tests/test_project_scope.py` covering all six resolution branches plus the default-on case.
- Full suite: 26 tests, all green (19 existing + 7 new).

```
$ python3 -m unittest discover tests
Ran 26 tests in 0.512s
OK
```

## Example config

```json
{
  "defaultMode": "full",
  "projectScope": {
    "deny": ["/Users/me/work/client-xyz"],
    "allow": ["/Users/me/code/flow", "/Users/me/code/api"]
  }
}
```

Marker files (zero-byte sentinels in the project root) are usually enough; the config-driven lists are for users who want centralized control across many repos.

## Out of scope (intentional)

- Walking up parent directories for marker files — kept to CWD-only for cheap detection and explicit semantics.
- Honoring scope in `caveman-mode-tracker.js` (the UserPromptSubmit hook). Could be a follow-up if there's appetite; for this PR I wanted the diff to be focused on the SessionStart entrypoint.

Happy to revise scope (rename markers, drop env var, drop allowlist support, etc.) — wanted to put the full design forward to start the conversation.