### PR TITLE
fix(install): use --skill '*' instead of --all in per-agent skills install

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -449,7 +449,7 @@ function installViaSkills(ctx, prov) {
   // and our installer happily reports success. See issue #370.
   // We've already decided which agent to install for via auto-detect / --only;
   // making the user re-select 7 skills inside skills CLI would be redundant.
-  const args = ['-y', 'skills', 'add', REPO, '-a', prov.profile, '--yes', '--all'];
+  const args = ['-y', 'skills', 'add', REPO, '--skill', '*', '-a', prov.profile, '--yes'];
   const r = runSpawn('npx', args, null, opts.dryRun);
   if ((r.status || 0) === 0) results.installed.push(prov.id);
   else results.failed.push([prov.id, `npx skills add (${prov.profile}) failed`]);


### PR DESCRIPTION
## What

The `--all` flag in the `npx skills add` CLI installs all skills to all agents, not just the one selected by `-a`. This caused the per-provider `installViaSkills()` to install to all 55 agents on every call instead of targeting only the detected agent.

## Fix

Replace `--all` with `--skill '*'` in `installViaSkills()` so all caveman skills are installed only to the specific agent profile selected by `-a`.

### Before
```
npx -y skills add JuliusBrussee/caveman -a codex --yes --all
npx -y skills add JuliusBrussee/caveman -a amp --yes --all
```

### After
```
npx -y skills add JuliusBrussee/caveman --skill '*' -a codex --yes
npx -y skills add JuliusBrussee/caveman --skill '*' -a amp --yes
```

The auto-detect fallback (no `-a`, true all-agents behavior) remains unchanged.

Closes #389
