### PR TITLE
fix(compress): resolve claude binary via shutil.which for Windows .cmd shims

### DIFF
--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -8,6 +8,7 @@ Usage:
 
 import os
 import re
+import shutil
 import subprocess
 from pathlib import Path
 from typing import List
@@ -87,10 +88,15 @@ def call_claude(prompt: str) -> str:
             return strip_llm_wrapper(msg.content[0].text.strip())
         except ImportError:
             pass  # anthropic not installed, fall back to CLI
-    # Fallback: use claude CLI (handles desktop auth)
+    # Fallback: use claude CLI (handles desktop auth).
+    # Resolve binary via shutil.which so Windows .cmd/.bat shims (e.g.
+    # %APPDATA%\npm\claude.CMD) work without shell=True. On POSIX,
+    # shutil.which returns the same absolute path as the implicit lookup,
+    # so this is a no-op there.
+    claude_bin = shutil.which("claude") or "claude"
     try:
         result = subprocess.run(
-            ["claude", "--print"],
+            [claude_bin, "--print"],
             input=prompt,
             text=True,
             capture_output=True,


### PR DESCRIPTION
## Summary

`caveman-compress` fails on Windows 11 with `WinError 2: file not found` when invoking the `claude` CLI fallback. Cause: `npm install -g @anthropic-ai/claude-code` puts a `claude.CMD` shim on PATH, and Python's `subprocess.run(["claude", ...])` does not consult PATHEXT, so a bare `"claude"` argv entry never resolves on Windows.

This silently breaks the documented "CLI fallback uses your existing Claude Code desktop auth" path for any Windows user without an `ANTHROPIC_API_KEY` set — which is most Claude Code subscribers.

## Fix

Resolve the binary via `shutil.which("claude")`. On Windows, `shutil.which` consults PATHEXT and returns the full path to `claude.CMD`. On POSIX, it returns the same absolute path the implicit lookup would produce, so behavior is unchanged. No `shell=True`, no string interpolation, no injection surface change.

```diff
+import shutil
 ...
+claude_bin = shutil.which("claude") or "claude"
 result = subprocess.run(
-    ["claude", "--print"],
+    [claude_bin, "--print"],
     input=prompt,
     ...
 )
```

## Test plan

- [x] Reproduced original failure on Win11 (`WinError 2` from `subprocess.run(["claude", ...])`)
- [x] Patched, ran `python3 -m scripts <12KB markdown>` end-to-end
- [x] subprocess exit 0, validation passed first attempt, backup written
- [x] Content integrity verified: 32/32 trigger phrases preserved, 47/47 markdown links preserved, headings + code blocks + inline backticks intact
- [ ] Maintainer to confirm POSIX behavior unchanged (should be a no-op there)

Discovered while running ClawGuard audit + dry-run on a memory file under a Claude Code subscription (no `ANTHROPIC_API_KEY` set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)