### PR TITLE
fix(compress): harden validation, CLI, benchmark, and default model

### DIFF
--- a/plugins/caveman/skills/caveman-compress/scripts/benchmark.py
+++ b/plugins/caveman/skills/caveman-compress/scripts/benchmark.py
@@ -60,8 +60,12 @@ def main():
     # Walk up four dirs: scripts → caveman-compress → skills → repo_root.
     tests_dir = Path(__file__).resolve().parents[3] / "tests" / "caveman-compress"
     if not tests_dir.exists():
-        print(f"❌ Tests dir not found: {tests_dir}")
-        sys.exit(1)
+        # Glob mode is an optional helper that benchmarks the bundled fixtures.
+        # When they are absent (e.g. running from an install copy without the
+        # repo's tests/ tree), degrade gracefully instead of failing.
+        print(f"Note: fixtures dir not found, skipping benchmark: {tests_dir}")
+        print("Pass an original/compressed file pair to benchmark directly.")
+        return
 
     rows = []
     for orig in sorted(tests_dir.glob("*.original.md")):

--- a/plugins/caveman/skills/caveman-compress/scripts/cli.py
+++ b/plugins/caveman/skills/caveman-compress/scripts/cli.py
@@ -3,7 +3,7 @@
 Caveman Compress CLI
 
 Usage:
-    caveman <filepath>
+    python3 -m scripts <filepath>
 """
 
 import sys
@@ -26,7 +26,7 @@ from .detect import detect_file_type, should_compress
 
 
 def print_usage():
-    print("Usage: caveman <filepath>")
+    print("Usage: python3 -m scripts <filepath>")
 
 
 def main():

--- a/plugins/caveman/skills/caveman-compress/scripts/compress.py
+++ b/plugins/caveman/skills/caveman-compress/scripts/compress.py
@@ -80,7 +80,8 @@ def call_claude(prompt: str) -> str:
 
             client = anthropic.Anthropic(api_key=api_key)
             msg = client.messages.create(
-                model=os.environ.get("CAVEMAN_MODEL", "claude-sonnet-4-5"),
+                # Keep in sync with https://docs.anthropic.com/en/docs/about-claude/models
+                model=os.environ.get("CAVEMAN_MODEL", "claude-sonnet-4-6"),
                 max_tokens=8192,
                 messages=[{"role": "user", "content": prompt}],
             )

--- a/plugins/caveman/skills/caveman-compress/scripts/detect.py
+++ b/plugins/caveman/skills/caveman-compress/scripts/detect.py
@@ -17,6 +17,12 @@ SKIP_EXTENSIONS = {
     ".dockerfile", ".makefile", ".csv", ".ini", ".cfg",
 }
 
+# Build files that are code/config but are conventionally EXTENSIONLESS
+# (Dockerfile, Makefile, Dockerfile.prod, Makefile.local). The SKIP_EXTENSIONS
+# entries .dockerfile/.makefile only catch the rare `*.dockerfile` form; match
+# these by basename so the common extensionless variants are skipped too.
+SKIP_BASENAME_REGEX = re.compile(r"(?i)^(dockerfile|makefile)(\..+)?$")
+
 # Patterns that indicate a line is code
 CODE_PATTERNS = [
     re.compile(r"^\s*(import |from .+ import |require\(|const |let |var )"),
@@ -66,6 +72,11 @@ def detect_file_type(filepath: Path) -> str:
         One of: 'natural_language', 'code', 'config', 'unknown'
     """
     ext = filepath.suffix.lower()
+
+    # Extensionless build files (Dockerfile, Makefile, Dockerfile.prod, ...).
+    # Check basename before extension rules so these are never sniffed as prose.
+    if SKIP_BASENAME_REGEX.match(filepath.name):
+        return "config"
 
     # Extension-based classification
     if ext in COMPRESSIBLE_EXTENSIONS:

--- a/plugins/caveman/skills/caveman-compress/scripts/validate.py
+++ b/plugins/caveman/skills/caveman-compress/scripts/validate.py
@@ -38,48 +38,86 @@ def extract_headings(text):
     return [(level, title.strip()) for level, title in HEADING_REGEX.findall(text)]
 
 
-def extract_code_blocks(text):
-    """Line-based fenced code block extractor.
+def _is_blank(line):
+    return line.strip() == ""
 
-    Handles ``` and ~~~ fences with variable length (CommonMark: closing
-    fence must use same char and be at least as long as opening). Supports
-    nested fences (e.g. an outer 4-backtick block wrapping inner 3-backtick
-    content).
+
+def _is_indented_code(line):
+    """A line is indented-code content if it starts with a tab or >=4 spaces."""
+    if line.startswith("\t"):
+        return True
+    return len(line) - len(line.lstrip(" ")) >= 4
+
+
+def _scan_code_blocks(lines):
+    """Walk the lines once and return a list of (start, end_exclusive, kind).
+
+    Covers both block forms the validator must preserve verbatim:
+
+    - Fenced blocks: ``` / ~~~ with variable length (CommonMark — the closing
+      fence uses the same char and is at least as long as the opening one).
+      Nested fences work because a longer outer fence is not closed by a
+      shorter inner one.
+    - Indented blocks: runs of lines indented by a tab or >=4 spaces, separated
+      only by blank lines. Indented code cannot interrupt a paragraph, so a run
+      only starts when the preceding non-blank line is blank (or it is the
+      first content). Trailing blank lines are not part of the block.
     """
-    blocks = []
-    lines = text.split("\n")
+    spans = []
     i = 0
     n = len(lines)
     while i < n:
         m = FENCE_OPEN_REGEX.match(lines[i])
-        if not m:
+        if m:
+            fence_char = m.group(2)[0]
+            fence_len = len(m.group(2))
+            start = i
             i += 1
-            continue
-        fence_char = m.group(2)[0]
-        fence_len = len(m.group(2))
-        open_line = lines[i]
-        block_lines = [open_line]
-        i += 1
-        closed = False
-        while i < n:
-            close_m = FENCE_OPEN_REGEX.match(lines[i])
-            if (
-                close_m
-                and close_m.group(2)[0] == fence_char
-                and len(close_m.group(2)) >= fence_len
-                and close_m.group(3).strip() == ""
-            ):
-                block_lines.append(lines[i])
-                closed = True
+            closed = False
+            while i < n:
+                close_m = FENCE_OPEN_REGEX.match(lines[i])
+                if (
+                    close_m
+                    and close_m.group(2)[0] == fence_char
+                    and len(close_m.group(2)) >= fence_len
+                    and close_m.group(3).strip() == ""
+                ):
+                    i += 1
+                    closed = True
+                    break
                 i += 1
-                break
-            block_lines.append(lines[i])
+            if closed:
+                spans.append((start, i, "fenced"))
+            # Unclosed fences are silently skipped — they indicate malformed
+            # markdown and including them would cause false-positive failures.
+            continue
+
+        # Indented code block: must not interrupt a paragraph, so the line
+        # immediately before the block must be blank (or this is the first line).
+        prev_is_blank = (i == 0) or _is_blank(lines[i - 1])
+        if _is_indented_code(lines[i]) and not _is_blank(lines[i]) and prev_is_blank:
+            start = i
+            last_content = i
             i += 1
-        if closed:
-            blocks.append("\n".join(block_lines))
-        # Unclosed fences are silently skipped — they indicate malformed markdown
-        # and including them would cause false-positive validation failures.
-    return blocks
+            while i < n and (_is_blank(lines[i]) or _is_indented_code(lines[i])):
+                if not _is_blank(lines[i]):
+                    last_content = i
+                i += 1
+            spans.append((start, last_content + 1, "indented"))
+            continue
+
+        i += 1
+    return spans
+
+
+def extract_code_blocks(text):
+    """Extract verbatim code blocks (fenced and indented) for preservation.
+
+    Handles ``` / ~~~ fences with variable length and nesting, plus 4-space /
+    tab indented code blocks. Each block is returned as its exact source text.
+    """
+    lines = text.split("\n")
+    return ["\n".join(lines[start:end]) for start, end, _ in _scan_code_blocks(lines)]
 
 
 def extract_urls(text):
@@ -95,9 +133,19 @@ def count_bullets(text):
 
 
 def extract_inline_codes(text):
-    text_without_fences = re.sub(r"^```[\s\S]*?^```", "", text, flags=re.MULTILINE)
-    text_without_fences = re.sub(r"^~~~[\s\S]*?^~~~", "", text_without_fences, flags=re.MULTILINE)
-    return re.findall(r"`([^`]+)`", text_without_fences)
+    """Find inline `code` spans, excluding anything inside a code block.
+
+    Strips every code-block line (variable-length fenced blocks AND indented
+    blocks) before scanning, so backticks inside e.g. a ```` ````-fenced block
+    or a 4-space-indented block are not mistaken for inline code — which would
+    otherwise cause false validation failures.
+    """
+    lines = text.split("\n")
+    block_lines = set()
+    for start, end, _ in _scan_code_blocks(lines):
+        block_lines.update(range(start, end))
+    kept = [line for idx, line in enumerate(lines) if idx not in block_lines]
+    return re.findall(r"`([^`]+)`", "\n".join(kept))
 
 
 # ---------- Validators ----------
@@ -107,11 +155,14 @@ def validate_headings(orig, comp, result):
     h1 = extract_headings(orig)
     h2 = extract_headings(comp)
 
+    # Headings must be preserved exactly — anchors, TOCs, and cross-links
+    # depend on the exact text and order. A count mismatch and a text/order
+    # change are both hard errors; the elif keeps a count mismatch from also
+    # emitting the (now redundant) text-change error.
     if len(h1) != len(h2):
         result.add_error(f"Heading count mismatch: {len(h1)} vs {len(h2)}")
-
-    if h1 != h2:
-        result.add_warning("Heading text/order changed")
+    elif h1 != h2:
+        result.add_error("Heading text/order changed")
 
 
 def validate_code_blocks(orig, comp, result):
@@ -134,8 +185,17 @@ def validate_paths(orig, comp, result):
     p1 = extract_paths(orig)
     p2 = extract_paths(comp)
 
-    if p1 != p2:
-        result.add_warning(f"Path mismatch: lost={p1 - p2}, added={p2 - p1}")
+    # File paths referenced in the original must survive compression — dropping
+    # or rewriting one silently breaks what the doc points at, so a LOST path is
+    # a hard error. Added matches are kept as a warning: PATH_REGEX is broad and
+    # caveman prose like "pros/cons" or "req/min" can coincidentally match, so
+    # an extra match in the compressed output is noise, not path loss.
+    lost = p1 - p2
+    added = p2 - p1
+    if lost:
+        result.add_error(f"File path(s) lost in compression: {lost}")
+    if added:
+        result.add_warning(f"Path-like tokens added (possibly prose): {added}")
 
 
 def validate_bullets(orig, comp, result):

--- a/skills/caveman-compress/scripts/benchmark.py
+++ b/skills/caveman-compress/scripts/benchmark.py
@@ -60,8 +60,12 @@ def main():
     # Walk up four dirs: scripts → caveman-compress → skills → repo_root.
     tests_dir = Path(__file__).resolve().parents[3] / "tests" / "caveman-compress"
     if not tests_dir.exists():
-        print(f"❌ Tests dir not found: {tests_dir}")
-        sys.exit(1)
+        # Glob mode is an optional helper that benchmarks the bundled fixtures.
+        # When they are absent (e.g. running from an install copy without the
+        # repo's tests/ tree), degrade gracefully instead of failing.
+        print(f"Note: fixtures dir not found, skipping benchmark: {tests_dir}")
+        print("Pass an original/compressed file pair to benchmark directly.")
+        return
 
     rows = []
     for orig in sorted(tests_dir.glob("*.original.md")):

--- a/skills/caveman-compress/scripts/cli.py
+++ b/skills/caveman-compress/scripts/cli.py
@@ -3,7 +3,7 @@
 Caveman Compress CLI
 
 Usage:
-    caveman <filepath>
+    python3 -m scripts <filepath>
 """
 
 import sys
@@ -26,7 +26,7 @@ from .detect import detect_file_type, should_compress
 
 
 def print_usage():
-    print("Usage: caveman <filepath>")
+    print("Usage: python3 -m scripts <filepath>")
 
 
 def main():

--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -80,7 +80,8 @@ def call_claude(prompt: str) -> str:
 
             client = anthropic.Anthropic(api_key=api_key)
             msg = client.messages.create(
-                model=os.environ.get("CAVEMAN_MODEL", "claude-sonnet-4-5"),
+                # Keep in sync with https://docs.anthropic.com/en/docs/about-claude/models
+                model=os.environ.get("CAVEMAN_MODEL", "claude-sonnet-4-6"),
                 max_tokens=8192,
                 messages=[{"role": "user", "content": prompt}],
             )

--- a/skills/caveman-compress/scripts/detect.py
+++ b/skills/caveman-compress/scripts/detect.py
@@ -17,6 +17,12 @@ SKIP_EXTENSIONS = {
     ".dockerfile", ".makefile", ".csv", ".ini", ".cfg",
 }
 
+# Build files that are code/config but are conventionally EXTENSIONLESS
+# (Dockerfile, Makefile, Dockerfile.prod, Makefile.local). The SKIP_EXTENSIONS
+# entries .dockerfile/.makefile only catch the rare `*.dockerfile` form; match
+# these by basename so the common extensionless variants are skipped too.
+SKIP_BASENAME_REGEX = re.compile(r"(?i)^(dockerfile|makefile)(\..+)?$")
+
 # Patterns that indicate a line is code
 CODE_PATTERNS = [
     re.compile(r"^\s*(import |from .+ import |require\(|const |let |var )"),
@@ -66,6 +72,11 @@ def detect_file_type(filepath: Path) -> str:
         One of: 'natural_language', 'code', 'config', 'unknown'
     """
     ext = filepath.suffix.lower()
+
+    # Extensionless build files (Dockerfile, Makefile, Dockerfile.prod, ...).
+    # Check basename before extension rules so these are never sniffed as prose.
+    if SKIP_BASENAME_REGEX.match(filepath.name):
+        return "config"
 
     # Extension-based classification
     if ext in COMPRESSIBLE_EXTENSIONS:

--- a/skills/caveman-compress/scripts/validate.py
+++ b/skills/caveman-compress/scripts/validate.py
@@ -38,48 +38,86 @@ def extract_headings(text):
     return [(level, title.strip()) for level, title in HEADING_REGEX.findall(text)]
 
 
-def extract_code_blocks(text):
-    """Line-based fenced code block extractor.
+def _is_blank(line):
+    return line.strip() == ""
 
-    Handles ``` and ~~~ fences with variable length (CommonMark: closing
-    fence must use same char and be at least as long as opening). Supports
-    nested fences (e.g. an outer 4-backtick block wrapping inner 3-backtick
-    content).
+
+def _is_indented_code(line):
+    """A line is indented-code content if it starts with a tab or >=4 spaces."""
+    if line.startswith("\t"):
+        return True
+    return len(line) - len(line.lstrip(" ")) >= 4
+
+
+def _scan_code_blocks(lines):
+    """Walk the lines once and return a list of (start, end_exclusive, kind).
+
+    Covers both block forms the validator must preserve verbatim:
+
+    - Fenced blocks: ``` / ~~~ with variable length (CommonMark — the closing
+      fence uses the same char and is at least as long as the opening one).
+      Nested fences work because a longer outer fence is not closed by a
+      shorter inner one.
+    - Indented blocks: runs of lines indented by a tab or >=4 spaces, separated
+      only by blank lines. Indented code cannot interrupt a paragraph, so a run
+      only starts when the preceding non-blank line is blank (or it is the
+      first content). Trailing blank lines are not part of the block.
     """
-    blocks = []
-    lines = text.split("\n")
+    spans = []
     i = 0
     n = len(lines)
     while i < n:
         m = FENCE_OPEN_REGEX.match(lines[i])
-        if not m:
+        if m:
+            fence_char = m.group(2)[0]
+            fence_len = len(m.group(2))
+            start = i
             i += 1
-            continue
-        fence_char = m.group(2)[0]
-        fence_len = len(m.group(2))
-        open_line = lines[i]
-        block_lines = [open_line]
-        i += 1
-        closed = False
-        while i < n:
-            close_m = FENCE_OPEN_REGEX.match(lines[i])
-            if (
-                close_m
-                and close_m.group(2)[0] == fence_char
-                and len(close_m.group(2)) >= fence_len
-                and close_m.group(3).strip() == ""
-            ):
-                block_lines.append(lines[i])
-                closed = True
+            closed = False
+            while i < n:
+                close_m = FENCE_OPEN_REGEX.match(lines[i])
+                if (
+                    close_m
+                    and close_m.group(2)[0] == fence_char
+                    and len(close_m.group(2)) >= fence_len
+                    and close_m.group(3).strip() == ""
+                ):
+                    i += 1
+                    closed = True
+                    break
                 i += 1
-                break
-            block_lines.append(lines[i])
+            if closed:
+                spans.append((start, i, "fenced"))
+            # Unclosed fences are silently skipped — they indicate malformed
+            # markdown and including them would cause false-positive failures.
+            continue
+
+        # Indented code block: must not interrupt a paragraph, so the line
+        # immediately before the block must be blank (or this is the first line).
+        prev_is_blank = (i == 0) or _is_blank(lines[i - 1])
+        if _is_indented_code(lines[i]) and not _is_blank(lines[i]) and prev_is_blank:
+            start = i
+            last_content = i
             i += 1
-        if closed:
-            blocks.append("\n".join(block_lines))
-        # Unclosed fences are silently skipped — they indicate malformed markdown
-        # and including them would cause false-positive validation failures.
-    return blocks
+            while i < n and (_is_blank(lines[i]) or _is_indented_code(lines[i])):
+                if not _is_blank(lines[i]):
+                    last_content = i
+                i += 1
+            spans.append((start, last_content + 1, "indented"))
+            continue
+
+        i += 1
+    return spans
+
+
+def extract_code_blocks(text):
+    """Extract verbatim code blocks (fenced and indented) for preservation.
+
+    Handles ``` / ~~~ fences with variable length and nesting, plus 4-space /
+    tab indented code blocks. Each block is returned as its exact source text.
+    """
+    lines = text.split("\n")
+    return ["\n".join(lines[start:end]) for start, end, _ in _scan_code_blocks(lines)]
 
 
 def extract_urls(text):
@@ -95,9 +133,19 @@ def count_bullets(text):
 
 
 def extract_inline_codes(text):
-    text_without_fences = re.sub(r"^```[\s\S]*?^```", "", text, flags=re.MULTILINE)
-    text_without_fences = re.sub(r"^~~~[\s\S]*?^~~~", "", text_without_fences, flags=re.MULTILINE)
-    return re.findall(r"`([^`]+)`", text_without_fences)
+    """Find inline `code` spans, excluding anything inside a code block.
+
+    Strips every code-block line (variable-length fenced blocks AND indented
+    blocks) before scanning, so backticks inside e.g. a ```` ````-fenced block
+    or a 4-space-indented block are not mistaken for inline code — which would
+    otherwise cause false validation failures.
+    """
+    lines = text.split("\n")
+    block_lines = set()
+    for start, end, _ in _scan_code_blocks(lines):
+        block_lines.update(range(start, end))
+    kept = [line for idx, line in enumerate(lines) if idx not in block_lines]
+    return re.findall(r"`([^`]+)`", "\n".join(kept))
 
 
 # ---------- Validators ----------
@@ -107,11 +155,14 @@ def validate_headings(orig, comp, result):
     h1 = extract_headings(orig)
     h2 = extract_headings(comp)
 
+    # Headings must be preserved exactly — anchors, TOCs, and cross-links
+    # depend on the exact text and order. A count mismatch and a text/order
+    # change are both hard errors; the elif keeps a count mismatch from also
+    # emitting the (now redundant) text-change error.
     if len(h1) != len(h2):
         result.add_error(f"Heading count mismatch: {len(h1)} vs {len(h2)}")
-
-    if h1 != h2:
-        result.add_warning("Heading text/order changed")
+    elif h1 != h2:
+        result.add_error("Heading text/order changed")
 
 
 def validate_code_blocks(orig, comp, result):
@@ -134,8 +185,17 @@ def validate_paths(orig, comp, result):
     p1 = extract_paths(orig)
     p2 = extract_paths(comp)
 
-    if p1 != p2:
-        result.add_warning(f"Path mismatch: lost={p1 - p2}, added={p2 - p1}")
+    # File paths referenced in the original must survive compression — dropping
+    # or rewriting one silently breaks what the doc points at, so a LOST path is
+    # a hard error. Added matches are kept as a warning: PATH_REGEX is broad and
+    # caveman prose like "pros/cons" or "req/min" can coincidentally match, so
+    # an extra match in the compressed output is noise, not path loss.
+    lost = p1 - p2
+    added = p2 - p1
+    if lost:
+        result.add_error(f"File path(s) lost in compression: {lost}")
+    if added:
+        result.add_warning(f"Path-like tokens added (possibly prose): {added}")
 
 
 def validate_bullets(orig, comp, result):

--- a/tests/caveman-compress/claude-md-project.md
+++ b/tests/caveman-compress/claude-md-project.md
@@ -87,7 +87,7 @@ Rules:
 * Mock external services
 * Do NOT mock DB in integration tests
 
-## Git Workflow
+### Git Workflow
 
 Trunk-based development.
 Short-lived feature branches → PR → merge to `main`.

--- a/tests/test_validate_inline.py
+++ b/tests/test_validate_inline.py
@@ -8,9 +8,12 @@ sys.path.insert(0, str(REPO_ROOT / "skills" / "caveman-compress"))
 
 from scripts.validate import (  # noqa: E402
     ValidationResult,
+    extract_code_blocks,
     extract_inline_codes,
     validate,
+    validate_headings,
     validate_inline_codes,
+    validate_paths,
 )
 
 
@@ -68,6 +71,104 @@ class TestValidateInlineCodes(unittest.TestCase):
     def test_both_empty(self):
         result = ValidationResult()
         validate_inline_codes("plain text", "also plain", result)
+        self.assertTrue(result.is_valid)
+
+
+class TestVariableLengthFences(unittest.TestCase):
+    """Fix #5 — backticks inside a 4+ backtick fence must not count as inline."""
+
+    def test_four_backtick_fence_excludes_inner_backticks(self):
+        text = "````\n`not inline` ```nested```\n````\n`real inline`"
+        self.assertEqual(extract_inline_codes(text), ["real inline"])
+
+    def test_tilde_variable_fence(self):
+        text = "~~~~\n`inside tilde block`\n~~~~\n`outside`"
+        self.assertEqual(extract_inline_codes(text), ["outside"])
+
+    def test_closing_fence_must_be_at_least_open_length(self):
+        # A 3-backtick line does NOT close a 4-backtick fence; the whole region
+        # (including the would-be inline backticks) stays a single code block.
+        text = "````\n`a`\n```\n`b`\n````\n`outside`"
+        self.assertEqual(extract_inline_codes(text), ["outside"])
+
+
+class TestIndentedCodeBlocks(unittest.TestCase):
+    """Fix #6 — 4-space / tab indented code blocks are preserved like fenced."""
+
+    def test_indented_block_extracted(self):
+        text = "Para.\n\n    code line one\n    code line two\n\nMore prose."
+        blocks = extract_code_blocks(text)
+        self.assertEqual(blocks, ["    code line one\n    code line two"])
+
+    def test_tab_indented_block_extracted(self):
+        text = "Para.\n\n\ttabbed code\n\nProse."
+        self.assertEqual(extract_code_blocks(text), ["\ttabbed code"])
+
+    def test_inline_backticks_in_indented_block_ignored(self):
+        text = "Intro.\n\n    `looks inline but is code`\n\n`truly inline`"
+        self.assertEqual(extract_inline_codes(text), ["truly inline"])
+
+    def test_indented_code_loss_fails_validation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = Path(tmp) / "o.md"
+            comp = Path(tmp) / "c.md"
+            orig.write_text("Intro.\n\n    keep me verbatim\n\nEnd.")
+            comp.write_text("Intro.\n\nEnd.")
+            result = validate(orig, comp)
+            self.assertFalse(result.is_valid)
+            self.assertTrue(any("Code blocks not preserved" in e for e in result.errors))
+
+
+class TestHeadingExactEnforced(unittest.TestCase):
+    """Fix #7 / #9 — heading text/order/level change is an ERROR, not a warning;
+    a count mismatch does not also emit the redundant text-change message."""
+
+    def test_heading_text_change_is_error(self):
+        result = ValidationResult()
+        validate_headings("## API Reference\n", "## API\n", result)
+        self.assertFalse(result.is_valid)
+        self.assertTrue(any("Heading text/order changed" in e for e in result.errors))
+        self.assertEqual(result.warnings, [])
+
+    def test_heading_level_change_is_error(self):
+        result = ValidationResult()
+        validate_headings("### Git Workflow\n", "## Git Workflow\n", result)
+        self.assertFalse(result.is_valid)
+
+    def test_heading_count_mismatch_no_redundant_warning(self):
+        result = ValidationResult()
+        validate_headings("# A\n## B\n", "# A\n", result)
+        self.assertFalse(result.is_valid)
+        self.assertEqual(len(result.errors), 1)
+        self.assertIn("Heading count mismatch", result.errors[0])
+        self.assertEqual(result.warnings, [])
+
+    def test_identical_headings_pass(self):
+        result = ValidationResult()
+        validate_headings("# A\n## B\n", "# A\n## B\n", result)
+        self.assertTrue(result.is_valid)
+
+
+class TestPathLossEnforced(unittest.TestCase):
+    """Fix #8 — a referenced path dropped/changed is an ERROR; spurious
+    prose-like matches that only appear in the compressed output stay a warning."""
+
+    def test_lost_path_is_error(self):
+        result = ValidationResult()
+        validate_paths("See ./src/app.py for details", "See for details", result)
+        self.assertFalse(result.is_valid)
+        self.assertTrue(any("path(s) lost" in e.lower() for e in result.errors))
+
+    def test_added_prose_match_is_warning_not_error(self):
+        result = ValidationResult()
+        # "pros/cons" is caveman prose, not a real path; it must not fail.
+        validate_paths("weigh the options", "weigh pros/cons", result)
+        self.assertTrue(result.is_valid)
+        self.assertTrue(result.warnings)
+
+    def test_preserved_path_passes(self):
+        result = ValidationResult()
+        validate_paths("edit ./config/settings.json now", "edit ./config/settings.json", result)
         self.assertTrue(result.is_valid)
 
 


### PR DESCRIPTION
## Summary

Five fixes to the `caveman-compress` skill (in `skills/caveman-compress/scripts/`
and the synced copy). Each closes a correctness gap where the validator could
pass while the compressed output lost structure, or where a helper failed in an
install-only copy.

### Fixes

- **Validation hardening (`validate.py`)** — five gaps:
  - *Variable-length fences*: `extract_inline_codes` only stripped exact 3-char
    ` ``` `/`~~~` fences, so backticks inside a 4+ backtick block were misread as
    inline code → false failures. Now reuses the CommonMark fence-aware scanner
    (closing fence ≥ opening length).
  - *Indented code blocks*: 4-space/tab blocks were treated as prose and could be
    silently rewritten while validation passed. Now extracted and preserved like
    fenced blocks.
  - *Headings exact*: a heading text/order/level change with equal count was only
    a warning (accepted by `compress_file`). Anchors/TOCs/cross-links depend on
    exact headings → now a hard error.
  - *Redundant warning*: a count mismatch fired both an error and the text-change
    warning; the text branch is now `elif` → one error per condition, no noise.
  - *File paths exact*: a dropped/changed referenced path was only a warning → a
    *lost* path is now a hard error; an extra path-like token only in the output
    stays a warning (PATH_REGEX is broad; caveman prose like "pros/cons" can
    coincidentally match).
- **Extensionless build files (`detect.py`)** — `SKIP_EXTENSIONS` only matched the
  rare `*.dockerfile`/`*.makefile` forms, so real `Dockerfile`/`Makefile`
  (extensionless or `Dockerfile.prod`) fell through and could be compressed as
  prose. Adds a case-insensitive basename match that runs before the extension
  rules.
- **Benchmark degrades gracefully (`benchmark.py`)** — glob/no-args mode called
  `sys.exit(1)` when `tests/caveman-compress` was absent (an install copy without
  the repo's `tests/` tree). Benchmarking bundled fixtures is optional → prints a
  note and exits 0. Direct file-pair mode unchanged.
- **CLI usage (`cli.py`)** — corrects the printed usage to the module invocation.
- **Default model (`compress.py`)** — bumps the default to `claude-sonnet-4-6`.

### Tests

- Adds `tests/test_validate_inline.py`: fail/pass coverage for variable-length
  fences, indented blocks, heading-exact failures (text/level/count, no redundant
  warning), and path-loss-vs-prose.
- Corrects the `claude-md-project` compressed fixture, which had mutated a heading
  level (`###` → `##`) — that encoded the old warn-only behavior and now fails the
  headings-exact rule.

Local verification on this branch:
- `python3 -m unittest tests.test_validate_inline tests.test_compress_safety` → **29 tests OK**
- `python3 tests/verify_repo.py` → **all checks passed**

---

Co-authored-by: claude <noreply@anthropic.com>
