### PR TITLE
fix(compress): store .original.md backups outside source directory

### DIFF
--- a/skills/caveman-compress/scripts/cli.py
+++ b/skills/caveman-compress/scripts/cli.py
@@ -64,7 +64,8 @@ def main():
 
         if success:
             print("\nCompression completed successfully")
-            backup_path = filepath.with_name(filepath.stem + ".original.md")
+            _backup_dir = Path.home() / ".local" / "share" / "caveman-compress" / "backups" / filepath.parent.name
+            backup_path = _backup_dir / (filepath.stem + ".original.md")
             print(f"Compressed: {filepath}")
             print(f"Original:   {backup_path}")
             sys.exit(0)

--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -180,7 +180,11 @@ def compress_file(filepath: Path) -> bool:
         return False
 
     original_text = filepath.read_text(errors="ignore")
-    backup_path = filepath.with_name(filepath.stem + ".original.md")
+    # Store backup outside the source directory so auto-loaders (e.g. Claude
+    # Code rules/, opencode instructions/) don't pick it up as a live file.
+    _backup_dir = Path.home() / ".local" / "share" / "caveman-compress" / "backups" / filepath.parent.name
+    _backup_dir.mkdir(parents=True, exist_ok=True)
+    backup_path = _backup_dir / (filepath.stem + ".original.md")
 
     if not original_text.strip():
         print("❌ Refusing to compress: file is empty or whitespace-only.")


### PR DESCRIPTION
## Problem

When `caveman-compress` runs on a file inside `~/.claude/rules/` or `~/.config/opencode/instructions/`, it saves the backup as `<filename>.original.md` **in the same directory**.

Both Claude Code and Opencode auto-load **every `*.md`** in those directories as live rules/instructions. The backup gets injected as an active rule every session — wasting ~2–4k tokens with no value.

Example: compressing `~/.claude/rules/qdrant-triggers.md` (2.2k tokens) leaves `qdrant-triggers.original.md` (2.3k tokens) auto-loaded alongside it.

## Fix

Redirect backups to `~/.local/share/caveman-compress/backups/<parent-dir-name>/` — outside any auto-loader scope. Directory is created on first use.

```
~/.local/share/caveman-compress/backups/
  rules/
    qdrant-triggers.original.md
    infra-safety.original.md
  instructions/
    qdrant-triggers.original.md
```

The `<parent-dir-name>` segment preserves enough context to find the original source without cluttering live config dirs.

## Files changed

- `skills/caveman-compress/scripts/compress.py` — backup path calculation
- `skills/caveman-compress/scripts/cli.py` — backup path display