### PR TITLE
docs: add Companion tools section (savings-mirror + sovacount)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ Caveman save you token, save you money. Star cost zero. Fair trade. ⭐
 
 Community-built MIT tools that pair with caveman:
 
-- **[savings-mirror](https://github.com/sovareq/savings-mirror)** — read-only dashboard that visualises caveman compression as per-day USD savings + cumulative chart. Consumes Claude Code JSONL transcripts.
-- **[sovacount](https://github.com/sovareq/sovacount)** — scope-level LLM tier-router (Haiku/Sonnet/Opus). Stacks with caveman: tier-routing cuts cost on *which model* runs; caveman cuts cost on *which tokens* are sent. Includes [real-Anthropic benchmark](https://github.com/sovareq/sovacount/tree/main/benchmark) (88.1% saved on 5-task sample).
+- **[savings-mirror](https://github.com/sovareq/savings-mirror)** — read-only Rust dashboard. Parses `~/.claude/projects/**/*.jsonl` and shows per-day / 7-day / cumulative / per-mode caveman savings. Auto-detects Anthropic API vs Pro/Max subscription billing and switches metric: USD against the public price table (API) or tokens-saved + 5h/7d cap utilization (subscription). No telemetry, no write-back.
+- **[sovacount](https://github.com/sovareq/sovacount)** — scope-level LLM tier-router (Haiku/Sonnet/Opus). Stacks with caveman: tier-routing cuts cost on *which model* runs; caveman cuts cost on *which tokens* are sent. Includes [real-Anthropic benchmark](https://github.com/sovareq/sovacount/tree/main/benchmark) — 88.1% saved on a 5-task sample (raw data + methodology committed, reproducible).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ Caveman save you token, save you money. Star cost zero. Fair trade. ⭐
 
 - **[Revu](https://github.com/JuliusBrussee/revu-swift)** — local-first macOS study app with FSRS spaced repetition. [revu.cards](https://revu.cards)
 
+
+## Companion tools
+
+Community-built MIT tools that pair with caveman:
+
+- **[savings-mirror](https://github.com/sovareq/savings-mirror)** — read-only dashboard that visualises caveman compression as per-day USD savings + cumulative chart. Consumes Claude Code JSONL transcripts.
+- **[sovacount](https://github.com/sovareq/sovacount)** — scope-level LLM tier-router (Haiku/Sonnet/Opus). Stacks with caveman: tier-routing cuts cost on *which model* runs; caveman cuts cost on *which tokens* are sent. Includes [real-Anthropic benchmark](https://github.com/sovareq/sovacount/tree/main/benchmark) (88.1% saved on 5-task sample).
+
 ## License
 
 MIT — free like mass mammoth on open plain.


### PR DESCRIPTION
Per discussion in #449. Adds a brief **Companion tools** section so users discover two MIT companion tools that pair with caveman.

![savings-mirror dashboard](https://raw.githubusercontent.com/sovareq/savings-mirror/main/assets/screenshot.png)

## What this adds

- **[savings-mirror](https://github.com/sovareq/savings-mirror)** — read-only Rust dashboard. Parses `~/.claude/projects/**/*.jsonl` and shows per-day / 7-day / cumulative / per-mode caveman savings. Auto-detects Anthropic API vs Pro/Max subscription billing and switches metric: USD against the public price table (API) or tokens-saved + 5h/7d cap utilization (subscription).
- **[sovacount](https://github.com/sovareq/sovacount)** — scope-level LLM tier-router (Haiku/Sonnet/Opus). Stacks with caveman:
  - caveman cuts cost on *which tokens* are sent
  - sovacount cuts cost on *which model* runs them
  - Combined > either alone
  - Includes [real-Anthropic benchmark](https://github.com/sovareq/sovacount/tree/main/benchmark) — 88.1% saved on a 5-task sample, raw data + methodology committed (reproducible)

## Relationship to existing work

@DeeptimaanB already shipped `/caveman-stats` in #251 — a terminal command for current-session savings, with Codex + Gemini-CLI work in progress. That's the right shape for inline CLI introspection.

`savings-mirror` is a complementary shape: a standalone web dashboard that parses the full transcript history across sessions, auto-adapts to billing mode (USD for API users, tokens for subscription users), and folds in sovacount routing decisions. Different audience, same underlying intent.

## Why merge

- Pure docs-only diff (+8 / -0 in README.md), trivial revert
- Both repos MIT, attribution to @JuliusBrussee preserved
- Zero changes to caveman itself — both tools are pure consumers of the existing JSONL format + published compression factor
- Every claim in the README addition traces to source code in the linked repos (no marketing fluff)

Happy to adjust wording, drop a tool, or split if preferred.
