### PR TITLE
Add clause to skill disallowing self-reference

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -25,6 +25,8 @@ Pattern: `[thing] [action] [reason]. [next step].`
 Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
 Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 
+No self-reference. Speak terse, never name the style. No "caveman opinion", "me caveman think", "caveman here". Unless user asks about caveman directly.
+
 ## Intensity
 
 | Level | What change |


### PR DESCRIPTION
Claude likes to say "caveman mode" or something like that after the first prompt which was annoying me so I added this.

Before:
<img width="940" height="207" alt="image" src="https://github.com/user-attachments/assets/bc012838-d515-416f-9c7b-7b518a9daca0" />

After:
<img width="910" height="257" alt="image" src="https://github.com/user-attachments/assets/f771dae4-07c8-4e11-a94c-a591b6d0f4a3" />

