### PR TITLE
Fix configuration issues and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ __pycache__/
 *.pyc
 .venv/
 .env.local
-caveman-compress.md
 **/.DS_Store
 .claude/worktrees/
 evals/snapshots/*.html

--- a/agents/cavecrew-builder.md
+++ b/agents/cavecrew-builder.md
@@ -6,7 +6,13 @@ description: >
   scope. Returns caveman diff receipt. Use when scope is bounded and
   obvious; do NOT use for new features, new files (unless asked), or
   cross-file refactors.
-tools: [Read, Edit, Write, Grep, Glob]
+permission:
+  "*": deny
+  read: allow
+  edit: allow
+  write: allow
+  grep: allow
+  glob: allow
 ---
 
 Caveman-ultra. Drop articles/filler. Code/paths exact, backticked. No narration.

--- a/agents/cavecrew-investigator.md
+++ b/agents/cavecrew-investigator.md
@@ -11,7 +11,6 @@ permission:
   grep: allow
   glob: allow
   bash: allow
-model: haiku
 ---
 
 Caveman-ultra. Drop articles/filler/hedging. Code/symbols/paths exact, backticked. Lead with answer.

--- a/agents/cavecrew-investigator.md
+++ b/agents/cavecrew-investigator.md
@@ -5,7 +5,12 @@ description: >
   "what calls Y", "list all uses of Z", "map this directory". Output is
   caveman-compressed so the main thread eats ~60% fewer tokens than
   vanilla Explore. Refuses to suggest fixes.
-tools: [Read, Grep, Glob, Bash]
+permission:
+  "*": deny
+  read: allow
+  grep: allow
+  glob: allow
+  bash: allow
 model: haiku
 ---
 

--- a/agents/cavecrew-reviewer.md
+++ b/agents/cavecrew-reviewer.md
@@ -10,7 +10,6 @@ permission:
   read: allow
   grep: allow
   bash: allow
-model: haiku
 ---
 
 Caveman-ultra. Findings only. No "looks good", no "I'd suggest", no preamble.

--- a/agents/cavecrew-reviewer.md
+++ b/agents/cavecrew-reviewer.md
@@ -5,7 +5,11 @@ description: >
   no scope creep. Output format `path:line: <emoji> <severity>: <problem>. <fix>.`
   Use for "review this PR", "review my diff", "audit this file". Skips
   formatting nits unless they change meaning.
-tools: [Read, Grep, Bash]
+permission:
+  "*": deny
+  read: allow
+  grep: allow
+  bash: allow
 model: haiku
 ---
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -464,7 +464,7 @@ function installViaSkills(ctx, prov) {
 // (opencode's TUI exposes no plugin-writable badge).
 const OPENCODE_SKILL_DIRS  = ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'cavecrew'];
 const OPENCODE_AGENT_FILES = ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md'];
-const OPENCODE_COMMAND_FILES = ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-compress.md', 'caveman-stats.md', 'caveman-help.md'];
+const OPENCODE_COMMAND_FILES = ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-stats.md', 'caveman-help.md'];
 const OPENCODE_PLUGIN_REL = './plugins/caveman/plugin.js';
 const OPENCODE_AGENTS_MD_SENTINEL = 'Respond terse like smart caveman';
 // Marker fence for the opencode AGENTS.md ruleset block. Same convention as

--- a/bin/install.js
+++ b/bin/install.js
@@ -507,7 +507,7 @@ function installOpencode(ctx) {
   const commandsDir = path.join(dir, 'commands');
   const agentsDir   = path.join(dir, 'agents');
   const skillsDir   = path.join(dir, 'skills');
-  const opencodeJson = path.join(dir, 'opencode.json');
+  const opencodeJson = ['jsonc', 'json'].map(ext => path.join(dir, `opencode.${ext}`)).find(fs.existsSync) || path.join(dir, 'opencode.json');
   const agentsMd     = path.join(dir, 'AGENTS.md');
 
   if (opts.dryRun) {


### PR DESCRIPTION
This pull request updates the permission model for several agent configuration files, replacing the old `tools` field with a more explicit `permission` block. The new format specifies which actions are allowed or denied for each agent, improving clarity and control over agent capabilities.

Permission model migration:

* [`agents/cavecrew-builder.md`](diffhunk://#diff-74b601a309bd4681e1a7a701231d06db847bb30bdfd47c6ec06256cab97e4ce4L9-R15): Replaces the `tools` array with a `permission` block, explicitly allowing `read`, `edit`, `write`, `grep`, and `glob` actions, while denying all others by default.
* [`agents/cavecrew-investigator.md`](diffhunk://#diff-250d80af6c2b7da29e9a18f717c255508c8582dcaf0e8490189c25a87fcb92a5L8-R13): Replaces the `tools` array with a `permission` block, explicitly allowing `read`, `grep`, `glob`, and `bash` actions, while denying all others by default.
* [`agents/cavecrew-reviewer.md`](diffhunk://#diff-b4e30e59fc47ba11522bcf9a20bd4eb2b9b798fd8273a05f1be8f71a1936dc68L8-R12): Replaces the `tools` array with a `permission` block, explicitly allowing `read`, `grep`, and `bash` actions, while denying all others by default.