### PR TITLE
fix(install): rename $Args to $InstallerArgs in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -17,7 +17,7 @@
 [CmdletBinding()]
 param(
   [Parameter(ValueFromRemainingArguments = $true)]
-  [string[]]$Args
+  [string[]]$InstallerArgs
 )
 
 $ErrorActionPreference = "Stop"
@@ -44,7 +44,7 @@ if ($nodeMajor -lt 18) {
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $local = Join-Path $here "bin/install.js"
 if (Test-Path $local) {
-  & node $local @Args
+  & node $local @InstallerArgs
   exit $LASTEXITCODE
 }
 
@@ -58,5 +58,5 @@ if (-not $npx) {
 # Do NOT pass `--` here — npm 7+ npx already forwards trailing args to the
 # package, and a literal `--` was tripping bin/install.js's parseArgs as an
 # unknown flag.
-& npx -y "github:$Repo" @Args
+& npx -y "github:$Repo" @InstallerArgs
 exit $LASTEXITCODE


### PR DESCRIPTION
## Summary

- `$Args` is a reserved automatic variable in PowerShell 7+ and cannot be declared as a `param` — causes `Cannot overwrite variable Args because the variable has been optimized` on install
- Renamed to `$InstallerArgs` in the `param` block and both usage sites (`@Args` → `@InstallerArgs`)

Fixes #366

## Test plan
- [ ] Run `irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 | iex` in PowerShell 7+ — should no longer throw the variable error
- [ ] Run with flags (e.g. `install.ps1 --only claude`) — args still forwarded correctly