### PR TITLE
fix(caveman-stats): correct Opus output price ($75→$25) for 4.5+ era

### DIFF
--- a/src/hooks/caveman-stats.js
+++ b/src/hooks/caveman-stats.js
@@ -22,13 +22,20 @@ const COMPRESSION = { 'full': 0.65 };
 // Match by model id prefix so this stays correct across point releases
 // (e.g. claude-sonnet-4-20250514, claude-sonnet-4-7). Update from
 // https://www.anthropic.com/pricing if a release changes the tier.
+// Most-specific prefixes MUST come first — priceForModel returns the first match.
 const MODEL_OUTPUT_PRICE_PER_M = [
-  ['claude-opus-4',     75.00],
-  ['claude-sonnet-4',   15.00],
-  ['claude-haiku-4',     4.00],
-  ['claude-3-5-sonnet', 15.00],
-  ['claude-3-5-haiku',   4.00],
-  ['claude-3-opus',     75.00],
+  // Legacy Opus 4.0 / 4.1 (pre-4.5) billed at the old $75/M output tier,
+  // including the dated ids (e.g. claude-opus-4-20250514).
+  ['claude-opus-4-0',    75.00],
+  ['claude-opus-4-1',    75.00],
+  ['claude-opus-4-2025', 75.00],
+  // Opus 4.5–4.8 dropped to $25/M output (rate card held since 4.5).
+  ['claude-opus-4',      25.00],
+  ['claude-sonnet-4',    15.00],
+  ['claude-haiku-4',      5.00],   // Haiku 4.5 = $5/M output
+  ['claude-3-5-sonnet',  15.00],
+  ['claude-3-5-haiku',    4.00],
+  ['claude-3-opus',      75.00],
 ];
 
 function priceForModel(model) {

--- a/tests/test_caveman_stats.js
+++ b/tests/test_caveman_stats.js
@@ -160,10 +160,12 @@ test('omits USD line when model is unknown', (tmp) => {
 
 test('priceForModel matches by prefix across point releases', () => {
   const { priceForModel } = require(path.join(ROOT, 'src', 'hooks', 'caveman-stats.js'));
-  assert.strictEqual(priceForModel('claude-opus-4-7'), 75.00);
+  assert.strictEqual(priceForModel('claude-opus-4-7'), 25.00);
+  assert.strictEqual(priceForModel('claude-opus-4-8'), 25.00);
   assert.strictEqual(priceForModel('claude-opus-4-20250101'), 75.00);
+  assert.strictEqual(priceForModel('claude-opus-4-1-20250805'), 75.00);
   assert.strictEqual(priceForModel('claude-sonnet-4-7-20260315'), 15.00);
-  assert.strictEqual(priceForModel('claude-haiku-4-5'), 4.00);
+  assert.strictEqual(priceForModel('claude-haiku-4-5'), 5.00);
   assert.strictEqual(priceForModel('claude-3-5-sonnet-20241022'), 15.00);
   assert.strictEqual(priceForModel(null), null);
   assert.strictEqual(priceForModel('gpt-4'), null);


### PR DESCRIPTION
Fixes #465.

## Problem
`src/hooks/caveman-stats.js` `priceForModel()` prefix-matches every `claude-opus-4*` id to **$75/M** output — the legacy *Claude 3 Opus* rate. Anthropic's Opus rate card has been **$5/M in, $25/M out since Opus 4.5** (4.8 shipped on the same card, 2026-05-28). So `/caveman-stats` overstates the savings/cost figure **~3×** for anyone running a current Opus model — increasingly the default.

`claude-haiku-4` was also stale ($4 vs Haiku 4.5's $5/M).

## Fix
Split the table into legacy vs current Opus, **most-specific prefixes first** (the loop returns the first match), so retired 4.0/4.1 (incl. dated ids like `claude-opus-4-20250514`) keep $75 while 4.5–4.8 resolve to $25:

```js
['claude-opus-4-0',    75.00],
['claude-opus-4-1',    75.00],
['claude-opus-4-2025', 75.00],   // dated 4.0 ids
['claude-opus-4',      25.00],   // 4.5–4.8
...
['claude-haiku-4',      5.00],   // Haiku 4.5
```

This keeps the existing dated-id test (`claude-opus-4-20250101 → 75`) valid instead of regressing it — preferred over a flat constant flip, which is the alternative I floated in #465.

## Tests
`tests/test_caveman_stats.js` updated and green — **29/29**. Added asserts pinning both eras (`claude-opus-4-8 → 25`, `claude-opus-4-1-20250805 → 75`).

> Note: `npm test` (the `tests/installer/*` suite) shows 4 failing `opencode …` tests, but they fail identically on a clean `main` checkout — pre-existing and unrelated to this change.

Source: <https://platform.claude.com/docs/en/about-claude/pricing>