### PR TITLE
feat: /caveman <level> persists across sessions (symmetric)

### DIFF
--- a/commands/caveman.toml
+++ b/commands/caveman.toml
@@ -1,2 +1,13 @@
-description = "Switch caveman intensity level (lite/full/ultra/wenyan)"
-prompt = "Switch to caveman {{args}} mode. If no level specified, use full. Respond terse like smart caveman — drop articles, filler, pleasantries. Fragments OK. Technical terms exact. Code unchanged. Pattern: [thing] [action] [reason]. [next step]."
+description = "Switch caveman intensity level (lite/full/ultra/wenyan/off)"
+prompt = """Requested level: {{args}}.
+
+If the level is "off" (also accept: "stop", "disable", "persist-off"), turn caveman off **persistently across sessions** by writing the caveman config file:
+
+- macOS/Linux: `~/.config/caveman/config.json` (or `$XDG_CONFIG_HOME/caveman/config.json` if set)
+- Windows: `%APPDATA%\\caveman\\config.json`
+
+Create the parent directory if missing. Read any existing JSON from that path first; merge `{"defaultMode": "off"}` into it (do not clobber other fields). Write the result back. After writing, return to normal Claude voice for the remainder of this session and every future session — the SessionStart hook reads `defaultMode` and skips activation when it is `"off"`.
+
+If the level is anything else (lite, full, ultra, wenyan-lite, wenyan-full, wenyan-ultra) or empty (default to full), switch session-mode only — do not write the config file. Respond terse like smart caveman — drop articles, filler, pleasantries. Fragments OK. Technical terms exact. Code unchanged. Pattern: [thing] [action] [reason]. [next step].
+
+To re-enable caveman after a persistent off, the user can run `/caveman full` and then either (a) edit the config to set `defaultMode` to the desired level, or (b) delete the config file to fall back to the built-in default of `full`."""

--- a/commands/caveman.toml
+++ b/commands/caveman.toml
@@ -1,13 +1,20 @@
-description = "Switch caveman intensity level (lite/full/ultra/wenyan/off)"
+description = "Switch caveman intensity level (lite/full/ultra/wenyan/off) — persists across sessions"
 prompt = """Requested level: {{args}}.
 
-If the level is "off" (also accept: "stop", "disable", "persist-off"), turn caveman off **persistently across sessions** by writing the caveman config file:
+Resolve the level:
+- Empty → "full" (the documented default)
+- Aliases: "stop", "disable", "persist-off" → "off"; "on", "enable" → "full"; "wenyan" → "wenyan-full"
+- Valid levels: off, lite, full, ultra, wenyan-lite, wenyan-full, wenyan-ultra. Anything else: tell the user the valid set and stop.
+
+Write the resolved level to the caveman config file so the choice persists across sessions:
 
 - macOS/Linux: `~/.config/caveman/config.json` (or `$XDG_CONFIG_HOME/caveman/config.json` if set)
 - Windows: `%APPDATA%\\caveman\\config.json`
 
-Create the parent directory if missing. Read any existing JSON from that path first; merge `{"defaultMode": "off"}` into it (do not clobber other fields). Write the result back. After writing, return to normal Claude voice for the remainder of this session and every future session — the SessionStart hook reads `defaultMode` and skips activation when it is `"off"`.
+Create the parent directory if missing. Read any existing JSON from that path first; merge `{"defaultMode": "<level>"}` into it (do not clobber other fields). Write the result back.
 
-If the level is anything else (lite, full, ultra, wenyan-lite, wenyan-full, wenyan-ultra) or empty (default to full), switch session-mode only — do not write the config file. Respond terse like smart caveman — drop articles, filler, pleasantries. Fragments OK. Technical terms exact. Code unchanged. Pattern: [thing] [action] [reason]. [next step].
+Then act on the new level for this session:
+- If level is "off": return to normal Claude voice for the rest of this session and every future session — the SessionStart hook reads `defaultMode` and skips activation.
+- Otherwise: respond terse like smart caveman at the requested intensity — drop articles, filler, pleasantries. Fragments OK. Technical terms exact. Code unchanged. Pattern: [thing] [action] [reason]. [next step]. The intensity definitions live in SKILL.md.
 
-To re-enable caveman after a persistent off, the user can run `/caveman full` and then either (a) edit the config to set `defaultMode` to the desired level, or (b) delete the config file to fall back to the built-in default of `full`."""
+Persistence is symmetric: `/caveman off` persistently disables, `/caveman <level>` persistently sets that level. To clear the persistent choice entirely and fall back to the built-in default, delete the config file."""

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -14,11 +14,11 @@ Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
 ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure.
 
-Off this session only: "stop caveman" / "normal mode" / `/caveman off`. Default returns next session.
+Off this session only: "stop caveman" / "normal mode". Default returns next session.
 
-Off persistently (across sessions): `/caveman off` writes `{"defaultMode": "off"}` to the caveman config file (`~/.config/caveman/config.json`, or `%APPDATA%\caveman\config.json` on Windows). The SessionStart hook reads this and skips activation. Re-enable with `/caveman full` (or any other level), or delete the config file.
+`/caveman <level>` persists across sessions: it writes `{"defaultMode": "<level>"}` to the caveman config file (`~/.config/caveman/config.json`, or `%APPDATA%\caveman\config.json` on Windows). The SessionStart hook reads this on every resume and applies the saved level — including `off`, which makes the hook skip activation entirely. Symmetric: `/caveman off` persists off, `/caveman full` persists full, etc. To clear the saved choice and fall back to the built-in default of `full`, delete the config file.
 
-Default: **full**. Switch: `/caveman lite|full|ultra|off`.
+Default: **full**. Switch: `/caveman lite|full|ultra|off|wenyan-{lite,full,ultra}`.
 
 ## Rules
 
@@ -75,6 +75,6 @@ Example — destructive op:
 
 ## Boundaries
 
-Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert for the rest of this session. Level persists until changed or session end.
+Code/commits/PRs: write normal. "stop caveman" or "normal mode" without a `/caveman` command: revert for the rest of this session only.
 
-`/caveman off` is the exception: it persists across sessions by writing `defaultMode: "off"` to the config file (see Persistence section).
+`/caveman <level>` persists across sessions in both directions — `off` saves off, any other level saves that level. See the Persistence section.

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -12,9 +12,13 @@ Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
 ## Persistence
 
-ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure.
 
-Default: **full**. Switch: `/caveman lite|full|ultra`.
+Off this session only: "stop caveman" / "normal mode" / `/caveman off`. Default returns next session.
+
+Off persistently (across sessions): `/caveman off` writes `{"defaultMode": "off"}` to the caveman config file (`~/.config/caveman/config.json`, or `%APPDATA%\caveman\config.json` on Windows). The SessionStart hook reads this and skips activation. Re-enable with `/caveman full` (or any other level), or delete the config file.
+
+Default: **full**. Switch: `/caveman lite|full|ultra|off`.
 
 ## Rules
 
@@ -71,4 +75,6 @@ Example — destructive op:
 
 ## Boundaries
 
-Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert for the rest of this session. Level persists until changed or session end.
+
+`/caveman off` is the exception: it persists across sessions by writing `defaultMode: "off"` to the config file (see Persistence section).


### PR DESCRIPTION
## What's broken today

The slash command `/caveman` only switches caveman for the current session. The SessionStart hook re-activates whatever the SKILL/hook default is on every session resume — even after the user explicitly asked for a different level (most painfully, `off`).

Verbatim user reactions from real sessions:
- *"i thought i turned caveman off?"*
- *"but the caveman skill itself says you can turn it off and that should persist??"*

SKILL.md said "Level persist until changed or session end" — which is a documentation of the limitation, not a desirable property. Persistent levels via `~/.config/caveman/config.json` already work (`getDefaultMode()` reads it, `caveman-activate.js` honors `defaultMode: "off"` and would honor any other valid level the user wrote there). But the user-facing slash command never wrote that file, so anyone who didn't know about the config layer just saw the bug.

## What this PR changes

`/caveman <level>` now writes `defaultMode: "<level>"` to the platform's caveman config file. The choice persists across sessions in **both directions** — `/caveman off` saves off, `/caveman full` saves full, etc. The persistent choice is whatever the user last asked for. Clearing it is a single action: delete the config file.

**`commands/caveman.toml`** — replaced the one-liner prompt with a "resolve → persist → act" flow:
1. Resolve the requested level (with aliases: `stop`/`disable`/`persist-off` → `off`, `on`/`enable` → `full`, `wenyan` → `wenyan-full`). Reject unknown levels loudly.
2. Merge `{"defaultMode": "<level>"}` into `~/.config/caveman/config.json` (or `%APPDATA%\caveman\config.json` on Windows, or `$XDG_CONFIG_HOME/caveman/...`). Existing JSON fields preserved.
3. Apply the level to the current session.

**`skills/caveman/SKILL.md`** — Persistence and Boundaries sections rewritten to describe symmetric persistence and clarify that the slash command itself is the persistence mechanism (no separate `/caveman persist` and no hand-editing JSON required).

## Why symmetric

The first revision of this PR (90cd5ac) only persisted `off` — other levels stayed session-scope. That produced the next confusing UX: after `/caveman off`, running `/caveman full` re-enabled caveman for the current session, but the config still said `off`, so the next session resume was silent again. Users had to know to delete the config file by hand.

The current revision (66f98a8) makes it symmetric. The mental model becomes: *"`/caveman <level>` sets your caveman level. It persists. Delete the config to reset."*

## Compatibility

The hook layer already handles every `defaultMode` value this command writes — no `caveman-config.js` or `caveman-activate.js` changes. Users who never type `/caveman` see no behavior change.

Users who were relying on slash commands being session-scope (probably few — there's no obvious upside) can still set `CAVEMAN_DEFAULT_MODE` in their shell env, which overrides the config file per the existing precedence in `getDefaultMode()`.

## Test plan

- [ ] `/caveman off` in a session: bot drops caveman style; config file contains `{"defaultMode": "off"}`.
- [ ] Start a new session: SessionStart hook outputs `OK` only, no "CAVEMAN MODE ACTIVE" reminder.
- [ ] `/caveman full` in that session: caveman resumes; config now `{"defaultMode": "full"}`.
- [ ] Start a new session: hook outputs the full ruleset reminder.
- [ ] `/caveman ultra`: caveman switches to ultra; config now `{"defaultMode": "ultra"}`. Next session is ultra.
- [ ] `/caveman nonsense`: command refuses with the valid level list, no file write.
- [ ] Pre-existing fields in `~/.config/caveman/config.json` (e.g. user-added `theme: ...`) are preserved after every write.