### PR TITLE
feat(hooks): add defaultMode "manual" for opt-in activation

### DIFF
--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -17,8 +17,10 @@ const settingsPath = path.join(claudeDir, 'settings.json');
 
 const mode = getDefaultMode();
 
-// "off" mode — skip activation entirely, don't write flag or emit rules
-if (mode === 'off') {
+// "off" / "manual" — skip auto-activation at session start: don't write flag
+// or emit rules. The two differ only in caveman-mode-tracker.js, where an
+// explicit /caveman still activates under 'manual' but stays a no-op under 'off'.
+if (mode === 'off' || mode === 'manual') {
   try { fs.unlinkSync(flagPath); } catch (e) {}
   process.stdout.write('OK');
   process.exit(0);

--- a/src/hooks/caveman-config.js
+++ b/src/hooks/caveman-config.js
@@ -293,4 +293,16 @@ function readHistory(filePath) {
   }
 }
 
-module.exports = { getDefaultMode, getExplicitActivationLevel, MANUAL_DEFAULT_LEVEL, getConfigDir, getConfigPath, VALID_MODES, VALID_DEFAULT_MODES, safeWriteFlag, readFlag, appendFlag, readHistory };
+module.exports = {
+  getDefaultMode,
+  getExplicitActivationLevel,
+  MANUAL_DEFAULT_LEVEL,
+  getConfigDir,
+  getConfigPath,
+  VALID_MODES,
+  VALID_DEFAULT_MODES,
+  safeWriteFlag,
+  readFlag,
+  appendFlag,
+  readHistory,
+};

--- a/src/hooks/caveman-config.js
+++ b/src/hooks/caveman-config.js
@@ -19,6 +19,17 @@ const VALID_MODES = [
   'commit', 'review', 'compress'
 ];
 
+// Valid values for the `defaultMode` CONFIG field. Superset of VALID_MODES plus
+// the 'manual' policy: SessionStart does NOT auto-activate, but an explicit bare
+// /caveman (or natural-language activation) still turns caveman on at
+// MANUAL_DEFAULT_LEVEL. Kept separate from VALID_MODES so 'manual' can never
+// become a flag-file value or a selectable `/caveman <arg>` intensity level.
+const VALID_DEFAULT_MODES = VALID_MODES.concat(['manual']);
+
+// Intensity level used for an EXPLICIT activation when the default policy is
+// 'manual'. Ensures bare /caveman is never a silent no-op for manual users.
+const MANUAL_DEFAULT_LEVEL = 'full';
+
 function getConfigDir() {
   if (process.env.XDG_CONFIG_HOME) {
     return path.join(process.env.XDG_CONFIG_HOME, 'caveman');
@@ -39,7 +50,7 @@ function getConfigPath() {
 function getDefaultMode() {
   // 1. Environment variable (highest priority)
   const envMode = process.env.CAVEMAN_DEFAULT_MODE;
-  if (envMode && VALID_MODES.includes(envMode.toLowerCase())) {
+  if (envMode && VALID_DEFAULT_MODES.includes(envMode.toLowerCase())) {
     return envMode.toLowerCase();
   }
 
@@ -47,7 +58,7 @@ function getDefaultMode() {
   try {
     const configPath = getConfigPath();
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-    if (config.defaultMode && VALID_MODES.includes(config.defaultMode.toLowerCase())) {
+    if (config.defaultMode && VALID_DEFAULT_MODES.includes(config.defaultMode.toLowerCase())) {
       return config.defaultMode.toLowerCase();
     }
   } catch (e) {
@@ -56,6 +67,17 @@ function getDefaultMode() {
 
   // 3. Default
   return 'full';
+}
+
+// Resolve the intensity level for an EXPLICIT activation (bare /caveman, or
+// natural-language "talk like caveman"). Under the 'manual' policy this returns
+// MANUAL_DEFAULT_LEVEL so explicit activation always does something. 'off' is
+// intentionally passed through unchanged so its existing no-op behavior on
+// explicit activation is preserved.
+function getExplicitActivationLevel() {
+  const def = getDefaultMode();
+  if (def === 'manual') return MANUAL_DEFAULT_LEVEL;
+  return def;
 }
 
 // Symlink-safe flag file write.
@@ -271,4 +293,4 @@ function readHistory(filePath) {
   }
 }
 
-module.exports = { getDefaultMode, getConfigDir, getConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory };
+module.exports = { getDefaultMode, getExplicitActivationLevel, MANUAL_DEFAULT_LEVEL, getConfigDir, getConfigPath, VALID_MODES, VALID_DEFAULT_MODES, safeWriteFlag, readFlag, appendFlag, readHistory };

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { execFileSync } = require('child_process');
-const { getDefaultMode, safeWriteFlag, readFlag, VALID_MODES } = require('./caveman-config');
+const { getExplicitActivationLevel, safeWriteFlag, readFlag, VALID_MODES } = require('./caveman-config');
 
 // Modes handled by their own slash commands (/caveman-commit, etc.) — not
 // selectable via /caveman <arg>.
@@ -28,7 +28,10 @@ process.stdin.on('end', () => {
     if (/\b(activate|enable|turn on|start|talk like)\b.*\bcaveman\b/i.test(prompt) ||
         /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt)) {
       if (!/\b(stop|disable|turn off|deactivate)\b/i.test(prompt)) {
-        const mode = getDefaultMode();
+        // Explicit activation: under 'manual' this resolves to a concrete level
+        // instead of the non-activating policy value, so "talk like caveman"
+        // works even when auto-activation is disabled. 'off' still no-ops.
+        const mode = getExplicitActivationLevel();
         if (mode !== 'off') {
           safeWriteFlag(flagPath, mode);
         }
@@ -77,9 +80,11 @@ process.stdin.on('end', () => {
       } else if (cmd === '/caveman-compress' || cmd === '/caveman:caveman-compress') {
         mode = 'compress';
       } else if (cmd === '/caveman' || cmd === '/caveman:caveman') {
-        // Bare /caveman → activate at configured default
+        // Bare /caveman → activate at configured default. Under 'manual' this
+        // resolves to MANUAL_DEFAULT_LEVEL so opt-in users get a real activation
+        // instead of a no-op; 'off' is preserved (resolves to 'off' → unlink).
         if (!arg) {
-          mode = getDefaultMode();
+          mode = getExplicitActivationLevel();
         } else if (arg === 'off' || arg === 'stop' || arg === 'disable') {
           mode = 'off';
         } else if (arg === 'wenyan-full') {

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -157,5 +157,75 @@ class HookScriptTests(unittest.TestCase):
             self.assertEqual((claude_dir / ".caveman-active").read_text(), "full")
 
 
+class ManualModeTests(unittest.TestCase):
+    """defaultMode 'manual': SessionStart must not auto-activate, but an explicit
+    bare /caveman must still activate (at MANUAL_DEFAULT_LEVEL = 'full'). 'off'
+    behavior must remain a no-op on explicit activation."""
+
+    def run_hook(self, script, home, default_mode=None, stdin=None):
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)
+        if default_mode is not None:
+            env["CAVEMAN_DEFAULT_MODE"] = default_mode
+        return subprocess.run(
+            ["node", script],
+            cwd=REPO_ROOT,
+            env=env,
+            input=stdin,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+    def test_activate_manual_does_not_auto_activate(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-manual-activate-") as tmp:
+            home = Path(tmp)
+            (home / ".claude").mkdir(parents=True)
+
+            result = self.run_hook(
+                "src/hooks/caveman-activate.js", home, default_mode="manual"
+            )
+
+            self.assertEqual(result.stdout, "OK")
+            self.assertFalse(
+                (home / ".claude" / ".caveman-active").exists(),
+                "manual mode must not write the active flag at session start",
+            )
+
+    def test_bare_caveman_activates_full_under_manual(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-manual-tracker-") as tmp:
+            home = Path(tmp)
+            (home / ".claude").mkdir(parents=True)
+
+            self.run_hook(
+                "src/hooks/caveman-mode-tracker.js",
+                home,
+                default_mode="manual",
+                stdin=json.dumps({"prompt": "/caveman"}),
+            )
+
+            flag = home / ".claude" / ".caveman-active"
+            self.assertTrue(flag.exists(), "bare /caveman under manual must activate")
+            self.assertEqual(flag.read_text().strip(), "full")
+
+    def test_bare_caveman_is_noop_under_off(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-off-tracker-") as tmp:
+            home = Path(tmp)
+            (home / ".claude").mkdir(parents=True)
+
+            self.run_hook(
+                "src/hooks/caveman-mode-tracker.js",
+                home,
+                default_mode="off",
+                stdin=json.dumps({"prompt": "/caveman"}),
+            )
+
+            self.assertFalse(
+                (home / ".claude" / ".caveman-active").exists(),
+                "bare /caveman under off must remain a no-op (unchanged behavior)",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -226,6 +226,42 @@ class ManualModeTests(unittest.TestCase):
                 "bare /caveman under off must remain a no-op (unchanged behavior)",
             )
 
+    def test_nl_activation_activates_full_under_manual(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-manual-nl-") as tmp:
+            home = Path(tmp)
+            (home / ".claude").mkdir(parents=True)
+
+            self.run_hook(
+                "src/hooks/caveman-mode-tracker.js",
+                home,
+                default_mode="manual",
+                stdin=json.dumps({"prompt": "talk like caveman"}),
+            )
+
+            flag = home / ".claude" / ".caveman-active"
+            self.assertTrue(
+                flag.exists(),
+                "natural-language activation under manual must activate",
+            )
+            self.assertEqual(flag.read_text().strip(), "full")
+
+    def test_nl_activation_is_noop_under_off(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-off-nl-") as tmp:
+            home = Path(tmp)
+            (home / ".claude").mkdir(parents=True)
+
+            self.run_hook(
+                "src/hooks/caveman-mode-tracker.js",
+                home,
+                default_mode="off",
+                stdin=json.dumps({"prompt": "talk like caveman"}),
+            )
+
+            self.assertFalse(
+                (home / ".claude" / ".caveman-active").exists(),
+                "natural-language activation under off must remain a no-op",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #447.

## What

Adds a `defaultMode: "manual"` policy so caveman can be used strictly opt-in: the SessionStart hook does **not** auto-activate, but an explicit bare `/caveman` (or natural-language "talk like caveman") still activates at `MANUAL_DEFAULT_LEVEL` (`full`).

This fills the gap between `"off"` (no activation at all -- bare `/caveman` is a no-op) and the default `"full"` (auto-activates every session). Previously, users who wanted on-demand-only had to set `"off"`, which also made bare `/caveman` do nothing, forcing `/caveman full` every time.

## Changes

- **`src/hooks/caveman-config.js`**: add `VALID_DEFAULT_MODES` (config-only superset that includes `manual`) and `MANUAL_DEFAULT_LEVEL`; add `getExplicitActivationLevel()`. `getDefaultMode()` now validates against `VALID_DEFAULT_MODES`. `manual` is deliberately kept **out** of `VALID_MODES`, so it can never be written as a flag value or selected via `/caveman <arg>` (the `readFlag` whitelist and arg validation are unchanged).
- **`src/hooks/caveman-activate.js`**: treat `manual` like `off` at session start (no flag, no rules).
- **`src/hooks/caveman-mode-tracker.js`**: bare `/caveman` and NL activation resolve via `getExplicitActivationLevel()`, so they activate `full` under `manual`; `off` stays a no-op.
- **`tests/test_hooks.py`**: add `ManualModeTests`.

## Behavior with `{"defaultMode":"manual"}`

| Action | Result |
|--------|--------|
| Session start | not activated |
| `/caveman` | activates `full` |
| `/caveman ultra` | activates `ultra` |
| "normal mode" | deactivates |

Backward compatible: `off`, `lite`, `full`, `ultra`, `wenyan*` behavior is unchanged. `off` users keep the existing bare-`/caveman` no-op.

## Testing

Ran locally on macOS, Node v22.19.0:

- New `ManualModeTests` (3 cases): **pass**
  - `test_activate_manual_does_not_auto_activate` -- SessionStart writes no flag under `manual`
  - `test_bare_caveman_activates_full_under_manual` -- bare `/caveman` writes flag `full`
  - `test_bare_caveman_is_noop_under_off` -- regression guard: `off` stays a no-op
- Full `tests/test_hooks.py`: **7/7 pass**
- `npm test` (installer suite): **47 pass, 4 fail**. The 4 failures are all in the unrelated `opencode` installer tests (`not ok 13, 14, 16, 17`) and reproduce identically on a clean `upstream/main` checkout without this change -- i.e. they are pre-existing and not introduced here.

Happy to also add an installer `--manual` flag and a README row for `manual` in a follow-up if this direction is acceptable.
