### PR TITLE
fix(statusline): render ⛏ correctly on Windows, add spacing

### DIFF
--- a/src/hooks/caveman-stats.js
+++ b/src/hooks/caveman-stats.js
@@ -324,7 +324,7 @@ function main() {
     // Routed through safeWriteFlag — the suffix path is predictable and
     // user-owned, same symlink-clobber surface as the .caveman-active flag.
     const agg = aggregateHistory(historyPath, null);
-    const suffix = agg.estSavedTokens > 0 ? `⛏ ${humanizeTokens(agg.estSavedTokens)}` : '';
+    const suffix = agg.estSavedTokens > 0 ? `⛏  ${humanizeTokens(agg.estSavedTokens)}` : '';
     safeWriteFlag(path.join(claudeDir, '.caveman-statusline-suffix'), suffix);
   }
 

--- a/src/hooks/caveman-statusline.ps1
+++ b/src/hooks/caveman-statusline.ps1
@@ -1,3 +1,4 @@
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
 $Flag = Join-Path $ClaudeDir ".caveman-active"
 if (-not (Test-Path $Flag)) { exit 0 }
@@ -50,7 +51,7 @@ if ($env:CAVEMAN_STATUSLINE_SAVINGS -ne "0") {
             $SavingsItem = Get-Item -LiteralPath $SavingsFile -Force -ErrorAction Stop
             if (-not ($SavingsItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -and
                 $SavingsItem.Length -le 64) {
-                $Savings = (Get-Content -LiteralPath $SavingsFile -Raw -ErrorAction Stop).TrimEnd()
+                $Savings = (Get-Content -LiteralPath $SavingsFile -Encoding UTF8 -Raw -ErrorAction Stop).TrimEnd()
                 $Savings = ($Savings -replace '[\x00-\x1F]', '')
                 if ($Savings.Length -gt 0) {
                     [Console]::Write(" ${Esc}[38;5;172m$Savings${Esc}[0m")


### PR DESCRIPTION
## Summary

- Set `[Console]::OutputEncoding = UTF8` in `caveman-statusline.ps1` so `⛏` (U+26CF) renders instead of garbled bytes on Windows (PS5.1 defaults to system code page)
- Add `-Encoding UTF8` to `Get-Content` so the suffix file is read correctly
- Add a second space between `⛏` and the token count for visual breathing room

## Test plan

- [ ] Run `/caveman-stats` after install
- [ ] Statusline shows `[CAVEMAN] ⛏  12.4k` with visible space between pickaxe and number
- [ ] No garbled characters on Windows