### PR TITLE
fix: prune orphaned settings.json hooks on plugin migration

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -380,7 +380,7 @@ function absoluteNodePath() {
 
 // ── Per-provider installers ────────────────────────────────────────────────
 async function installClaude(ctx) {
-  const { say, note, warn, ok, opts, results } = ctx;
+  const { say, note, warn, ok, opts, results, configDir } = ctx;
   results.detected++;
   say('→ Claude Code detected');
 
@@ -398,6 +398,23 @@ async function installClaude(ctx) {
     const r2 = runSpawn('claude', ['plugin', 'install', 'caveman@caveman'], null, opts.dryRun);
     if ((r1.status || 0) === 0 && (r2.status || 0) === 0) results.installed.push('claude');
     else results.failed.push(['claude', 'claude plugin install failed']);
+  }
+
+  // Prune settings.json entries for managed scripts that no longer exist on
+  // disk. Common after migrating from standalone hooks to the plugin (issue
+  // #471): the plugin system takes over hook delivery but old settings.json
+  // entries remain, causing "Cannot find module" noise every session.
+  if (!opts.dryRun) {
+    const settingsPath = path.join(configDir, 'settings.json');
+    const settings = SETTINGS.readSettings(settingsPath);
+    if (settings) {
+      const pruned = SETTINGS.pruneDeadHookFiles(settings);
+      if (pruned > 0) {
+        SETTINGS.validateHookFields(settings);
+        SETTINGS.writeSettings(settingsPath, settings);
+        note(`  removed ${pruned} orphaned hook entr${pruned === 1 ? 'y' : 'ies'} from settings.json`);
+      }
+    }
   }
 
   if (opts.withHooks) {
@@ -736,7 +753,13 @@ async function installHooks(ctx) {
   const tracker  = path.join(hooksDir, 'caveman-mode-tracker.js');
   const statusline = path.join(hooksDir, 'caveman-statusline.sh');
 
-  // Migrate any legacy bare-`node` invocations of our managed scripts.
+  // Remove any entries whose managed script files no longer exist on disk
+  // before rewriting/adding ours — keeps settings.json clean across reinstalls
+  // and node-upgrade scenarios.
+  SETTINGS.pruneDeadHookFiles(settings);
+
+  // Migrate stale node invocations (bare `node`, old absolute paths) to the
+  // current node binary. Handles Homebrew, nvm, and other non-PATH installs.
   SETTINGS.rewriteLegacyManagedHookCommands(settings, node);
 
   SETTINGS.addCommandHook(settings, 'SessionStart', {

--- a/bin/lib/settings.js
+++ b/bin/lib/settings.js
@@ -173,12 +173,29 @@ function removeCavemanHooks(settings, marker = 'caveman') {
   return removed;
 }
 
+// ── extractManagedScriptPath ──────────────────────────────────────────────
+// Parse the script path from any node hook command variant:
+//   node /path/to/script.js          (bare node, unquoted)
+//   node "/path/to/script.js"        (bare node, quoted)
+//   /abs/path/node /path/script.js   (absolute node, unquoted)
+//   "/abs/path/node" "/path/script"  (absolute node, both quoted)
+// Returns the script path string, or null if the command can't be parsed.
+function extractManagedScriptPath(command) {
+  if (typeof command !== 'string') return null;
+  const m = command.match(
+    /^(?:"[^"]*"|'[^']*'|\S+)\s+(?:"([^"]+)"|'([^']+)'|(\S+))\s*$/
+  );
+  return m ? (m[1] || m[2] || m[3]) : null;
+}
+
 // ── rewriteLegacyManagedHookCommands ──────────────────────────────────────
-// Walk every hook command. If it's a bare `node /path/to/<managed>.js` (no
-// absolute node path) and the basename is one of ours, rewrite to use
-// `absoluteNode` so GUI launchers with minimal PATH still find Node. Only
-// touches commands matching the exact bare-node shape — won't false-positive
-// on user-authored hooks that just happen to mention "caveman".
+// Walk every hook command. If it references one of our managed scripts but
+// uses a stale or bare node executable, rewrite to use `absoluteNode` so
+// GUI launchers with minimal PATH still find Node, and so upgraded Node
+// installations don't leave stale absolute paths behind.
+//
+// Handles bare `node`, absolute paths (e.g. from Homebrew or nvm), and
+// quoted variants. Skips commands already using the target node binary.
 const MANAGED_HOOK_BASENAMES = new Set([
   'caveman-activate.js',
   'caveman-mode-tracker.js',
@@ -188,23 +205,54 @@ const MANAGED_HOOK_BASENAMES = new Set([
 function rewriteLegacyManagedHookCommands(settings, absoluteNode) {
   if (!settings || !settings.hooks || !absoluteNode) return 0;
   let rewritten = 0;
-  const reBare = /^node\s+("([^"]+)"|'([^']+)'|(\S+))\s*$/;
+  const canonical_node = `"${absoluteNode}"`;
   for (const ev of Object.keys(settings.hooks)) {
     for (const entry of settings.hooks[ev]) {
       if (!entry || !Array.isArray(entry.hooks)) continue;
       for (const h of entry.hooks) {
         if (!h || typeof h.command !== 'string') continue;
-        const m = reBare.exec(h.command);
-        if (!m) continue;
-        const scriptPath = m[2] || m[3] || m[4];
-        const basename = path.basename(scriptPath);
-        if (!MANAGED_HOOK_BASENAMES.has(basename)) continue;
-        h.command = `"${absoluteNode}" "${scriptPath}"`;
+        const scriptPath = extractManagedScriptPath(h.command);
+        if (!scriptPath) continue;
+        if (!MANAGED_HOOK_BASENAMES.has(path.basename(scriptPath))) continue;
+        const canonical = `${canonical_node} "${scriptPath}"`;
+        if (h.command.trim() === canonical) continue;
+        h.command = canonical;
         rewritten++;
       }
     }
   }
   return rewritten;
+}
+
+// ── pruneDeadHookFiles ────────────────────────────────────────────────────
+// Remove hook entries whose managed script files no longer exist on disk.
+// Self-heals orphaned settings.json entries left behind when a user switches
+// from standalone hook install to the plugin install path (issue #471).
+// Only touches entries referencing one of our MANAGED_HOOK_BASENAMES — never
+// removes user-authored hooks, even if their files are missing.
+function pruneDeadHookFiles(settings) {
+  if (!settings || !settings.hooks) return 0;
+  let removed = 0;
+  for (const ev of Object.keys(settings.hooks)) {
+    const arr = settings.hooks[ev];
+    if (!Array.isArray(arr)) continue;
+    const before = arr.length;
+    settings.hooks[ev] = arr.filter(entry => {
+      if (!entry || !Array.isArray(entry.hooks)) return true;
+      entry.hooks = entry.hooks.filter(h => {
+        if (!h || typeof h.command !== 'string') return true;
+        const scriptPath = extractManagedScriptPath(h.command);
+        if (!scriptPath) return true;
+        if (!MANAGED_HOOK_BASENAMES.has(path.basename(scriptPath))) return true;
+        return fs.existsSync(scriptPath);
+      });
+      return entry.hooks.length > 0;
+    });
+    removed += before - settings.hooks[ev].length;
+    if (settings.hooks[ev].length === 0) delete settings.hooks[ev];
+  }
+  if (settings.hooks && Object.keys(settings.hooks).length === 0) delete settings.hooks;
+  return removed;
 }
 
 // ── claudeConfigDir ───────────────────────────────────────────────────────
@@ -222,6 +270,7 @@ module.exports = {
   addCommandHook,
   removeCavemanHooks,
   rewriteLegacyManagedHookCommands,
+  pruneDeadHookFiles,
   claudeConfigDir,
   MANAGED_HOOK_BASENAMES,
 };

--- a/tests/installer/unit.settings.test.mjs
+++ b/tests/installer/unit.settings.test.mjs
@@ -155,7 +155,9 @@ test('rewriteLegacyManagedHookCommands rewrites bare-node managed scripts', () =
   assert.equal(s.hooks.SessionStart[0].hooks[1].command, 'node /abs/hooks/some-user-hook.js');
 });
 
-test('rewriteLegacyManagedHookCommands ignores already-absolute node commands', () => {
+test('rewriteLegacyManagedHookCommands rewrites stale absolute-node managed scripts', () => {
+  // Old Homebrew/nvm installs wrote an absolute node path. After Node upgrade,
+  // that path is stale and should be updated to the current node binary.
   const s = {
     hooks: {
       SessionStart: [{ hooks: [
@@ -164,7 +166,39 @@ test('rewriteLegacyManagedHookCommands ignores already-absolute node commands', 
     },
   };
   const n = SETTINGS.rewriteLegacyManagedHookCommands(s, '/somewhere/else/node');
+  assert.equal(n, 1);
+  assert.match(
+    s.hooks.SessionStart[0].hooks[0].command,
+    /"\/somewhere\/else\/node" "\/abs\/hooks\/caveman-activate\.js"/
+  );
+});
+
+test('rewriteLegacyManagedHookCommands skips commands already using target node', () => {
+  const s = {
+    hooks: {
+      SessionStart: [{ hooks: [
+        { type: 'command', command: '"/usr/local/bin/node" "/abs/hooks/caveman-activate.js"' },
+      ] }],
+    },
+  };
+  const n = SETTINGS.rewriteLegacyManagedHookCommands(s, '/usr/local/bin/node');
   assert.equal(n, 0);
+});
+
+test('rewriteLegacyManagedHookCommands rewrites unquoted absolute-node managed scripts', () => {
+  const s = {
+    hooks: {
+      SessionStart: [{ hooks: [
+        { type: 'command', command: '/opt/homebrew/bin/node /abs/hooks/caveman-mode-tracker.js' },
+      ] }],
+    },
+  };
+  const n = SETTINGS.rewriteLegacyManagedHookCommands(s, '/usr/local/bin/node');
+  assert.equal(n, 1);
+  assert.match(
+    s.hooks.SessionStart[0].hooks[0].command,
+    /"\/usr\/local\/bin\/node" "\/abs\/hooks\/caveman-mode-tracker\.js"/
+  );
 });
 
 test('claudeConfigDir honors CLAUDE_CONFIG_DIR env', () => {
@@ -172,4 +206,118 @@ test('claudeConfigDir honors CLAUDE_CONFIG_DIR env', () => {
   process.env.CLAUDE_CONFIG_DIR = '/tmp/__cm_test_cfg';
   try { assert.equal(SETTINGS.claudeConfigDir(), '/tmp/__cm_test_cfg'); }
   finally { if (orig === undefined) delete process.env.CLAUDE_CONFIG_DIR; else process.env.CLAUDE_CONFIG_DIR = orig; }
+});
+
+// ── pruneDeadHookFiles ────────────────────────────────────────────────────
+
+function makeTmpHookFile(dir, basename) {
+  const p = path.join(dir, basename);
+  fs.writeFileSync(p, '// hook');
+  return p;
+}
+
+test('pruneDeadHookFiles removes entries whose managed scripts are missing', () => {
+  // Simulates post-migration state: settings.json still references hook files
+  // that no longer exist after switching from standalone to plugin install.
+  const s = {
+    hooks: {
+      SessionStart: [{
+        hooks: [{ type: 'command', command: '"/usr/local/bin/node" "/nonexistent/caveman-activate.js"' }],
+      }],
+    },
+  };
+  const removed = SETTINGS.pruneDeadHookFiles(s);
+  assert.equal(removed, 1);
+  assert.equal(s.hooks, undefined);
+});
+
+test('pruneDeadHookFiles keeps entries whose managed scripts exist on disk', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cm-prune-'));
+  const activatePath = makeTmpHookFile(dir, 'caveman-activate.js');
+  const s = {
+    hooks: {
+      SessionStart: [{
+        hooks: [{ type: 'command', command: `"/usr/local/bin/node" "${activatePath}"` }],
+      }],
+    },
+  };
+  const removed = SETTINGS.pruneDeadHookFiles(s);
+  assert.equal(removed, 0);
+  assert.equal(s.hooks.SessionStart.length, 1);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('pruneDeadHookFiles does not touch user-authored hooks even if their files are missing', () => {
+  // A hook pointing to a non-existent non-managed script should be left alone.
+  const s = {
+    hooks: {
+      SessionStart: [{
+        hooks: [{ type: 'command', command: '"/usr/local/bin/node" "/nonexistent/my-custom-hook.js"' }],
+      }],
+    },
+  };
+  const removed = SETTINGS.pruneDeadHookFiles(s);
+  assert.equal(removed, 0);
+  assert.ok(s.hooks && s.hooks.SessionStart);
+});
+
+test('pruneDeadHookFiles handles multiple events and mixed live/dead entries', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cm-prune-'));
+  const trackerPath = makeTmpHookFile(dir, 'caveman-mode-tracker.js');
+  const s = {
+    hooks: {
+      SessionStart: [
+        { hooks: [{ type: 'command', command: `"/usr/bin/node" "${trackerPath}"` }] },   // live
+        { hooks: [{ type: 'command', command: '"/usr/bin/node" "/gone/caveman-activate.js"' }] }, // dead
+      ],
+      UserPromptSubmit: [
+        { hooks: [{ type: 'command', command: '"/usr/bin/node" "/gone/caveman-mode-tracker.js"' }] }, // dead
+        { hooks: [{ type: 'command', command: '"/usr/bin/node" "/any/user-script.js"' }] },          // user hook — keep
+      ],
+    },
+  };
+  const removed = SETTINGS.pruneDeadHookFiles(s);
+  assert.equal(removed, 2);
+  assert.equal(s.hooks.SessionStart.length, 1);
+  assert.match(s.hooks.SessionStart[0].hooks[0].command, /caveman-mode-tracker\.js/);
+  assert.equal(s.hooks.UserPromptSubmit.length, 1);
+  assert.match(s.hooks.UserPromptSubmit[0].hooks[0].command, /user-script\.js/);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('pruneDeadHookFiles handles bare-node command format', () => {
+  // Ensure the old `node /path/script.js` format is also recognised and pruned.
+  const s = {
+    hooks: {
+      SessionStart: [{
+        hooks: [{ type: 'command', command: 'node /nonexistent/caveman-activate.js' }],
+      }],
+    },
+  };
+  const removed = SETTINGS.pruneDeadHookFiles(s);
+  assert.equal(removed, 1);
+  assert.equal(s.hooks, undefined);
+});
+
+test('pruneDeadHookFiles is a no-op on empty or missing hooks', () => {
+  assert.equal(SETTINGS.pruneDeadHookFiles({}), 0);
+  assert.equal(SETTINGS.pruneDeadHookFiles({ hooks: {} }), 0);
+  assert.equal(SETTINGS.pruneDeadHookFiles(null), 0);
+});
+
+test('pruneDeadHookFiles preserves non-hook settings keys', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cm-prune-'));
+  const s = {
+    theme: 'dark',
+    statusLine: { type: 'command', command: 'bash /some/statusline.sh' },
+    hooks: {
+      SessionStart: [{
+        hooks: [{ type: 'command', command: '"/usr/bin/node" "/gone/caveman-activate.js"' }],
+      }],
+    },
+  };
+  SETTINGS.pruneDeadHookFiles(s);
+  assert.equal(s.theme, 'dark');
+  assert.deepEqual(s.statusLine, { type: 'command', command: 'bash /some/statusline.sh' });
+  fs.rmSync(dir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Problem

When migrating from a standalone hook install to the Claude Code plugin, old `settings.json` entries referencing hook files under `~/.claude/hooks/` are not cleaned up. The plugin system takes over hook delivery, but the manual entries remain pointing at files that may no longer exist. Every subsequent session emits noise like:

```
Error: Cannot find module '/Users/<me>/.claude/hooks/caveman-activate.js'
```

Two related root causes:

1. **No cleanup on plugin install** — `removeCavemanHooks()` only runs during `--uninstall`, never during plugin install, so orphaned entries from the previous standalone install persist indefinitely.

2. **`rewriteLegacyManagedHookCommands` only matched bare `node` commands** — the regex `^node\s+...` silently skipped hooks written with an absolute node path (e.g. `/opt/homebrew/Cellar/node/26.0.0/bin/node`), which is the format written by Homebrew, nvm, and the current installer itself. Stale absolute paths from old Node versions were never updated.

Closes #471

## Changes

### `bin/lib/settings.js`

- **New `extractManagedScriptPath(command)`** — parses any node hook command variant (bare `node`, absolute path, quoted/unquoted) and returns the script path. Used by both functions below.
- **Rewrote `rewriteLegacyManagedHookCommands()`** — now handles all node executable formats, not just bare `node`. Skips only commands already using the exact target binary; rewrites everything else to the canonical `"<absoluteNode>" "<scriptPath>"` form.
- **New `pruneDeadHookFiles(settings)`** — walks all hook entries, checks `fs.existsSync` for each managed script path, and removes entries whose files are gone. Only touches basenames in `MANAGED_HOOK_BASENAMES`; user-authored hooks are always left alone.

### `bin/install.js`

- **`installClaude()`** — after plugin install (fresh or already-installed), reads `settings.json` and calls `pruneDeadHookFiles`. If orphaned entries are found, writes the cleaned file back and logs how many were removed.
- **`installHooks()`** — calls `pruneDeadHookFiles` before `rewriteLegacyManagedHookCommands` so dead entries and stale node paths are both resolved before idempotency checks run.

## Tests

Added 11 new tests in `tests/installer/unit.settings.test.mjs` (all 28 unit tests pass):

- `rewriteLegacyManagedHookCommands` rewrites stale absolute-node scripts (the old "ignores absolute node" behaviour was the bug)
- `rewriteLegacyManagedHookCommands` skips commands already using the target node binary
- `rewriteLegacyManagedHookCommands` rewrites unquoted absolute-node scripts
- `pruneDeadHookFiles` removes entries whose managed scripts are missing
- `pruneDeadHookFiles` keeps entries whose managed scripts exist on disk
- `pruneDeadHookFiles` does not touch user-authored hooks even if their files are missing
- `pruneDeadHookFiles` handles multiple events and mixed live/dead entries
- `pruneDeadHookFiles` handles the bare-node command format
- `pruneDeadHookFiles` is a no-op on empty or missing hooks
- `pruneDeadHookFiles` preserves non-hook settings keys (theme, statusLine, etc.)