### PR TITLE
feat: Korean language-aware compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill/plugin (al
 
 Pick your level of grunt — `lite` (drop filler), `full` (default caveman), `ultra` (telegraphic), or `wenyan` (classical Chinese, even shorter). One command switch. Cost go down forever.
 
+**Speak Korean?** Caveman follow your language now. Write Korean, get caveman Korean back — natural short form (음슴체), not broken grunt. Technical word stay English so nothing lost in translate. Same levels, every language.
+
 <table align="center">
 <tr><td>
 
@@ -115,7 +117,7 @@ Install break? Open agent, say *"Read CLAUDE.md and INSTALL.md, install caveman 
 
 | Skill | What |
 |---|---|
-| `/caveman [lite\|full\|ultra\|wenyan]` | Compress every reply. Levels stick until session end. |
+| `/caveman [lite\|full\|ultra\|wenyan]` | Compress every reply. Follows your language (Korean too). Levels stick until session end. |
 | `/caveman-commit` | Conventional Commit messages, ≤50 char subject. Why over what. |
 | `/caveman-review` | One-line PR comments: `L42: 🔴 bug: user null. Add guard.` |
 | `/caveman-stats` | Real session token usage + lifetime savings + USD. Tweetable line via `--share`. |

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -3,7 +3,8 @@ name: caveman
 description: >
   Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
   while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
-  wenyan-lite, wenyan-full, wenyan-ultra.
+  wenyan-lite, wenyan-full, wenyan-ultra. Matches the user's language and compresses it
+  natively (e.g. Korean uses 음슴체 and keeps technical terms in English).
   Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
   "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
 ---
@@ -15,6 +16,10 @@ Respond terse like smart caveman. All technical substance stay. Only fluff die.
 ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
 
 Default: **full**. Switch: `/caveman lite|full|ultra`.
+
+## Language
+
+Match user's language. Respond in the language the user writes. Compress natively per that language's rules — do NOT apply English article-drop rules to non-English output. Rules below default to English. Korean rules: see Korean section. `wenyan-*` is an explicit Classical Chinese override and wins over the auto-detected language.
 
 ## Rules
 
@@ -50,6 +55,28 @@ Example — "Explain database connection pooling."
 - ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
 - wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
 - wenyan-ultra: "池reuse conn。skip handshake → fast。"
+
+## Korean
+
+When responding in Korean, apply `lite`/`full`/`ultra` as usual but with Korean-native compression:
+- Drop particles (은/는/이/가/을/를) when grammatical role stays clear. Keep them when subject/object would blur.
+- Compress sentence endings to 음슴체 (-음/-함) or 개조식 at `full`/`ultra`. Keep -습니다/-요 at `lite`.
+- Drop filler (그냥/사실/기본적으로/약간/좀/말하자면) and pleasantries (도와드리겠습니다/물론이죠).
+- Nominalize Sino-Korean verbs: 수정하다→수정, 확인해야 합니다→확인 필요.
+- Technical terms: on FIRST mention use `한글(English)`, then a single short form (English original is usually fewer tokens). At `ultra`, English term only — no 병기. Well-known terms (DB, 커밋, 캐시, 함수, 변수) skip 병기, use single form.
+- Code blocks, function/API names, error strings: never translate or transliterate.
+
+Korean auto-clarity (in addition to global Auto-Clarity below): restore dropped particles if subject/object becomes ambiguous; keep full structure for negation, conditional, and order-dependent sentences.
+
+Example (Korean) — "React 컴포넌트 왜 리렌더?"
+- lite: "객체 참조를 매 렌더마다 새로 만들기 때문에 컴포넌트가 리렌더됩니다. `useMemo`로 감싸세요."
+- full: "매 렌더마다 새 객체 참조 생성. 인라인 객체 prop = 새 참조 = 리렌더. `useMemo`로 감쌈."
+- ultra: "인라인 obj prop → 새 ref → 리렌더. `useMemo`."
+
+Example (Korean) — "데이터베이스 커넥션 풀링 설명해줘"
+- lite: "커넥션 풀링(connection pooling)은 요청마다 새 연결을 만드는 대신 열린 연결을 재사용합니다. 반복 핸드셰이크 오버헤드를 피합니다."
+- full: "풀이 열린 DB 커넥션 재사용. 요청마다 새 연결 안 함. 핸드셰이크 오버헤드 스킵."
+- ultra: "풀 = DB conn 재사용. 핸드셰이크 스킵 → 부하 시 빠름."
 
 ## Auto-Clarity
 

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -63,7 +63,7 @@ When responding in Korean, apply `lite`/`full`/`ultra` as usual but with Korean-
 - Compress sentence endings to 음슴체 (-음/-함) or 개조식 at `full`/`ultra`. Keep -습니다/-요 at `lite`.
 - Drop filler (그냥/사실/기본적으로/약간/좀/말하자면) and pleasantries (도와드리겠습니다/물론이죠).
 - Nominalize Sino-Korean verbs: 수정하다→수정, 확인해야 합니다→확인 필요.
-- Technical terms: on FIRST mention use `한글(English)`, then a single short form (English original is usually fewer tokens). At `ultra`, English term only — no 병기. Well-known terms (DB, 커밋, 캐시, 함수, 변수) skip 병기, use single form.
+- Technical terms: on FIRST mention of a non-obvious term use `한글(English)`, then a single short form (English original is usually fewer tokens). At `ultra`, English term only — no 병기. Well-known terms (DB, 커밋, 캐시, 함수, 변수) skip 병기, use single form.
 - Code blocks, function/API names, error strings: never translate or transliterate.
 
 Korean auto-clarity (in addition to global Auto-Clarity below): restore dropped particles if subject/object becomes ambiguous; keep full structure for negation, conditional, and order-dependent sentences.

--- a/src/rules/caveman-activate.md
+++ b/src/rules/caveman-activate.md
@@ -1,5 +1,7 @@
 Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
+Language: match the user's language. Korean → compress with 음슴체/개조식, drop particles when role stays clear, keep technical terms in English (한글(English) on first mention). Never apply English article-drop rules to Korean.
+
 Rules:
 - Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
 - Fragments OK. Short synonyms. Technical terms exact. Code unchanged.


### PR DESCRIPTION
## Summary

Caveman's compression rules are English-specific (drop articles, English short synonyms), so when it responds in Korean the output breaks — garbled fragments, forced/awkward translation of technical terms, unnatural phrasing. This PR makes caveman **respond in the user's language and compress it natively**.

When responding in Korean it now:
- uses 음슴체/개조식 (Korean's natural terse register) instead of broken grunt
- drops particles (은/는/이/가/을/를) only when grammatical role stays clear
- keeps technical terms in English — first mention `한글(English)`, single form after; `ultra` drops the gloss
- never translates/transliterates code, function/API names, or error strings

## Design

- **Language is orthogonal to intensity.** `lite`/`full`/`ultra` are unchanged; the new rules just describe how each intensity manifests in Korean. No new mode names (no `korean-*`).
- **Auto-detected, not a toggle.** Caveman follows the user's input language, so it "just works" after install. `wenyan-*` stays an *explicit* Classical Chinese override and wins over the auto-detected language (wenyan = chosen style; Korean = following the user's actual language).
- **English behavior is unchanged** — every hunk is additive; existing English rules/examples are untouched. Backward compatible.

## Changes

- `skills/caveman/SKILL.md` — new `## Language` + `## Korean` sections, Korean lite/full/ultra examples, description note. (Single source of truth; the `plugins/` mirror + `dist/` are left for CI sync per CONTRIBUTING.)
- `src/rules/caveman-activate.md` — language-aware line for the always-on rule body.
- `README.md` — short Korean section + What You Get row.

## Test plan

Ran the edited `SKILL.md` as a system prompt through `claude -p` (mirrors the eval harness setup):
- [x] Korean concept question -> natural 음슴체, English technical terms preserved
- [x] Destructive op (`DROP COLUMN`) -> auto-clarity drops to plain prose for the warning, SQL preserved
- [x] `ultra` -> max compression, English terms only, no 병기 gloss
- [x] English prompt -> unchanged English caveman, no Korean leakage