### PR TITLE
fix(install): prune orphaned managed hooks from settings.json (#471)

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -400,6 +400,29 @@ async function installClaude(ctx) {
     else results.failed.push(['claude', 'claude plugin install failed']);
   }
 
+  // Self-heal: drop managed settings.json hook/statusLine entries whose target
+  // script no longer exists. Migrating an old manual install to the plugin
+  // disables the local ~/.claude/hooks/caveman-*.js scripts but leaves the
+  // settings.json entries pointing at them, so Claude Code crashes every
+  // SessionStart / UserPromptSubmit with `loader:1478 — Cannot find module
+  // …caveman-activate.js` (issue #471). Runs unconditionally (independent of
+  // the hook-wiring decision) so it repairs an already-dirty config even when
+  // we then skip standalone wiring because the plugin manifest handles hooks.
+  {
+    const settingsPath = path.join(SETTINGS.claudeConfigDir(), 'settings.json');
+    const settings = SETTINGS.readSettings(settingsPath);
+    if (settings) {
+      const pruned = SETTINGS.pruneOrphanedManagedHooks(settings, SETTINGS.claudeConfigDir());
+      if (pruned > 0) {
+        note(`  removed ${pruned} orphaned caveman hook entr${pruned === 1 ? 'y' : 'ies'} from settings.json (target script missing)`);
+        if (!opts.dryRun) {
+          SETTINGS.validateHookFields(settings);
+          SETTINGS.writeSettings(settingsPath, settings);
+        }
+      }
+    }
+  }
+
   if (opts.withHooks) {
     say('  → installing hooks (--with-hooks)');
     const r = await installHooks(ctx);

--- a/bin/lib/settings.js
+++ b/bin/lib/settings.js
@@ -230,23 +230,38 @@ function pruneOrphanedManagedHooks(settings, configDir) {
   const baseDir = configDir || claudeConfigDir();
   let removed = 0;
 
-  // Pull the first token that ends in a managed basename out of a command
-  // string. Handles: `node "/a/x.js"`, `"/abs/node" "/a/x.js"`, `bash /a/x.sh`.
-  const managedAlt = [...MANAGED_HOOK_BASENAMES]
-    .map(b => b.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-    .join('|');
-  const reManaged = new RegExp(`(?:"([^"]*(?:${managedAlt}))"|'([^']*(?:${managedAlt}))'|(\\S*(?:${managedAlt})))`);
+  // Split a command into shell-ish tokens, honoring single/double quotes so a
+  // path containing spaces survives intact. Good enough for hook commands we
+  // generate (`node "/a/x.js"`, `"/abs/node" "/a/x.js"`, `bash /a/x.sh`); not
+  // a full shell parser.
+  const tokenize = (command) => {
+    const out = [];
+    const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
+    let m;
+    while ((m = re.exec(command)) !== null) out.push(m[1] ?? m[2] ?? m[3]);
+    return out;
+  };
 
+  // A command is a missing managed target iff some token's BASENAME exactly
+  // equals a managed script (exact match — not substring — so a user hook like
+  // `mycaveman-activate.js` is never touched) and that resolved path is absent.
+  // Relative paths resolve against configDir; honors CLAUDE_CONFIG_DIR. Wrapped
+  // so a malformed command or fs error never throws out of the prune pass.
   const targetMissing = (command) => {
-    const m = reManaged.exec(command);
-    if (!m) return false; // not a managed-script command — leave it alone
-    let scriptPath = m[1] || m[2] || m[3];
-    if (!scriptPath) return false;
-    if (!path.isAbsolute(scriptPath)) scriptPath = path.join(baseDir, scriptPath);
-    return !fs.existsSync(scriptPath);
+    try {
+      for (const tok of tokenize(command)) {
+        if (!tok || typeof tok !== 'string') continue;
+        if (!MANAGED_HOOK_BASENAMES.has(path.basename(tok))) continue;
+        const scriptPath = path.isAbsolute(tok) ? tok : path.join(baseDir, tok);
+        return !fs.existsSync(scriptPath);
+      }
+    } catch (_) { /* silent-fail: never block install on a parse/fs hiccup */ }
+    return false;
   };
 
   if (settings.hooks && typeof settings.hooks === 'object') {
+    // Normalize malformed shapes first so the filter below only sees valid
+    // entries (and a poisoned settings.json can't survive the rewrite).
     validateHookFields(settings);
   }
   if (settings.hooks && typeof settings.hooks === 'object') {
@@ -254,7 +269,7 @@ function pruneOrphanedManagedHooks(settings, configDir) {
       if (!Array.isArray(settings.hooks[ev])) { delete settings.hooks[ev]; continue; }
       const before = settings.hooks[ev].length;
       settings.hooks[ev] = settings.hooks[ev].filter(entry => {
-        if (!entry || !Array.isArray(entry.hooks)) return true;
+        if (!entry || typeof entry !== 'object' || !Array.isArray(entry.hooks)) return true;
         return !entry.hooks.some(h => h && typeof h.command === 'string' && targetMissing(h.command));
       });
       removed += before - settings.hooks[ev].length;

--- a/bin/lib/settings.js
+++ b/bin/lib/settings.js
@@ -207,6 +207,74 @@ function rewriteLegacyManagedHookCommands(settings, absoluteNode) {
   return rewritten;
 }
 
+// ── pruneOrphanedManagedHooks ─────────────────────────────────────────────
+// Remove managed hook entries whose target script no longer exists on disk.
+//
+// Migrating an old manual install (settings.json hooks → ~/.claude/hooks/
+// caveman-*.js) to the Claude Code plugin disables/renames those local
+// scripts (e.g. caveman-activate.js → caveman-activate.js.disabled) but
+// leaves the settings.json entries pointing at the now-missing file. Claude
+// Code then runs `node <missing>` every SessionStart / UserPromptSubmit and
+// crashes with `node:…/loader:1478 — Cannot find module …caveman-activate.js`
+// (issue #471). rewriteLegacyManagedHookCommands can't help — it only matches
+// the bare-node shape and these orphans are usually absolute-node — and
+// removeCavemanHooks runs only on uninstall.
+//
+// We extract the script path from any managed-looking command (bare- or
+// absolute-node, quoted or not), resolve it relative to dir if not absolute,
+// and drop the hook only when its target is genuinely absent. A managed hook
+// whose script still exists is left untouched, so this is safe to run on
+// every install.
+function pruneOrphanedManagedHooks(settings, configDir) {
+  if (!settings || typeof settings !== 'object') return 0;
+  const baseDir = configDir || claudeConfigDir();
+  let removed = 0;
+
+  // Pull the first token that ends in a managed basename out of a command
+  // string. Handles: `node "/a/x.js"`, `"/abs/node" "/a/x.js"`, `bash /a/x.sh`.
+  const managedAlt = [...MANAGED_HOOK_BASENAMES]
+    .map(b => b.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|');
+  const reManaged = new RegExp(`(?:"([^"]*(?:${managedAlt}))"|'([^']*(?:${managedAlt}))'|(\\S*(?:${managedAlt})))`);
+
+  const targetMissing = (command) => {
+    const m = reManaged.exec(command);
+    if (!m) return false; // not a managed-script command — leave it alone
+    let scriptPath = m[1] || m[2] || m[3];
+    if (!scriptPath) return false;
+    if (!path.isAbsolute(scriptPath)) scriptPath = path.join(baseDir, scriptPath);
+    return !fs.existsSync(scriptPath);
+  };
+
+  if (settings.hooks && typeof settings.hooks === 'object') {
+    validateHookFields(settings);
+  }
+  if (settings.hooks && typeof settings.hooks === 'object') {
+    for (const ev of Object.keys(settings.hooks)) {
+      if (!Array.isArray(settings.hooks[ev])) { delete settings.hooks[ev]; continue; }
+      const before = settings.hooks[ev].length;
+      settings.hooks[ev] = settings.hooks[ev].filter(entry => {
+        if (!entry || !Array.isArray(entry.hooks)) return true;
+        return !entry.hooks.some(h => h && typeof h.command === 'string' && targetMissing(h.command));
+      });
+      removed += before - settings.hooks[ev].length;
+      if (settings.hooks[ev].length === 0) delete settings.hooks[ev];
+    }
+    if (Object.keys(settings.hooks).length === 0) delete settings.hooks;
+  }
+
+  // statusLine lives outside settings.hooks. A managed statusline command
+  // pointing at a missing script leaves a blank statusline (cosmetic, exits
+  // clean) but is still stale — drop it so Claude Code falls back to default.
+  if (settings.statusLine && typeof settings.statusLine.command === 'string'
+      && targetMissing(settings.statusLine.command)) {
+    delete settings.statusLine;
+    removed++;
+  }
+
+  return removed;
+}
+
 // ── claudeConfigDir ───────────────────────────────────────────────────────
 function claudeConfigDir() {
   if (process.env.CLAUDE_CONFIG_DIR) return process.env.CLAUDE_CONFIG_DIR;
@@ -222,6 +290,7 @@ module.exports = {
   addCommandHook,
   removeCavemanHooks,
   rewriteLegacyManagedHookCommands,
+  pruneOrphanedManagedHooks,
   claudeConfigDir,
   MANAGED_HOOK_BASENAMES,
 };

--- a/tests/installer/unit.settings.test.mjs
+++ b/tests/installer/unit.settings.test.mjs
@@ -167,6 +167,86 @@ test('rewriteLegacyManagedHookCommands ignores already-absolute node commands', 
   assert.equal(n, 0);
 });
 
+test('pruneOrphanedManagedHooks removes managed hook whose target is missing (absolute-node)', () => {
+  const s = {
+    hooks: {
+      SessionStart: [{ hooks: [
+        { type: 'command', command: '"/opt/node/bin/node" "/no/such/dir/caveman-activate.js"' },
+      ] }],
+    },
+  };
+  const removed = SETTINGS.pruneOrphanedManagedHooks(s, '/tmp/__cm_cfg_missing');
+  assert.equal(removed, 1);
+  assert.equal(s.hooks, undefined);
+});
+
+test('pruneOrphanedManagedHooks removes orphan bare-node managed hook', () => {
+  const s = {
+    hooks: {
+      UserPromptSubmit: [{ hooks: [
+        { type: 'command', command: 'node /no/such/dir/caveman-mode-tracker.js' },
+      ] }],
+    },
+  };
+  const removed = SETTINGS.pruneOrphanedManagedHooks(s, '/tmp/__cm_cfg_missing');
+  assert.equal(removed, 1);
+  assert.equal(s.hooks, undefined);
+});
+
+test('pruneOrphanedManagedHooks keeps managed hook whose target exists', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cm-prune-'));
+  const script = path.join(dir, 'caveman-activate.js');
+  fs.writeFileSync(script, '// real');
+  const s = {
+    hooks: {
+      SessionStart: [{ hooks: [
+        { type: 'command', command: `"/opt/node/bin/node" "${script}"` },
+      ] }],
+    },
+  };
+  const removed = SETTINGS.pruneOrphanedManagedHooks(s, dir);
+  assert.equal(removed, 0);
+  assert.equal(s.hooks.SessionStart.length, 1);
+});
+
+test('pruneOrphanedManagedHooks leaves non-managed hooks alone even if missing', () => {
+  const s = {
+    hooks: {
+      SessionStart: [{ hooks: [
+        { type: 'command', command: 'node /no/such/dir/some-user-hook.js' },
+        { type: 'command', command: '[ -n "$SUPERSET_HOME_DIR" ] && "$SUPERSET_HOME_DIR/hooks/notify.sh" || true' },
+      ] }],
+    },
+  };
+  const removed = SETTINGS.pruneOrphanedManagedHooks(s, '/tmp/__cm_cfg_missing');
+  assert.equal(removed, 0);
+  assert.equal(s.hooks.SessionStart[0].hooks.length, 2);
+});
+
+test('pruneOrphanedManagedHooks resolves relative target against configDir', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cm-prune-rel-'));
+  // hooks/caveman-activate.js intentionally NOT created → missing
+  const s = {
+    hooks: {
+      SessionStart: [{ hooks: [
+        { type: 'command', command: 'node hooks/caveman-activate.js' },
+      ] }],
+    },
+  };
+  const removed = SETTINGS.pruneOrphanedManagedHooks(s, dir);
+  assert.equal(removed, 1);
+  assert.equal(s.hooks, undefined);
+});
+
+test('pruneOrphanedManagedHooks drops orphaned managed statusLine', () => {
+  const s = {
+    statusLine: { type: 'command', command: 'bash /no/such/dir/caveman-statusline.sh' },
+  };
+  const removed = SETTINGS.pruneOrphanedManagedHooks(s, '/tmp/__cm_cfg_missing');
+  assert.equal(removed, 1);
+  assert.equal(s.statusLine, undefined);
+});
+
 test('claudeConfigDir honors CLAUDE_CONFIG_DIR env', () => {
   const orig = process.env.CLAUDE_CONFIG_DIR;
   process.env.CLAUDE_CONFIG_DIR = '/tmp/__cm_test_cfg';

--- a/tests/installer/unit.settings.test.mjs
+++ b/tests/installer/unit.settings.test.mjs
@@ -238,6 +238,33 @@ test('pruneOrphanedManagedHooks resolves relative target against configDir', () 
   assert.equal(s.hooks, undefined);
 });
 
+test('pruneOrphanedManagedHooks does NOT match a user script whose name merely contains a managed basename', () => {
+  const s = {
+    hooks: {
+      SessionStart: [{ hooks: [
+        // basename is "mycaveman-activate.js" — not an exact managed basename
+        { type: 'command', command: 'node /no/such/dir/mycaveman-activate.js' },
+      ] }],
+    },
+  };
+  const removed = SETTINGS.pruneOrphanedManagedHooks(s, '/tmp/__cm_cfg_missing');
+  assert.equal(removed, 0);
+  assert.equal(s.hooks.SessionStart[0].hooks.length, 1);
+});
+
+test('pruneOrphanedManagedHooks handles quoted paths containing spaces', () => {
+  const s = {
+    hooks: {
+      SessionStart: [{ hooks: [
+        { type: 'command', command: '"/opt/node/bin/node" "/no such dir/caveman-activate.js"' },
+      ] }],
+    },
+  };
+  const removed = SETTINGS.pruneOrphanedManagedHooks(s, '/tmp/__cm_cfg_missing');
+  assert.equal(removed, 1);
+  assert.equal(s.hooks, undefined);
+});
+
 test('pruneOrphanedManagedHooks drops orphaned managed statusLine', () => {
   const s = {
     statusLine: { type: 'command', command: 'bash /no/such/dir/caveman-statusline.sh' },


### PR DESCRIPTION
## What

Adds `pruneOrphanedManagedHooks()` to `bin/lib/settings.js` and runs it during `installClaude()` to remove managed `settings.json` hook / statusLine entries whose target script no longer exists on disk.

Fixes #471.

## Why

Migrating an old **manual** hook install (`settings.json` hooks → `~/.claude/hooks/caveman-*.js`) to the **Claude Code plugin** disables/renames the local scripts (e.g. `caveman-activate.js` → `caveman-activate.js.disabled`) but leaves the `settings.json` entries pointing at them. Claude Code then runs `node <missing>` every `SessionStart` / `UserPromptSubmit`:

```
SessionStart:startup hook error
Failed with non-blocking status code: node:internal/modules/cjs/loader:1478
Error: Cannot find module '…/.claude/hooks/caveman-activate.js'
```

Non-blocking, so caveman still works (plugin manifest fires) — but every session and prompt is noisy, and the error renders directly above unrelated plugins' output, so it misattributes the failure (I chased a different plugin for two sessions before isolating it to caveman).

Existing helpers don't cover it:
- `rewriteLegacyManagedHookCommands` only matches the **bare-node** shape; these orphans are **absolute-node** (`"/opt/…/node" "…/caveman-activate.js"`), which it explicitly skips.
- `removeCavemanHooks` runs only on **uninstall**.

## How

`pruneOrphanedManagedHooks(settings, configDir)`:
- Extracts the script path from any managed-looking hook command — bare- or absolute-node, quoted or not, and `bash …` for the statusline — by matching the managed basenames (`caveman-activate.js`, `caveman-mode-tracker.js`, `caveman-stats.js`, `caveman-statusline.sh`).
- Resolves relative paths against `configDir` (honors `CLAUDE_CONFIG_DIR`).
- Drops the hook entry / `statusLine` **only when the target file is genuinely missing**. A managed hook whose script still exists is left untouched; non-managed hooks (user/superset notify, `rtk`, etc.) are never touched — safe to run on every install.

`installClaude()` runs the prune **unconditionally**, right after the plugin install step and before the hook-wiring decision, so it self-heals an already-dirty config even when standalone wiring is skipped.

## Relationship to #393

Complementary, not overlapping. #393 prevents the **double-wiring** case (fresh install registers hooks via both plugin manifest and settings.json → fire twice). This cleans **pre-existing orphans** left by a migration that happened before any fix. A user who migrated before #393 still has the dead entries; #393 only gates *new* wiring and never removes them. The two work together.

## Tests

6 new unit cases in `tests/installer/unit.settings.test.mjs`:
- removes absolute-node orphan
- removes bare-node orphan
- keeps managed hook whose target exists
- leaves non-managed hooks alone even if missing
- resolves relative target against `configDir`
- drops orphaned managed `statusLine`

`node --test tests/installer/unit.settings.test.mjs` → 25/25 pass. Verified end-to-end against a `settings.json` reproducing the crash: 3 orphans removed (SessionStart + UserPromptSubmit + statusLine), the superset notify hook preserved.

> Note: `tests/installer/opencode.test.mjs` fails on a clean checkout here (Node 26 `JSON.parse` strictness on a JSONC fixture) — pre-existing, unrelated to this change.

CI will resync any mirrors on merge; no source-of-truth skill files touched.
