### PR TITLE
fix(opencode): use correct plugin hooks (chat.message + system.transform)

### DIFF
--- a/src/plugins/opencode/plugin.js
+++ b/src/plugins/opencode/plugin.js
@@ -1,22 +1,29 @@
 // caveman — opencode plugin
 //
-// Mirrors the Claude Code SessionStart + UserPromptSubmit hook pair using
-// opencode's lifecycle hook system. Bun ESM module; loads the existing
-// security-hardened helpers from caveman-config.js via createRequire so the
-// symlink-safe flag-write code lives in one place.
+// Provides dynamic caveman mode tracking for opencode:
+// - Writes the mode flag on plugin initialization (session start)
+// - Parses user messages for /caveman commands and natural-language toggles
+// - Injects per-turn reinforcement into the system prompt
 //
 // Layout once installed:
 //   ~/.config/opencode/plugins/caveman/
 //   ├── package.json
 //   ├── plugin.js              ← this file
-//   └── caveman-config.js      ← copied sibling of src/hooks/caveman-config.js
+//   └── caveman-config.cjs     ← copied sibling of src/hooks/caveman-config.js
 //
-// Always-on caveman ruleset is provided separately via
-// ~/.config/opencode/AGENTS.md (Tier-3 base) so this plugin only handles
-// dynamic state — flag writes, slash-command parsing, natural-language
-// activation, and per-prompt reinforcement. opencode's `session.created`
-// payload doesn't expose a documented system-prompt-injection return, so we
-// don't try to emit ruleset content here.
+// The always-on caveman ruleset is provided separately via
+// ~/.config/opencode/AGENTS.md (Tier-3 base). This plugin handles dynamic
+// state only: flag writes, slash-command parsing, natural-language
+// activation, and per-turn reinforcement.
+//
+// Hook mapping (opencode >=1.15.x):
+//   - Plugin factory: session initialization (runs once at load)
+//   - chat.message: intercept user prompts for mode changes
+//   - experimental.chat.system.transform: inject reinforcement per-turn
+//
+// Note: opencode does NOT support 'session.created' or 'tui.prompt.append'
+// as named plugin hooks. Those exist as internal bus events only. See:
+// https://github.com/JuliusBrussee/caveman/issues/418
 
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
@@ -37,7 +44,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 // either way.
 function loadConfig() {
   try { return require(join(here, 'caveman-config.cjs')); }
-  catch (_) { return require(join(here, '..', '..', 'hooks', 'caveman-config.js')); }
+  catch (e) {
+    if (e.code !== 'MODULE_NOT_FOUND') throw e;
+    return require(join(here, '..', '..', 'hooks', 'caveman-config.js'));
+  }
 }
 const config = loadConfig();
 
@@ -122,33 +132,42 @@ function applyModeChange(mode) {
   safeWriteFlag(flagPath, mode);
 }
 
-export const CavemanPlugin = async (_ctx) => ({
-  'session.created': async () => {
-    const mode = getDefaultMode();
-    if (mode === 'off') {
-      try { if (existsSync(flagPath)) unlinkSync(flagPath); } catch (e) {}
-      return;
-    }
+export const CavemanPlugin = async (_ctx) => {
+  // Initialize flag at plugin load time (equivalent to session start).
+  // The factory runs once per opencode session — this is the correct place
+  // for session-init logic since opencode does not expose a 'session.created'
+  // hook to plugins.
+  const mode = getDefaultMode();
+  if (mode === 'off') {
+    try { if (existsSync(flagPath)) unlinkSync(flagPath); } catch (e) {}
+  } else {
     safeWriteFlag(flagPath, mode);
-  },
+  }
 
-  // opencode's TUI prompt-append hook fires before the prompt is sent to the
-  // model. We use it for two things: react to mode-changing prompts (slash
-  // commands + natural language), and append a one-line reinforcement when
-  // caveman is active so the model can't drift mid-session. Returning an
-  // object with `append` is the documented way to inject prompt content.
-  'tui.prompt.append': async (input) => {
-    const promptText = (input && (input.prompt || input.text)) || '';
+  return {
+    // Intercept user messages to detect /caveman commands and
+    // natural-language mode toggles. opencode fires chat.message with
+    // (input, output) where output.parts contains the message text parts.
+    'chat.message': async (_input, output) => {
+      if (!output || !output.parts) return;
+      for (const part of output.parts) {
+        if (part && part.type === 'text' && part.text) {
+          const change = parseModeChange(part.text);
+          if (change) applyModeChange(change);
+        }
+      }
+    },
 
-    const change = parseModeChange(promptText);
-    if (change) applyModeChange(change);
-
-    const active = readFlag(flagPath);
-    if (active && !INDEPENDENT_MODES.has(active)) {
-      return { append: reinforcementLine(active) };
-    }
-    return undefined;
-  },
-});
+    // Inject reinforcement line into system prompt when caveman is active.
+    // This fires before every LLM call via plugin.trigger(), ensuring the
+    // model stays in mode even across long sessions.
+    'experimental.chat.system.transform': async (_input, output) => {
+      const active = readFlag(flagPath);
+      if (active && !INDEPENDENT_MODES.has(active)) {
+        output.system.push(reinforcementLine(active));
+      }
+    },
+  };
+};
 
 export default CavemanPlugin;

--- a/tests/installer/opencode.test.mjs
+++ b/tests/installer/opencode.test.mjs
@@ -248,7 +248,7 @@ test('opencode uninstall removes plugin dir, command/agent/skill files, prunes o
 });
 
 // ── 5. Plugin smoke: load installed plugin.js, fire fake hooks ────────────
-test('opencode plugin handles /caveman ultra and stop caveman via tui.prompt.append', async () => {
+test('opencode plugin handles /caveman ultra and stop caveman via chat.message', async () => {
   const xdg = freshTmpDir();
   const shimDir = shimOpencode();
   try {
@@ -264,22 +264,29 @@ test('opencode plugin handles /caveman ultra and stop caveman via tui.prompt.app
 
     const mod = await import(pathToFileURL(pluginPath).href);
     const factory = mod.default || mod.CavemanPlugin;
+
+    // Factory initializes the flag (equivalent to session start)
     const handlers = await factory({});
-
-    // Slash command activates ultra
-    const out1 = await handlers['tui.prompt.append']({ prompt: '/caveman ultra' });
-    assert.equal(fs.readFileSync(flagPath, 'utf8'), 'ultra');
-    assert.ok(out1 && typeof out1.append === 'string', 'expected reinforcement append');
-    assert.match(out1.append, /CAVEMAN MODE ACTIVE \(ultra\)/);
-
-    // Natural-language deactivation removes flag
-    const out2 = await handlers['tui.prompt.append']({ prompt: 'stop caveman please' });
-    assert.equal(fs.existsSync(flagPath), false, 'flag should be deleted after deactivation');
-    assert.equal(out2, undefined, 'no reinforcement when flag absent');
-
-    // session.created writes default mode
-    await handlers['session.created']();
     assert.equal(fs.readFileSync(flagPath, 'utf8'), 'full');
+
+    // Slash command activates ultra via chat.message
+    await handlers['chat.message']({}, { parts: [{ type: 'text', text: '/caveman ultra' }] });
+    assert.equal(fs.readFileSync(flagPath, 'utf8'), 'ultra');
+
+    // System transform injects reinforcement when active
+    const system = { system: [] };
+    await handlers['experimental.chat.system.transform']({}, system);
+    assert.ok(system.system.length > 0, 'expected system prompt injection');
+    assert.match(system.system[0], /CAVEMAN MODE ACTIVE \(ultra\)/);
+
+    // Natural-language deactivation removes flag via chat.message
+    await handlers['chat.message']({}, { parts: [{ type: 'text', text: 'stop caveman please' }] });
+    assert.equal(fs.existsSync(flagPath), false, 'flag should be deleted after deactivation');
+
+    // System transform does not inject when inactive
+    const system2 = { system: [] };
+    await handlers['experimental.chat.system.transform']({}, system2);
+    assert.equal(system2.system.length, 0, 'no injection when inactive');
   } finally {
     fs.rmSync(xdg, { recursive: true, force: true });
     fs.rmSync(shimDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

The opencode plugin registers `session.created` and `tui.prompt.append` as named hook keys, but opencode's plugin API (`@opencode-ai/plugin` `Hooks` interface) does not support these as trigger-able hooks. They exist as internal bus events only — the plugin system never dispatches them to user plugins.

**Result**: the flag file is never written and per-turn reinforcement never fires. Caveman is effectively dead on opencode despite the plugin loading successfully.

## Root cause

opencode's `plugin.trigger(name, input, output)` only dispatches to hooks defined in the `Hooks` interface:
- `chat.message`, `chat.params`, `chat.headers`
- `tool.execute.before` / `tool.execute.after`
- `shell.env`
- `experimental.chat.system.transform`
- `experimental.session.compacting`
- etc.

`session.created` and `tui.prompt.append` are NOT in this list.

Additionally, the trigger pattern is `(input, output) => Promise<void>` with **mutation on output** — return values are discarded. The old code returned `{ append: ... }` which was silently ignored.

## Fix

| Old (broken) | New (working) |
|---|---|
| `session.created` hook | Plugin factory body (runs once at load) |
| `tui.prompt.append` returning `{ append }` | `chat.message` for mode detection + `experimental.chat.system.transform` for injection |

## Testing

- ✅ Tested with opencode 1.15.4 on Linux via `opencode run` headless mode
- ✅ Flag initialization on session start
- ✅ `/caveman ultra` mode switching
- ✅ `stop caveman` natural-language deactivation
- ✅ System prompt reinforcement injection
- ✅ Updated unit test passes

Closes #418