### PR TITLE
feat(caveman): extend write-normal carve-out to issue/PR/MR titles and descriptions

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -71,4 +71,4 @@ Example — destructive op:
 
 ## Boundaries
 
-Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+Code/commits/issue+PR+MR titles+descriptions: write normal prose. "stop caveman" or "normal mode": revert. Level persist until changed or session end.

--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -107,7 +107,7 @@ if (skillContent) {
     '## Auto-Clarity\n\n' +
     'Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.\n\n' +
     '## Boundaries\n\n' +
-    'Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.';
+    'Code/commits/issue+PR+MR titles+descriptions: write normal prose. "stop caveman" or "normal mode": revert. Level persist until changed or session end.';
 }
 
 // 3. Detect missing statusline config — nudge Claude to help set it up

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -123,7 +123,7 @@ process.stdin.on('end', () => {
           hookEventName: "UserPromptSubmit",
           additionalContext: "CAVEMAN MODE ACTIVE (" + activeMode + "). " +
             "Drop articles/filler/pleasantries/hedging. Fragments OK. " +
-            "Code/commits/security: write normal."
+            "Code/commits/security/issue+PR+MR titles+descriptions: write normal prose."
         }
       }));
     }

--- a/src/plugins/opencode/commands/caveman.md
+++ b/src/plugins/opencode/commands/caveman.md
@@ -10,4 +10,4 @@ Fragments OK. Technical terms exact. Code unchanged.
 Pattern: [thing] [action] [reason]. [next step].
 
 Behavior persists until session ends or user says "stop caveman" / "normal mode".
-Code, commits, security warnings: write normal English.
+Code, commits, security warnings, issue/PR/MR titles and descriptions: write normal English prose.

--- a/src/plugins/opencode/plugin.js
+++ b/src/plugins/opencode/plugin.js
@@ -64,7 +64,7 @@ const flagPath = path.join(opencodeConfigDir(), '.caveman-active');
 function reinforcementLine(mode) {
   return 'CAVEMAN MODE ACTIVE (' + mode + '). ' +
     'Drop articles/filler/pleasantries/hedging. Fragments OK. ' +
-    'Code/commits/security: write normal.';
+    'Code/commits/security/issue+PR+MR titles+descriptions: write normal prose.';
 }
 
 // Parse a prompt for slash-command activation or natural-language toggles.

--- a/src/rules/caveman-activate.md
+++ b/src/rules/caveman-activate.md
@@ -12,4 +12,4 @@ Stop: "stop caveman" or "normal mode"
 
 Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
 
-Boundaries: code/commits/PRs written normal.
+Boundaries: code/commits/issue+PR+MR titles+descriptions written in normal prose.

--- a/src/tools/caveman-init.js
+++ b/src/tools/caveman-init.js
@@ -29,7 +29,7 @@ Stop: "stop caveman" or "normal mode"
 
 Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
 
-Boundaries: code/commits/PRs written normal.
+Boundaries: code/commits/issue+PR+MR titles+descriptions written in normal prose.
 `;
 
 const SENTINEL = 'Respond terse like smart caveman';


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

The active-mode reminder and skill boundaries already tell the model to write **code, commits, and security warnings** in normal prose. They say nothing about **issue, pull-request, and merge-request titles and descriptions** — which are prose artifacts that should not be compressed into caveman fragments. In practice the model writes terse fragmented PR/MR/issue text while caveman mode is active.

This extends the existing boundary line to explicitly cover issue/PR/MR titles and descriptions, across every source-of-truth surface that carries the carve-out (CI mirrors under `plugins/` are left untouched and regenerate from these).

## Changes

- `src/hooks/caveman-mode-tracker.js` — per-turn `UserPromptSubmit` reinforcement reminder
- `src/hooks/caveman-activate.js` — `SessionStart` full ruleset `## Boundaries`
- `skills/caveman/SKILL.md` — caveman skill behavior doc `## Boundaries`
- `src/rules/caveman-activate.md` — auto-activation rule body (Cursor/Windsurf/Cline/Copilot)
- `src/tools/caveman-init.js` — per-repo init template
- `src/plugins/opencode/plugin.js` and `src/plugins/opencode/commands/caveman.md` — opencode reminder + command

Each edit changes the single boundary line, e.g. `Code/commits/security: write normal.` becomes `Code/commits/security/issue+PR+MR titles+descriptions: write normal prose.`

## Testing

- `node --test tests/installer/*.test.mjs` — 51 pass, 0 fail
- `node --check` on all edited JS hooks — clean