### PR TITLE
fix(opencode): route session.created through event dispatcher (421)

### DIFF
--- a/src/plugins/opencode/plugin.js
+++ b/src/plugins/opencode/plugin.js
@@ -122,14 +122,23 @@ function applyModeChange(mode) {
   safeWriteFlag(flagPath, mode);
 }
 
+// Session-start logic — extracted so the `event` dispatcher (opencode >= 1.15)
+// and any direct-key fallback share one implementation.
+function handleSessionCreated() {
+  const mode = getDefaultMode();
+  if (mode === 'off') {
+    try { if (existsSync(flagPath)) unlinkSync(flagPath); } catch (e) {}
+    return;
+  }
+  safeWriteFlag(flagPath, mode);
+}
+
 export const CavemanPlugin = async (_ctx) => ({
-  'session.created': async () => {
-    const mode = getDefaultMode();
-    if (mode === 'off') {
-      try { if (existsSync(flagPath)) unlinkSync(flagPath); } catch (e) {}
-      return;
-    }
-    safeWriteFlag(flagPath, mode);
+  // opencode >= 1.15 dispatches session/lifecycle events through a single
+  // `event` handler; the older direct top-level `'session.created'` key is
+  // silently ignored. See https://opencode.ai/docs/plugins#events.
+  event: async ({ event }) => {
+    if (event && event.type === 'session.created') handleSessionCreated();
   },
 
   // opencode's TUI prompt-append hook fires before the prompt is sent to the

--- a/tests/installer/opencode.test.mjs
+++ b/tests/installer/opencode.test.mjs
@@ -277,9 +277,45 @@ test('opencode plugin handles /caveman ultra and stop caveman via tui.prompt.app
     assert.equal(fs.existsSync(flagPath), false, 'flag should be deleted after deactivation');
     assert.equal(out2, undefined, 'no reinforcement when flag absent');
 
-    // session.created writes default mode
-    await handlers['session.created']();
+    // session.created (via opencode >= 1.15 `event` dispatcher) writes default mode
+    assert.equal(typeof handlers.event, 'function', 'event handler missing');
+    assert.equal(handlers['session.created'], undefined, 'direct session.created key must not be used (silently ignored in opencode >= 1.15)');
+    await handlers.event({ event: { type: 'session.created' } });
     assert.equal(fs.readFileSync(flagPath, 'utf8'), 'full');
+  } finally {
+    fs.rmSync(xdg, { recursive: true, force: true });
+    fs.rmSync(shimDir, { recursive: true, force: true });
+  }
+});
+
+// ── 6. `event` dispatcher ignores unrelated event types ───────────────────
+test('opencode event handler dispatches session.created and ignores other event types', async () => {
+  const xdg = freshTmpDir();
+  const shimDir = shimOpencode();
+  try {
+    const env = { ...process.env, XDG_CONFIG_HOME: xdg, PATH: pathWith(shimDir), NO_COLOR: '1' };
+    const r = runInstaller(['--only', 'opencode'], env);
+    assert.notEqual(r.status, 2);
+
+    const pluginPath = path.join(xdg, 'opencode', 'plugins', 'caveman', 'plugin.js');
+    const flagPath = path.join(xdg, 'opencode', '.caveman-active');
+    process.env.XDG_CONFIG_HOME = xdg;
+
+    const mod = await import(pathToFileURL(pluginPath).href + '?v=event-dispatch');
+    const factory = mod.default || mod.CavemanPlugin;
+    const handlers = await factory({});
+
+    // Unrelated event types must NOT write the flag.
+    await handlers.event({ event: { type: 'session.idle' } });
+    assert.equal(fs.existsSync(flagPath), false, 'unrelated event type must not write flag');
+    await handlers.event({ event: { type: 'message.completed' } });
+    assert.equal(fs.existsSync(flagPath), false, 'unrelated event type must not write flag');
+    await handlers.event({});
+    assert.equal(fs.existsSync(flagPath), false, 'missing event payload must not write flag');
+
+    // session.created must write the flag.
+    await handlers.event({ event: { type: 'session.created' } });
+    assert.equal(fs.readFileSync(flagPath, 'utf8'), 'full', 'session.created event must write flag');
   } finally {
     fs.rmSync(xdg, { recursive: true, force: true });
     fs.rmSync(shimDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes #421 — opencode plugin's `session.created` handler never fires on opencode >= 1.15.

opencode >= 1.15 dispatches session/lifecycle events through a single `event` handler that switches on `event.type` ([plugin docs](https://opencode.ai/docs/plugins#events)). The previous direct top-level `'session.created'` key was silently ignored, so the `.caveman-active` flag was never written on session start and the per-prompt reinforcement in `tui.prompt.append` bailed every turn (it reads the flag and returns when empty). Always-on caveman in opencode kept working only via the separately-installed `~/.config/opencode/AGENTS.md`; the plugin's dynamic-state layer was silently inert.

`tui.prompt.append` is unchanged — TUI events still use the direct-key pattern.

## Fix

- Extract `handleSessionCreated` (single source for session-start logic, reusable from any dispatcher).
- Replace the direct `'session.created'` key with an `event` handler that filters on `event.type === 'session.created'`.

## TDD verification

- **RED check** (tests on `main` without prod fix): 2/2 new tests fail
  - `event handler missing` — `typeof handlers.event === 'function'` asserts undefined
  - `handlers.event is not a function` — TypeError on the new event-dispatch test
- **GREEN check** (tests with prod fix): 2/2 new tests pass

## Verification

- [x] Baseline tests on `main`: 51 total, 47 pass, 4 pre-existing failures (installer command-file copy, unrelated)
- [x] Post-fix tests: 52 total, 48 pass, same 4 pre-existing failures (no green→non-green flips, no new failures)
- [x] New tests: 1 added (`event` dispatcher ignores unrelated event types + dispatches `session.created`); 1 modified to use the v1.15 dispatch shape and assert the direct-key is gone

## Files changed

| File | Change |
|------|--------|
| `src/plugins/opencode/plugin.js` | Extract `handleSessionCreated`; route through `event` dispatcher |
| `tests/installer/opencode.test.mjs` | Update smoke test to v1.15 API; add `event` dispatcher coverage test |