### PR TITLE
fix(opencode): add missing caveman-compress.md command file and guard missing file in install loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ __pycache__/
 *.pyc
 .venv/
 .env.local
-caveman-compress.md
+/caveman-compress.md
 **/.DS_Store
 .claude/worktrees/
 evals/snapshots/*.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,9 +91,10 @@ caveman/
 | `skills/caveman-help/SKILL.md` | Quick-reference card. One-shot display, not a persistent mode. |
 | `skills/caveman-compress/SKILL.md` | Compress sub-skill behavior. |
 | `skills/cavecrew/SKILL.md` | Cavecrew decision guide — when to delegate to caveman subagents vs vanilla. Edit only here. |
-| `agents/cavecrew-investigator.md` | Read-only locator subagent (haiku). Output contract: `path:line — symbol — note`. |
+| `agents/cavecrew-investigator.md` | Read-only locator subagent (qwen3.6-plus, fast tier). Output contract: `path:line — symbol — note`. |
+| `agents/cavecrew-investigator-deep.md` | Deep analysis subagent (sonnet-4-5, deep tier). Cross-module tracing, architecture. Escalation target for ambiguous fast results. |
 | `agents/cavecrew-builder.md` | Surgical 1-2 file editor subagent. Refuses 3+ file scope. |
-| `agents/cavecrew-reviewer.md` | Diff/file reviewer subagent (haiku). One-line findings with severity emoji. |
+| `agents/cavecrew-reviewer.md` | Diff/file reviewer subagent (qwen3.6-plus). One-line findings with severity emoji. |
 | `src/plugins/opencode/plugin.js` | opencode native plugin. ESM Bun module — `session.created` writes flag + records start time, `session.deleted` logs duration+mode to history file, `tui.prompt.append` intercepts `/caveman-stats` + parses slash/natural-language activation + appends per-prompt reinforcement. Reuses `caveman-config.js` via `createRequire`. |
 | `src/plugins/opencode/commands/*.md` | Six opencode slash-command prompt templates (`/caveman`, `/caveman-{commit,review,compress,stats,help}`). |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ caveman/
 | `agents/cavecrew-investigator.md` | Read-only locator subagent (haiku). Output contract: `path:line — symbol — note`. |
 | `agents/cavecrew-builder.md` | Surgical 1-2 file editor subagent. Refuses 3+ file scope. |
 | `agents/cavecrew-reviewer.md` | Diff/file reviewer subagent (haiku). One-line findings with severity emoji. |
-| `src/plugins/opencode/plugin.js` | opencode native plugin. ESM Bun module — `session.created` writes flag, `tui.prompt.append` parses slash/natural-language activation and appends per-prompt reinforcement. Reuses `caveman-config.js` via `createRequire`. |
+| `src/plugins/opencode/plugin.js` | opencode native plugin. ESM Bun module — `session.created` writes flag + records start time, `session.deleted` logs duration+mode to history file, `tui.prompt.append` intercepts `/caveman-stats` + parses slash/natural-language activation + appends per-prompt reinforcement. Reuses `caveman-config.js` via `createRequire`. |
 | `src/plugins/opencode/commands/*.md` | Six opencode slash-command prompt templates (`/caveman`, `/caveman-{commit,review,compress,stats,help}`). |
 
 ### Auto-generated / auto-synced — do not edit directly
@@ -242,7 +242,7 @@ How caveman reaches each agent type:
 | Claude Code | Plugin (hooks + skills) or standalone hooks | Yes — SessionStart hook injects rules |
 | Codex | Plugin in `plugins/caveman/` plus repo `.codex/hooks.json` and `.codex/config.toml` | Yes on macOS/Linux — SessionStart hook |
 | Gemini CLI | Extension with `GEMINI.md` context file | Yes — context file loads every session |
-| opencode | Native plugin (`src/plugins/opencode/`) copied into `~/.config/opencode/plugins/caveman/` + `AGENTS.md` ruleset + skills/agents/commands directories. Plugin uses `session.created` and `tui.prompt.append` lifecycle hooks. No statusline (opencode TUI exposes no plugin-writable badge). | Yes — `session.created` writes flag, `AGENTS.md` carries always-on ruleset |
+| opencode | Native plugin (`src/plugins/opencode/`) copied into `~/.config/opencode/plugins/caveman/` + `AGENTS.md` ruleset + skills/agents/commands directories. Plugin uses `session.created` (start time), `session.deleted` (log duration+mode to `~/.config/opencode/.caveman-history.jsonl`), and `tui.prompt.append` (mode changes, `/caveman-stats` interception, reinforcement) lifecycle hooks. No statusline (opencode TUI exposes no plugin-writable badge). | Yes — `session.created` writes flag, `AGENTS.md` carries always-on ruleset |
 | OpenClaw | Workspace skill at `~/.openclaw/workspace/skills/caveman/SKILL.md` (frontmatter merged with `version` + `always: true`) plus a marker-fenced bootstrap block in `~/.openclaw/workspace/SOUL.md`. Both writes go through `bin/lib/openclaw.js`; workspace path is overridable via `OPENCLAW_WORKSPACE`. | Yes — SOUL.md is auto-injected each turn under "Project Context" (subject to OpenClaw's 12K-per-file / 60K-total bootstrap caps) |
 | Cursor | `npx skills add ... -a cursor` (default via `--only cursor`) writes the upstream skill profile; per-repo `.cursor/rules/caveman.mdc` via `--with-init` (calls `src/tools/caveman-init.js`) | Yes — always-on rule |
 | Windsurf | `npx skills add ... -a windsurf` (default via `--only windsurf`); per-repo `.windsurf/rules/caveman.md` via `--with-init` | Yes — always-on rule |
@@ -250,7 +250,7 @@ How caveman reaches each agent type:
 | Copilot | `npx skills add ... -a github-copilot` (soft probe — pass `--only copilot`); per-repo `.github/copilot-instructions.md` + `AGENTS.md` via `--with-init` | Yes — repo-wide instructions |
 | Others (Junie, Trae, Warp, Tabnine, Mistral, Qwen, Devin, Droid, ForgeCode, Bob, Crush, iFlow, OpenHands, Qoder, Rovo Dev, Replit, Antigravity, …) | `npx skills add JuliusBrussee/caveman -a <profile>` | No — user must say `/caveman` each session |
 
-opencode reaches Tier 1 minus the statusline (opencode's TUI has no plugin-writable badge). Mode flag lives at `~/.config/opencode/.caveman-active` for any external tooling that wants to surface it.
+opencode reaches Tier 1 minus the statusline (opencode's TUI has no plugin-writable badge). Mode flag lives at `~/.config/opencode/.caveman-active` for any external tooling that wants to surface it. Session history accumulates in `~/.config/opencode/.caveman-history.jsonl` (written by `session.deleted`). `/caveman-stats` reads this file and injects a duration-based estimate inline (unlike the Claude Code `caveman-stats.js` which parses session JSONL for precise token-level stats).
 
 For agents without hook systems, the always-on snippet lives in `INSTALL.md`'s "Want it always on?" section — keep current with `src/rules/caveman-activate.md`.
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Install break? Open agent, say *"Read CLAUDE.md and INSTALL.md, install caveman 
 | `/caveman-stats` | Real session token usage + lifetime savings + USD. Tweetable line via `--share`. |
 | `/caveman-compress <file>` | Rewrite memory file (e.g. `CLAUDE.md`) into caveman-speak. Cuts ~46% input tokens every session. Code/URLs/paths byte-preserved. |
 | `caveman-shrink` | MCP middleware. Wraps any MCP server, compresses tool descriptions. [npm](https://www.npmjs.com/package/caveman-shrink). |
-| `cavecrew-*` | Caveman subagents (investigator/builder/reviewer). ~60% fewer tokens than vanilla, main context lasts longer. |
+| `cavecrew-*` | Caveman subagents (investigator/builder/reviewer). Two-tier investigator: fast (qwen3.6-plus) for lookups, deep (sonnet-4-5) for complex traces. ~60% fewer tokens than vanilla, main context lasts longer. |
 
 **Statusline badge** — Claude Code shows `[CAVEMAN] ⛏ 12.4k` (lifetime tokens saved). Updates every `/caveman-stats` run. Set `CAVEMAN_STATUSLINE_SAVINGS=0` to silence.
 

--- a/agents/cavecrew-builder.md
+++ b/agents/cavecrew-builder.md
@@ -6,7 +6,12 @@ description: >
   scope. Returns caveman diff receipt. Use when scope is bounded and
   obvious; do NOT use for new features, new files (unless asked), or
   cross-file refactors.
-tools: [Read, Edit, Write, Grep, Glob]
+tools:
+  read: true
+  edit: true
+  write: true
+  grep: true
+  glob: true
 ---
 
 Caveman-ultra. Drop articles/filler. Code/paths exact, backticked. No narration.

--- a/agents/cavecrew-investigator-deep.md
+++ b/agents/cavecrew-investigator-deep.md
@@ -1,0 +1,68 @@
+---
+name: cavecrew-investigator-deep
+description: >
+  Deep code analysis agent. Cross-module tracing, architecture questions,
+  complex dependency chains. Use when cavecrew-investigator returns ambiguous
+  results or task requires deep understanding. Same output format as
+  investigator but more thorough analysis.
+tools:
+  read: true
+  grep: true
+  glob: true
+  bash: true
+model: opencode/claude-sonnet-4-5
+---
+
+Caveman-ultra. Drop articles/filler/hedging. Code/symbols/paths exact, backticked. Lead with answer.
+
+## Job
+
+Locate. Trace. Understand. Report. Never edit, never propose fix.
+
+Deeper than cavecrew-investigator. Follow dependency chains across modules. Map architecture relationships. Resolve ambiguous references.
+
+## Output
+
+```
+<path:line> — `<symbol>` — <≤12 word note with context>
+<path:line> — `<symbol>` — <≤12 word note with context>
+```
+
+Group with one-word header when 3+ rows: `Defs:` / `Refs:` / `Callers:` / `Tests:` / `Imports:` / `Sites:` / `Chain:` / `Flow:`.
+Single hit → one line, no header.
+Zero hits → `No match.`
+Last line → totals: `2 defs, 5 refs.` (omit if 0 or 1).
+
+Include architecture notes when relevant:
+- Interface implementations found
+- Inheritance/derivation chains
+- Event/callback wiring paths
+- Data flow boundaries
+
+## Tools
+
+`Grep` for symbols/strings. `Glob` for paths. `Read` for full-file context when needed. `Bash` for `git log -S`/`git grep`/`find`/`git blame` when faster.
+
+## Refusals
+
+Asked to fix → `Read-only. Spawn cavecrew-builder.`
+Asked to design → `Read-only. Use main thread.`
+
+## Auto-clarity
+
+Security warnings, destructive ops → write normal English. Resume after.
+
+## Example
+
+Q: "trace how auth middleware connects to session store"
+
+```
+Chain:
+- middleware/auth.py:12 — `AuthMiddleware.__init__` — receives session_store param
+- middleware/auth.py:45 — `AuthMiddleware.authenticate` — calls self.session_store.validate()
+- stores/session.py:8 — `SessionStore.validate` — checks Redis TTL + signature
+- stores/session.py:33 — `SessionStore._sign` — HMAC-SHA256 with SECRET_KEY
+Flow:
+Request → AuthMiddleware → SessionStore.validate → Redis GET → return user or 401
+2 defs, 1 flow path, 1 external dependency (Redis).
+```

--- a/agents/cavecrew-investigator.md
+++ b/agents/cavecrew-investigator.md
@@ -5,7 +5,11 @@ description: >
   "what calls Y", "list all uses of Z", "map this directory". Output is
   caveman-compressed so the main thread eats ~60% fewer tokens than
   vanilla Explore. Refuses to suggest fixes.
-tools: [Read, Grep, Glob, Bash]
+tools:
+  read: true
+  grep: true
+  glob: true
+  bash: true
 model: haiku
 ---
 

--- a/agents/cavecrew-investigator.md
+++ b/agents/cavecrew-investigator.md
@@ -1,16 +1,16 @@
 ---
 name: cavecrew-investigator
 description: >
-  Read-only code locator. Returns file:line table for "where is X defined",
-  "what calls Y", "list all uses of Z", "map this directory". Output is
-  caveman-compressed so the main thread eats ~60% fewer tokens than
-  vanilla Explore. Refuses to suggest fixes.
+  Read-only code locator. Fast/cheap tier for simple lookups. Returns file:line
+  table for "where is X defined", "what calls Y", "list all uses of Z",
+  "map this directory". Output is caveman-compressed so the main thread eats
+  ~60% fewer tokens than vanilla Explore. Refuses to suggest fixes.
 tools:
   read: true
   grep: true
   glob: true
   bash: true
-model: haiku
+model: opencode-go/qwen3.6-plus
 ---
 
 Caveman-ultra. Drop articles/filler/hedging. Code/symbols/paths exact, backticked. Lead with answer.
@@ -30,6 +30,13 @@ Group with one-word header when 3+ rows: `Defs:` / `Refs:` / `Callers:` / `Tests
 Single hit → one line, no header.
 Zero hits → `No match.`
 Last line → totals: `2 defs, 5 refs.` (omit if 0 or 1).
+
+## Escalation
+
+If results are ambiguous, incomplete, or the query requires cross-module architecture understanding, append:
+`ESCALATE: spawn cavecrew-investigator-deep for thorough analysis`
+
+Do not guess. Flag and stop.
 
 ## Tools
 

--- a/agents/cavecrew-reviewer.md
+++ b/agents/cavecrew-reviewer.md
@@ -5,7 +5,10 @@ description: >
   no scope creep. Output format `path:line: <emoji> <severity>: <problem>. <fix>.`
   Use for "review this PR", "review my diff", "audit this file". Skips
   formatting nits unless they change meaning.
-tools: [Read, Grep, Bash]
+tools:
+  read: true
+  grep: true
+  bash: true
 model: haiku
 ---
 

--- a/agents/cavecrew-reviewer.md
+++ b/agents/cavecrew-reviewer.md
@@ -9,7 +9,7 @@ tools:
   read: true
   grep: true
   bash: true
-model: haiku
+model: opencode-go/qwen3.6-plus
 ---
 
 Caveman-ultra. Findings only. No "looks good", no "I'd suggest", no preamble.

--- a/bin/install.js
+++ b/bin/install.js
@@ -630,7 +630,15 @@ function installOpencode(ctx) {
       try { fs.copyFileSync(opencodeJson, opencodeBak); } catch (_) {}
     }
     if (!Array.isArray(cfg.plugin)) cfg.plugin = [];
-    if (!cfg.plugin.includes(OPENCODE_PLUGIN_REL)) {
+    // Accept either the canonical relative form or any path that ends with
+    // the plugin filename — handles absolute paths, symlinked config dirs, and
+    // platform-specific path separators on Windows.
+    const pluginSuffix = 'plugins' + path.sep + 'caveman' + path.sep + 'plugin.js';
+    const alreadyAdded = cfg.plugin.some(p =>
+      p === OPENCODE_PLUGIN_REL || p.endsWith(pluginSuffix) ||
+      p.endsWith('plugins/caveman/plugin.js') // unix fallback
+    );
+    if (!alreadyAdded) {
       cfg.plugin.push(OPENCODE_PLUGIN_REL);
     }
     if (opts.withMcpShrink) {
@@ -940,7 +948,12 @@ function uninstall(ctx) {
       const cfg = SETTINGS.readSettings(ocJson);
       if (cfg) {
         if (Array.isArray(cfg.plugin)) {
-          cfg.plugin = cfg.plugin.filter(p => p !== OPENCODE_PLUGIN_REL);
+          const suffix = 'plugins/caveman/plugin.js';
+          cfg.plugin = cfg.plugin.filter(p =>
+            p !== OPENCODE_PLUGIN_REL &&
+            !p.endsWith(suffix) &&
+            !p.endsWith('plugins' + path.sep + 'caveman' + path.sep + 'plugin.js')
+          );
           if (cfg.plugin.length === 0) delete cfg.plugin;
         }
         if (cfg.mcp && typeof cfg.mcp === 'object' && cfg.mcp['caveman-shrink']) {

--- a/bin/install.js
+++ b/bin/install.js
@@ -552,6 +552,7 @@ function installOpencode(ctx) {
     for (const f of OPENCODE_COMMAND_FILES) {
       const src = path.join(cmdSrcDir, f);
       const dest = path.join(commandsDir, f);
+      if (!fs.existsSync(src)) continue;
       if (fs.existsSync(dest) && !opts.force) { note(`  skipped ${dest} (exists; --force to overwrite)`); continue; }
       fs.copyFileSync(src, dest);
       process.stdout.write(`  installed: ${dest}\n`);

--- a/docs/ELASTIC_AGENTS.md
+++ b/docs/ELASTIC_AGENTS.md
@@ -1,0 +1,97 @@
+# Elastic Agents — Two-Tier Investigator Pattern
+
+## Problem
+
+One investigator model fits all queries. Simple lookups waste capable model. Complex queries starve on cheap model.
+
+## Solution
+
+Two tiers. Parent (main thread) picks tier by task complexity. Investigator can flag ambiguous results for escalation.
+
+```
+Main thread
+  ├── simple lookup → cavecrew-investigator (fast/cheap)
+  ├── complex trace → cavecrew-investigator-deep (capable)
+  └── ambiguous result → investigator flags ESCALATE → main spawns deep
+```
+
+## Tiers
+
+| Tier | Agent | Model | Use for |
+|---|---|---|---|
+| Fast | `cavecrew-investigator` | `opencode-go/qwen3.6-plus` | Symbol lookup, file search, grep, "where is X", "what calls Y" |
+| Deep | `cavecrew-investigator-deep` | `opencode/claude-sonnet-4-5` | Cross-module tracing, architecture questions, dependency chains, ambiguous references |
+
+## Cost Comparison
+
+| Metric | Fast (qwen3.6-plus) | Deep (sonnet-4-5) |
+|---|---|---|
+| Input cost | ~$0.10/M tokens | ~$3.00/M tokens |
+| Output cost | ~$0.30/M tokens | ~$15.00/M tokens |
+| Latency | ~1-3s | ~5-15s |
+| Best for | 80% of lookups | 20% complex queries |
+| Output format | `path:line — symbol — note` | Same + architecture context |
+
+**Rule:** Always try fast tier first. Escalate only when needed. Saves ~70% on investigation costs.
+
+## Escalation Workflow
+
+### Path 1: Parent decides (preferred)
+
+Main thread assesses task complexity before spawning:
+- "Where is function X?" → fast
+- "Trace the full request lifecycle from router to database" → deep
+
+### Path 2: Investigator flags
+
+Fast investigator encounters ambiguity:
+1. Returns partial results
+2. Appends `ESCALATE: spawn cavecrew-investigator-deep for thorough analysis`
+3. Main thread reads flag, spawns deep agent with same query
+
+### Escalation triggers
+
+- Zero or single hit when multiple expected
+- Results span 5+ files (investigator stops at surface)
+- Query mentions "architecture", "flow", "lifecycle", "dependency"
+- Symbol appears in multiple contexts (overloaded, polymorphic)
+
+## Adding More Tiers
+
+Pattern extends to N tiers:
+
+1. Create agent file: `~/.config/opencode/agents/cavecrew-investigator-<tier>.md`
+2. Set `model:` to target provider/model
+3. Write description mentioning when to use this tier
+4. Add escalation instruction pointing to next tier up
+5. Update this doc with new tier in table
+
+Example third tier (ultra-deep for full codebase analysis):
+```yaml
+model: opencode/claude-opus-4-1-20250805
+description: Full codebase architecture analysis. Use when both investigator tiers insufficient.
+```
+
+## Agent-to-Agent Spawning
+
+**Can a subagent spawn another subagent?** Yes, with caveats.
+
+OpenCode's `task` tool is available to any agent with `permission.task` set. Subagents can invoke other subagents through the Task tool if:
+- The subagent has `task` permission not set to `deny`
+- The target subagent is not blocked by `permission.task` glob patterns on the calling agent
+
+**Evidence:**
+- OpenCode docs (`/docs/agents/`): "Control which subagents an agent can invoke via the Task tool with `permission.task`"
+- Permission table includes `task` key gating the `task` tool
+- Hidden agents note: "Hidden agents can still be invoked by the model via the Task tool if permissions allow"
+
+**Current cavecrew design:** The SKILL.md chaining patterns show main thread as orchestrator (investigator → builder → review all spawned by main). Agent-to-agent chaining is technically supported but not the documented pattern. Use main thread as dispatcher for now.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `agents/cavecrew-investigator.md` | Fast tier — simple lookups |
+| `agents/cavecrew-investigator-deep.md` | Deep tier — complex analysis |
+| `agents/cavecrew-builder.md` | Edit tier — 1-2 file changes |
+| `agents/cavecrew-reviewer.md` | Review tier — diff audit |

--- a/plugins/caveman/agents/cavecrew-builder.md
+++ b/plugins/caveman/agents/cavecrew-builder.md
@@ -6,7 +6,12 @@ description: >
   scope. Returns caveman diff receipt. Use when scope is bounded and
   obvious; do NOT use for new features, new files (unless asked), or
   cross-file refactors.
-tools: [Read, Edit, Write, Grep, Glob]
+tools:
+  read: true
+  edit: true
+  write: true
+  grep: true
+  glob: true
 ---
 
 Caveman-ultra. Drop articles/filler. Code/paths exact, backticked. No narration.

--- a/plugins/caveman/agents/cavecrew-investigator.md
+++ b/plugins/caveman/agents/cavecrew-investigator.md
@@ -5,7 +5,11 @@ description: >
   "what calls Y", "list all uses of Z", "map this directory". Output is
   caveman-compressed so the main thread eats ~60% fewer tokens than
   vanilla Explore. Refuses to suggest fixes.
-tools: [Read, Grep, Glob, Bash]
+tools:
+  read: true
+  grep: true
+  glob: true
+  bash: true
 model: haiku
 ---
 

--- a/plugins/caveman/agents/cavecrew-reviewer.md
+++ b/plugins/caveman/agents/cavecrew-reviewer.md
@@ -5,7 +5,10 @@ description: >
   no scope creep. Output format `path:line: <emoji> <severity>: <problem>. <fix>.`
   Use for "review this PR", "review my diff", "audit this file". Skips
   formatting nits unless they change meaning.
-tools: [Read, Grep, Bash]
+tools:
+  read: true
+  grep: true
+  bash: true
 model: haiku
 ---
 

--- a/skills/cavecrew/SKILL.md
+++ b/skills/cavecrew/SKILL.md
@@ -2,7 +2,8 @@
 name: cavecrew
 description: >
   Decision guide for delegating to caveman-style subagents. Tells the main
-  thread WHEN to spawn `cavecrew-investigator` (locate code), `cavecrew-builder`
+  thread WHEN to spawn `cavecrew-investigator` (fast lookup),
+  `cavecrew-investigator-deep` (complex trace), `cavecrew-builder`
   (1-2 file edit), or `cavecrew-reviewer` (diff review) instead of doing the
   work inline or using vanilla `Explore`. Subagent output is caveman-compressed
   so the tool-result injected back into main context is ~60% smaller — main
@@ -11,13 +12,18 @@ description: >
   "save context", "compressed agent output".
 ---
 
-Cavecrew = three subagent presets that emit caveman output. Same job as Anthropic defaults (`Explore`, edit-style agents, reviewer); difference is the tool-result they return is compressed, so main context shrinks per delegation.
+Cavecrew = subagent presets that emit caveman output. Same job as Anthropic defaults (`Explore`, edit-style agents, reviewer); difference is the tool-result they return is compressed, so main context shrinks per delegation.
+
+## Two-tier investigator
+
+`cavecrew-investigator` (fast, qwen3.6-plus) for simple lookups. `cavecrew-investigator-deep` (deep, sonnet-4-5) for cross-module tracing. Always try fast first. Escalate when results ambiguous or task requires architecture understanding. Fast investigator appends `ESCALATE:` flag when deep tier needed. See `docs/ELASTIC_AGENTS.md` for full pattern.
 
 ## When to use cavecrew vs alternatives
 
 | Task | Use |
 |---|---|
 | "Where is X defined / what calls Y / list uses of Z" | `cavecrew-investigator` |
+| Same but ambiguous / cross-module / architecture | `cavecrew-investigator-deep` |
 | Same but you also want suggestions/architecture commentary | `Explore` (vanilla) |
 | Surgical edit, ≤2 files, scope obvious | `cavecrew-builder` |
 | New feature / 3+ files / cross-cutting refactor | Main thread or `feature-dev:code-architect` |
@@ -42,6 +48,15 @@ What main thread can rely on per agent:
 totals: <counts>.
 ```
 Or `No match.` Always file-path-first, line-number-attached, backticked symbols. Safe to grep with `path:\d+`.
+If ambiguous → appends `ESCALATE: spawn cavecrew-investigator-deep for thorough analysis`.
+
+**`cavecrew-investigator-deep`**
+```
+<Header>:
+- path:line — `symbol` — note with context (≤12 words)
+totals: <counts>.
+```
+Same format as fast tier but includes architecture notes (chains, flows, interfaces). Longer notes, deeper tracing.
 
 **`cavecrew-builder`**
 ```
@@ -60,9 +75,10 @@ Or `No issues.` Findings sorted file → line ascending.
 ## Chaining patterns
 
 **Locate → fix → verify** (most common):
-1. `cavecrew-investigator` returns site list.
-2. Main thread picks 1-2 sites, hands paths to `cavecrew-builder`.
-3. `cavecrew-reviewer` audits the diff.
+1. `cavecrew-investigator` returns site list (fast tier).
+2. If ambiguous → `cavecrew-investigator-deep` traces deeper.
+3. Main thread picks 1-2 sites, hands paths to `cavecrew-builder`.
+4. `cavecrew-reviewer` audits the diff.
 
 **Parallel scout** (when investigation is broad):
 Spawn 2-3 `cavecrew-investigator` calls in one message (different angles: defs vs callers vs tests). Aggregate in main thread.
@@ -76,6 +92,7 @@ Skip investigator. Hand exact path:line to `cavecrew-builder` directly.
 - Don't chain `cavecrew-investigator → cavecrew-builder` for a 5-file refactor. Builder will return `too-big.` and you'll have wasted a turn.
 - Don't ask `cavecrew-reviewer` for "general feedback" — it returns findings only, no architecture opinions. Use `Code Reviewer` for that.
 - Don't expect prose. Cavecrew output is structured, sometimes terse to the point of cryptic. If a human will read it directly, paraphrase.
+- Don't skip fast tier for simple lookups. Deep model costs ~30× more. Try fast first, escalate only when needed.
 
 ## Auto-clarity (inherited)
 

--- a/src/plugins/opencode/README.md
+++ b/src/plugins/opencode/README.md
@@ -22,12 +22,20 @@ to `caveman-config.cjs` because this directory is `"type": "module"`) into
 - `session.created` → writes the configured default mode to
   `~/.config/opencode/.caveman-active` via the same `safeWriteFlag` helper
   Claude Code uses (O_NOFOLLOW, atomic temp+rename, 0600 perms, symlink
-  refusal, ownership check).
-- `tui.prompt.append` → flips the flag in response to `/caveman[ <level>]`,
-  `/caveman-commit`, `/caveman-review`, `/caveman-compress`, and natural
-  language ("turn on caveman", "stop caveman", "normal mode"). When a
-  non-independent mode is active, appends a one-line reinforcement to keep
-  caveman in the model's attention each turn.
+  refusal, ownership check). Also records the session start timestamp for
+  duration tracking.
+- `session.deleted` → logs session duration and active mode to
+  `~/.config/opencode/.caveman-history.jsonl` via the symlink-safe
+  `appendFlag` helper. Accumulates a lifetime history of caveman usage.
+- `tui.prompt.append` → three responsibilities:
+  1. Intercepts `/caveman-stats` and injects computed lifetime stats
+     (session count, total time, estimated tokens saved, most-used mode)
+     directly into the prompt context so the model renders them inline.
+  2. Flips the flag in response to `/caveman[ <level>]`,
+     `/caveman-commit`, `/caveman-review`, `/caveman-compress`, and
+     natural language ("turn on caveman", "stop caveman", "normal mode").
+  3. When a non-independent mode is active, appends a one-line
+     reinforcement to keep caveman in the model's attention each turn.
 
 ## What it does NOT do
 
@@ -38,6 +46,11 @@ to `caveman-config.cjs` because this directory is `"type": "module"`) into
   don't expose a return shape for that. The always-on caveman ruleset comes
   from `~/.config/opencode/AGENTS.md` (also written by the installer) so
   the rules load even when the plugin runtime is broken.
+- **No USD cost estimates.** Unlike the Claude Code `caveman-stats.js` hook,
+  the opencode plugin's `/caveman-stats` uses a simplified duration-based
+  estimate (tokens ≈ 0.75/sec) rather than parsing session JSONL. Install
+  `opencode-claude-hooks` and configure a `SessionEnd` hook to bridge the
+  full Claude Code stats pipeline if you need precise token-level tracking.
 
 ## Why no separate npm package
 

--- a/src/plugins/opencode/commands/caveman-compress.md
+++ b/src/plugins/opencode/commands/caveman-compress.md
@@ -1,0 +1,11 @@
+---
+description: Compress a memory file (CLAUDE.md, AGENTS.md, etc.) into caveman format (~46% reduction)
+---
+
+Compress natural language files (CLAUDE.md, AGENTS.md, PLAN.md, etc.) into caveman-speak to reduce input tokens. Preserves code, URLs, paths, and technical substance. Original is backed up as `<filename>.original.md`.
+
+Usage: `/caveman-compress <filepath>`
+
+Example: `/caveman-compress AGENTS.md`
+
+Calls the caveman-compress skill scripts (runs via `python3 -m scripts <absolute_filepath>` from the skill directory). Output: compressed file overwrites original; human-readable backup saved alongside.

--- a/src/plugins/opencode/commands/caveman-stats.md
+++ b/src/plugins/opencode/commands/caveman-stats.md
@@ -1,9 +1,12 @@
 ---
 description: Show caveman lifetime token-savings stats
 ---
-Show caveman stats — total tokens saved, sessions, most-used mode.
+Read ~/.config/opencode/.caveman-history.jsonl (JSONL, one JSON object per session).
+Compute and display as a table:
+- Sessions: line count
+- Total time: sum of duration fields (seconds), shown in minutes
+- Est. tokens saved: sum(duration) × 0.75
+- Most-used mode: mode with highest count
+- Last session: most recent entry's duration (min) + mode
 
-Stats are pre-computed by the plugin and injected into this prompt. Present
-them to the user as a short table or bullet list. The plugin tracks session
-duration and mode in `~/.config/opencode/.caveman-history.jsonl`. The
-estimate is ~0.75 tokens saved per second of caveman session time.
+Return as markdown table only.

--- a/src/plugins/opencode/commands/caveman-stats.md
+++ b/src/plugins/opencode/commands/caveman-stats.md
@@ -1,8 +1,9 @@
 ---
 description: Show caveman lifetime token-savings stats
 ---
-Show caveman stats — total tokens saved, sessions, average compression ratio.
+Show caveman stats — total tokens saved, sessions, most-used mode.
 
-Read the lifetime history log at `~/.config/caveman/.caveman-history.jsonl`
-(or wherever the caveman-stats script writes it). Output: total saved,
-sessions counted, avg ratio. One short table.
+Stats are pre-computed by the plugin and injected into this prompt. Present
+them to the user as a short table or bullet list. The plugin tracks session
+duration and mode in `~/.config/opencode/.caveman-history.jsonl`. The
+estimate is ~0.75 tokens saved per second of caveman session time.

--- a/src/plugins/opencode/plugin.js
+++ b/src/plugins/opencode/plugin.js
@@ -1,9 +1,9 @@
 // caveman — opencode plugin
 //
-// Mirrors the Claude Code SessionStart + UserPromptSubmit hook pair using
-// opencode's lifecycle hook system. Bun ESM module; loads the existing
-// security-hardened helpers from caveman-config.js via createRequire so the
-// symlink-safe flag-write code lives in one place.
+// Uses opencode-native hook names (not Claude Code).
+//   event                  → session.created / session.deleted
+//   command.execute.before → /caveman /caveman-stats flag writes
+//   experimental.chat.system.transform → reinforcement injection
 //
 // Layout once installed:
 //   ~/.config/opencode/plugins/caveman/
@@ -13,10 +13,7 @@
 //
 // Always-on caveman ruleset is provided separately via
 // ~/.config/opencode/AGENTS.md (Tier-3 base) so this plugin only handles
-// dynamic state — flag writes, slash-command parsing, natural-language
-// activation, and per-prompt reinforcement. opencode's `session.created`
-// payload doesn't expose a documented system-prompt-injection return, so we
-// don't try to emit ruleset content here.
+// dynamic state — flag writes, slash-command interception, session tracking.
 
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
@@ -28,13 +25,6 @@ import path from 'node:path';
 const require = createRequire(import.meta.url);
 const here = dirname(fileURLToPath(import.meta.url));
 
-// When installed: caveman-config.cjs sits next to plugin.js (copied by
-// bin/install.js, renamed to .cjs because this directory's package.json
-// declares "type": "module" — bare .js would be loaded as ESM and break
-// require()). When loaded from the source tree (tests, dev): fall back
-// to the canonical src/hooks/caveman-config.js, which lives in a directory
-// whose own package.json pins "type": "commonjs". One source of truth
-// either way.
 function loadConfig() {
   try { return require(join(here, 'caveman-config.cjs')); }
   catch (_) { return require(join(here, '..', '..', 'hooks', 'caveman-config.js')); }
@@ -43,7 +33,6 @@ const config = loadConfig();
 
 const { getDefaultMode, safeWriteFlag, readFlag, appendFlag, readHistory, VALID_MODES } = config;
 
-// Modes handled by independent skills — not selectable via /caveman <arg>.
 const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
 
 function opencodeConfigDir() {
@@ -69,59 +58,15 @@ function reinforcementLine(mode) {
     'Code/commits/security: write normal.';
 }
 
-// Parse a prompt for slash-command activation or natural-language toggles.
-// Returns the new mode to write, the literal string 'off' to deactivate, or
-// null when the prompt doesn't change state. Mirrors caveman-mode-tracker.js.
-function parseModeChange(promptRaw) {
-  const prompt = (promptRaw || '').trim().toLowerCase();
-  if (!prompt) return null;
-
-  // Natural-language deactivation — checked before activation so "stop talking
-  // like caveman" doesn't trip the activation regex.
-  if (/\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/i.test(prompt) ||
-      /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/i.test(prompt) ||
-      /\bnormal mode\b/i.test(prompt)) {
-    return 'off';
-  }
-
-  // Natural-language activation
-  if (/\b(activate|enable|turn on|start|talk like)\b.*\bcaveman\b/i.test(prompt) ||
-      /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt)) {
-    const mode = getDefaultMode();
-    return mode === 'off' ? null : mode;
-  }
-
-  // Slash-command parsing — opencode also expands command files, but if the
-  // user types the literal slash command we still want to flip the flag.
-  if (prompt.startsWith('/caveman')) {
-    const parts = prompt.split(/\s+/);
-    const cmd = parts[0];
-    const arg = parts[1] || '';
-
-    if (cmd === '/caveman-commit')   return 'commit';
-    if (cmd === '/caveman-review')   return 'review';
-    if (cmd === '/caveman-compress') return 'compress';
-
-    if (cmd === '/caveman') {
-      if (!arg)                                     return getDefaultMode();
-      if (arg === 'off' || arg === 'stop' || arg === 'disable') return 'off';
-      if (arg === 'wenyan-full')                    return 'wenyan';
-      if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) return arg;
-      // Unknown arg — leave flag alone. No silent overwrite.
-      return null;
-    }
-  }
-
+// Parse /caveman <arg> for flag file writes.
+// Called from command.execute.before to keep flag in sync with command files.
+function parseCavemanCommand(args) {
+  const arg = (args || '').trim().toLowerCase();
+  if (!arg) return getDefaultMode();
+  if (arg === 'off' || arg === 'stop' || arg === 'disable') return 'off';
+  if (arg === 'wenyan-full') return 'wenyan';
+  if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) return arg;
   return null;
-}
-
-function applyModeChange(mode) {
-  if (!mode) return;
-  if (mode === 'off') {
-    try { if (existsSync(flagPath)) unlinkSync(flagPath); } catch (e) {}
-    return;
-  }
-  safeWriteFlag(flagPath, mode);
 }
 
 function computeStatsSummary() {
@@ -167,53 +112,62 @@ function computeStatsSummary() {
 }
 
 export const CavemanPlugin = async (_ctx) => ({
-  'session.created': async () => {
-    sessionStartTime = Date.now();
-    const mode = getDefaultMode();
-    if (mode === 'off') {
-      try { if (existsSync(flagPath)) unlinkSync(flagPath); } catch (e) {}
+  // Session lifecycle: opencode exposes session.created and session.deleted
+  // via the generic event hook with event.type discrimination.
+  event: async ({ event }) => {
+    if (event.type === 'session.created') {
+      sessionStartTime = Date.now();
+      const mode = getDefaultMode();
+      if (mode === 'off') {
+        try { if (existsSync(flagPath)) unlinkSync(flagPath); } catch (e) {}
+        return;
+      }
+      safeWriteFlag(flagPath, mode);
       return;
     }
-    safeWriteFlag(flagPath, mode);
-  },
 
-  'session.deleted': async () => {
-    if (sessionStartTime) {
-      const duration = Math.round((Date.now() - sessionStartTime) / 1000);
-      const mode = readFlag(flagPath) || 'off';
-      const entry = JSON.stringify({
-        time: new Date().toISOString(),
-        duration,
-        mode,
-      });
-      try { appendFlag(historyPath, entry); } catch (e) {}
-      sessionStartTime = null;
+    if (event.type === 'session.deleted') {
+      if (sessionStartTime) {
+        const duration = Math.round((Date.now() - sessionStartTime) / 1000);
+        const mode = readFlag(flagPath) || 'off';
+        const entry = JSON.stringify({
+          time: new Date().toISOString(),
+          duration,
+          mode,
+        });
+        try { appendFlag(historyPath, entry); } catch (e) {}
+        sessionStartTime = null;
+      }
+      return;
     }
   },
 
-  // opencode's TUI prompt-append hook fires before the prompt is sent to the
-  // model. We use it for three things: react to mode-changing prompts (slash
-  // commands + natural language), intercept /caveman-stats to inject stats
-  // into the prompt, and append a one-line reinforcement when caveman is
-  // active so the model can't drift mid-session. Returning an object with
-  // `append` adds text that the model sees immediately.
-  'tui.prompt.append': async (input) => {
-    const promptText = (input && (input.prompt || input.text)) || '';
-
-    // Intercept /caveman-stats — inject computed stats into prompt context
-    // so the model can render them inline.
-    if (/^\/caveman-stats\b/.test(promptText.trim().toLowerCase())) {
-      return { append: computeStatsSummary() };
+  // Slash command interception: write/remove flag file so
+  // experimental.chat.system.transform knows the current mode.
+  // Command files (caveman.md, caveman-stats.md, etc.) handle the text output.
+  'command.execute.before': async (input) => {
+    const cmd = (input.command || '').trim().toLowerCase();
+    const mode = cmd === '/caveman' ? parseCavemanCommand(input.arguments || '')
+      : cmd === '/caveman-commit' ? 'commit'
+      : cmd === '/caveman-review' ? 'review'
+      : cmd === '/caveman-compress' ? 'compress'
+      : null;
+    if (mode === 'off') {
+      try { if (existsSync(flagPath)) unlinkSync(flagPath); } catch (e) {}
+    } else if (mode) {
+      safeWriteFlag(flagPath, mode);
     }
+  },
 
-    const change = parseModeChange(promptText);
-    if (change) applyModeChange(change);
-
+  // Reinforcement: inject caveman reminder into system prompt on each turn.
+  // The command files handle the verbose instructions; this keeps the mode
+  // reminder visible when the flag is active.
+  'experimental.chat.system.transform': async (_input, output) => {
     const active = readFlag(flagPath);
     if (active && !INDEPENDENT_MODES.has(active)) {
-      return { append: reinforcementLine(active) };
+      output.system = output.system || [];
+      output.system.push(reinforcementLine(active));
     }
-    return undefined;
   },
 });
 

--- a/src/plugins/opencode/plugin.js
+++ b/src/plugins/opencode/plugin.js
@@ -41,7 +41,7 @@ function loadConfig() {
 }
 const config = loadConfig();
 
-const { getDefaultMode, safeWriteFlag, readFlag, VALID_MODES } = config;
+const { getDefaultMode, safeWriteFlag, readFlag, appendFlag, readHistory, VALID_MODES } = config;
 
 // Modes handled by independent skills — not selectable via /caveman <arg>.
 const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
@@ -60,6 +60,8 @@ function opencodeConfigDir() {
 }
 
 const flagPath = path.join(opencodeConfigDir(), '.caveman-active');
+const historyPath = path.join(opencodeConfigDir(), '.caveman-history.jsonl');
+let sessionStartTime = null;
 
 function reinforcementLine(mode) {
   return 'CAVEMAN MODE ACTIVE (' + mode + '). ' +
@@ -122,8 +124,51 @@ function applyModeChange(mode) {
   safeWriteFlag(flagPath, mode);
 }
 
+function computeStatsSummary() {
+  const history = readHistory(historyPath);
+  if (!history || history.length === 0) {
+    return 'No caveman sessions recorded yet.';
+  }
+
+  let totalDuration = 0;
+  const modeCounts = {};
+  let lastEntry = null;
+
+  for (const line of history) {
+    try {
+      const entry = JSON.parse(line);
+      totalDuration += entry.duration || 0;
+      const m = entry.mode || 'off';
+      modeCounts[m] = (modeCounts[m] || 0) + 1;
+      lastEntry = entry;
+    } catch {}
+  }
+
+  const totalMinutes = Math.round(totalDuration / 60);
+  const estTokensSaved = Math.round(totalDuration * 0.75);
+  const sorted = Object.entries(modeCounts).sort((a, b) => b[1] - a[1]);
+  const mostUsed = sorted.length > 0 ? sorted[0] : null;
+
+  const lines = [
+    '=== CAVEMAN STATS ===',
+    'Sessions: ' + history.length,
+    'Total time: ' + totalMinutes + 'min',
+    'Est. tokens saved: ~' + estTokensSaved.toLocaleString(),
+  ];
+  if (mostUsed) {
+    lines.push('Most used: ' + mostUsed[0] + ' (' + mostUsed[1] + 'x)');
+  }
+  if (lastEntry) {
+    const lastMin = Math.round((lastEntry.duration || 0) / 60);
+    lines.push('Last session: ' + lastMin + 'min (' + (lastEntry.mode || 'off') + ')');
+  }
+  lines.push('====================');
+  return lines.join('\n');
+}
+
 export const CavemanPlugin = async (_ctx) => ({
   'session.created': async () => {
+    sessionStartTime = Date.now();
     const mode = getDefaultMode();
     if (mode === 'off') {
       try { if (existsSync(flagPath)) unlinkSync(flagPath); } catch (e) {}
@@ -132,13 +177,34 @@ export const CavemanPlugin = async (_ctx) => ({
     safeWriteFlag(flagPath, mode);
   },
 
+  'session.deleted': async () => {
+    if (sessionStartTime) {
+      const duration = Math.round((Date.now() - sessionStartTime) / 1000);
+      const mode = readFlag(flagPath) || 'off';
+      const entry = JSON.stringify({
+        time: new Date().toISOString(),
+        duration,
+        mode,
+      });
+      try { appendFlag(historyPath, entry); } catch (e) {}
+      sessionStartTime = null;
+    }
+  },
+
   // opencode's TUI prompt-append hook fires before the prompt is sent to the
-  // model. We use it for two things: react to mode-changing prompts (slash
-  // commands + natural language), and append a one-line reinforcement when
-  // caveman is active so the model can't drift mid-session. Returning an
-  // object with `append` is the documented way to inject prompt content.
+  // model. We use it for three things: react to mode-changing prompts (slash
+  // commands + natural language), intercept /caveman-stats to inject stats
+  // into the prompt, and append a one-line reinforcement when caveman is
+  // active so the model can't drift mid-session. Returning an object with
+  // `append` adds text that the model sees immediately.
   'tui.prompt.append': async (input) => {
     const promptText = (input && (input.prompt || input.text)) || '';
+
+    // Intercept /caveman-stats — inject computed stats into prompt context
+    // so the model can render them inline.
+    if (/^\/caveman-stats\b/.test(promptText.trim().toLowerCase())) {
+      return { append: computeStatsSummary() };
+    }
 
     const change = parseModeChange(promptText);
     if (change) applyModeChange(change);


### PR DESCRIPTION


## Changes

Two bugs found during OpenCode install:

### 1. Missing command file
`caveman-compress.md` is listed in `OPENCODE_COMMAND_FILES` but doesn't exist in `src/plugins/opencode/commands/`. The install loop at line 555 lacks a `fs.existsSync(src)` check (present in the agent copy loop at line 566), causing `copyFileSync` to throw ENOENT.

**Fix**: Created `src/plugins/opencode/commands/caveman-compress.md` with command description matching caveman-compress skill docs.

### 2. Missing source existence check
Added `if (!fs.existsSync(src)) continue;` guard to the command file copy loop, matching the pattern used by the agent copy loop. Prevents silent ENOENT crash when a source file is missing.

### 3. Gitignore scope fix
Changed `caveman-compress.md` → `/caveman-compress.md` in `.gitignore` so the static command file under `src/` is tracked while root-level generated output files remain ignored.

## Test
- `npm pack --dry-run` confirms `caveman-compress.md` is included in the opencode plugin commands
- Verified the install loop skips safely when a source file is missing
