### PR TITLE
fix: rename $Args to $InstallArgs in install.ps1 for Windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@ curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.
 **Windows (PowerShell 5.1+)**
 
 ```powershell
-irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 | iex
+$f = "$env:TEMP\caveman-install.ps1"; irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 -OutFile $f; & $f; Remove-Item $f
 ```
 
 What it does:
@@ -202,7 +202,11 @@ Still broken? [Open an issue](https://github.com/JuliusBrussee/caveman/issues).
 
 - Use `install.ps1`, not `install.sh`. Git Bash works for the shell version, but the hook side wires PowerShell counterparts (`caveman-statusline.ps1`).
 - PowerShell 5.1 minimum. Check with `$PSVersionTable.PSVersion`.
-- If `irm | iex` blocks on execution policy: `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass` for the install session, then re-run.
+- **Do NOT use `irm ... | iex`** — it fails with _"Cannot overwrite variable Args"_ because `$Args` is a PowerShell automatic variable that can't be reassigned inside `Invoke-Expression`. Use the download-then-run method instead:
+  ```powershell
+  $f = "$env:TEMP\caveman-install.ps1"; irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 -OutFile $f; & $f; Remove-Item $f
+  ```
+- If execution policy blocks the script: `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass` for the install session, then re-run.
 - Long-running issues: see `docs/install-windows.md` in the repo for manual fallback.
 
 **"My `settings.json` got mangled."**

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ One line. Find every agent. Install for each.
 curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.sh | bash
 
 # Windows (PowerShell 5.1+)
-irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 | iex
+$f = "$env:TEMP\caveman-install.ps1"; irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 -OutFile $f; & $f; Remove-Item $f
 ```
 
 ~30 seconds. Needs Node ≥18. Skip agent you no have. Safe to re-run.

--- a/install.ps1
+++ b/install.ps1
@@ -3,8 +3,8 @@
 # Thin wrapper around bin/install.js (the unified Node installer). Every flag
 # you'd pass to bin/install.js can be passed here; we just forward them.
 #
-# One-line install:
-#   irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 | iex
+# One-line install (download-then-run to avoid Invoke-Expression scope issues):
+#   $f = "$env:TEMP\caveman-install.ps1"; irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 -OutFile $f; & $f; Remove-Item $f
 #
 # Local clone:
 #   pwsh install.ps1 [flags]
@@ -13,11 +13,16 @@
 # truth and constantly drifted (issue #249 was a `node -e "..."` quoting bug
 # that silently dropped the JSON merge step on every Windows install). One
 # Node script works everywhere without quoting bugs.
+#
+# NOTE: The parameter is named $InstallArgs (not $Args) because $Args is a
+# PowerShell automatic variable. Using $Args in param() causes
+# "Cannot overwrite variable Args" when the script is piped to
+# Invoke-Expression (irm ... | iex).
 
 [CmdletBinding()]
 param(
   [Parameter(ValueFromRemainingArguments = $true)]
-  [string[]]$Args
+  [string[]]$InstallArgs
 )
 
 $ErrorActionPreference = "Stop"
@@ -44,7 +49,7 @@ if ($nodeMajor -lt 18) {
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $local = Join-Path $here "bin/install.js"
 if (Test-Path $local) {
-  & node $local @Args
+  & node $local @InstallArgs
   exit $LASTEXITCODE
 }
 
@@ -58,5 +63,5 @@ if (-not $npx) {
 # Do NOT pass `--` here — npm 7+ npx already forwards trailing args to the
 # package, and a literal `--` was tripping bin/install.js's parseArgs as an
 # unknown flag.
-& npx -y "github:$Repo" @Args
+& npx -y "github:$Repo" @InstallArgs
 exit $LASTEXITCODE


### PR DESCRIPTION
## Problem

`install.ps1` uses `$Args` as a `param()` name, but `$Args` is a [PowerShell automatic variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-5.1#args) that cannot be overwritten inside `Invoke-Expression`. When users run the documented one-liner:

```powershell
irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 | iex
```

PowerShell throws:

```
Invoke-Expression : Cannot overwrite variable Args because the variable has been optimized.
    + CategoryInfo          : WriteError: (Args:String) [Invoke-Expression], SessionStateUnauthorizedAccessException
    + FullyQualifiedErrorId : VariableNotWritableRare,Microsoft.PowerShell.Commands.InvokeExpressionCommand
```

This breaks the install on **every Windows machine** using PowerShell 5.1 (the default shell).

### Why it happens

When a script is piped to `Invoke-Expression`, PowerShell compiles the script block in the caller's scope. The automatic `$Args` variable is marked as an optimized/read-only variable in that context, so `param([string[]]$Args)` fails because it tries to reassign it.

Running the script as a file (`& .\install.ps1`) works fine because it gets its own scope — but that defeats the purpose of the one-liner install.

## Environment

- **OS:** Windows 11
- **PowerShell:** 5.1.26100.4061
- **Editor:** VS Code with GitHub Copilot agent
- **Node:** v22.x

## Fix

### 1. `install.ps1` — Rename parameter (3 occurrences)

| Before | After |
|--------|-------|
| `[string[]]$Args` | `[string[]]$InstallArgs` |
| `@Args` (splat in local path) | `@InstallArgs` |
| `@Args` (splat in npx path) | `@InstallArgs` |

Also updated the header comment to use the download-then-run pattern and added a `NOTE` block explaining why `$Args` cannot be used.

### 2. `README.md` — Updated Windows install command

```diff
-# Windows (PowerShell 5.1+)
-irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 | iex
+# Windows (PowerShell 5.1+)
+$f = "$env:TEMP\caveman-install.ps1"; irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 -OutFile $f; & $f; Remove-Item $f
```

### 3. `INSTALL.md` — Updated install command + troubleshooting

- Updated the Windows install command to match README
- Replaced the `irm | iex` troubleshooting bullet with an explicit warning and the correct command

## Testing

1. **Before fix:** `irm ... | iex` → crashes with `VariableNotWritableRare`
2. **After fix (download-then-run):** Downloads to `%TEMP%`, runs in own scope, installs successfully, cleans up temp file
3. **After fix (local clone):** `& .\install.ps1` still works (no regression)
4. **Verified:** All 7 skills installed successfully for GitHub Copilot on Windows 11

## Checklist

- [x] `$Args` → `$InstallArgs` in `install.ps1` (all 3 occurrences)
- [x] README.md Windows command updated
- [x] INSTALL.md Windows command updated
- [x] INSTALL.md troubleshooting section updated
- [x] No breaking changes for macOS/Linux (`install.sh` untouched)
- [x] No breaking changes for local clone usage (`& .\install.ps1` still works)
