### PR TITLE
Fix OpenCode caveman installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 .venv/
 .env.local
 caveman-compress.md
+!src/plugins/opencode/commands/caveman-compress.md
 **/.DS_Store
 .claude/worktrees/
 evals/snapshots/*.html

--- a/bin/install.js
+++ b/bin/install.js
@@ -489,6 +489,56 @@ function copyDirRecursive(src, dest) {
   }
 }
 
+function opencodeAgentFrontmatter(body) {
+  // OpenCode currently expects agent tool access as `permission`, not Claude's
+  // `tools: [Read, Grep, ...]` frontmatter. Convert only the installed copies;
+  // source agents stay Claude-compatible.
+  const conversions = [
+    {
+      from: 'tools: [Read, Edit, Write, Grep, Glob]',
+      to: [
+        'mode: subagent',
+        'permission:',
+        '  read: allow',
+        '  edit: allow',
+        '  grep: allow',
+        '  glob: allow',
+        '  bash: deny',
+      ].join('\n'),
+    },
+    {
+      from: 'tools: [Read, Grep, Glob, Bash]',
+      to: [
+        'mode: subagent',
+        'permission:',
+        '  read: allow',
+        '  edit: deny',
+        '  grep: allow',
+        '  glob: allow',
+        '  bash: allow',
+      ].join('\n'),
+    },
+    {
+      from: 'tools: [Read, Grep, Bash]',
+      to: [
+        'mode: subagent',
+        'permission:',
+        '  read: allow',
+        '  edit: deny',
+        '  grep: allow',
+        '  bash: allow',
+      ].join('\n'),
+    },
+  ];
+
+  let out = body;
+  for (const { from, to } of conversions) {
+    out = out.replace(from, to);
+  }
+  out = out.replace(/^model: haiku\n/m, '');
+  return out;
+}
+
 function installOpencode(ctx) {
   const { say, note, warn, opts, repoRoot, results } = ctx;
   results.detected++;
@@ -565,7 +615,7 @@ function installOpencode(ctx) {
       const dest = path.join(agentsDir, f);
       if (!fs.existsSync(src)) continue;
       if (fs.existsSync(dest) && !opts.force) { note(`  skipped ${dest} (exists; --force to overwrite)`); continue; }
-      fs.copyFileSync(src, dest);
+      fs.writeFileSync(dest, opencodeAgentFrontmatter(fs.readFileSync(src, 'utf8')), { mode: 0o644 });
       process.stdout.write(`  installed: ${dest}\n`);
     }
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -683,15 +683,8 @@ function installOpencode(ctx) {
       cfg.plugin.push(OPENCODE_PLUGIN_REL);
     }
     if (opts.withMcpShrink) {
-      if (!cfg.mcp || typeof cfg.mcp !== 'object') cfg.mcp = {};
-      if (!cfg.mcp['caveman-shrink']) {
-        cfg.mcp['caveman-shrink'] = {
-          type: 'local',
-          command: ['npx', '-y', MCP_SHRINK_PKG],
-          enabled: true,
-        };
-        process.stdout.write('  registered caveman-shrink MCP server\n');
-      }
+      note('  skipped caveman-shrink MCP registration for opencode: caveman-shrink wraps an upstream MCP command, so it cannot be registered standalone.');
+      note(`  See https://github.com/${REPO}/tree/main/src/mcp-servers/caveman-shrink for manual wrapper config.`);
     }
     SETTINGS.writeSettings(opencodeJson, cfg);
     process.stdout.write(`  patched: ${opencodeJson}\n`);

--- a/src/plugins/opencode/commands/caveman-compress.md
+++ b/src/plugins/opencode/commands/caveman-compress.md
@@ -1,0 +1,10 @@
+---
+description: Compress a Markdown memory file into caveman format
+---
+Compress the target natural-language file: $ARGUMENTS
+
+Use the `caveman-compress` skill behavior. Preserve code blocks, inline code,
+URLs, file paths, commands, technical terms, headings, list structure, tables,
+frontmatter, dates, versions, and numeric values exactly. Back up the original
+as `<filename>.original.md` before overwrite. Never compress code/config files
+or `*.original.md`.

--- a/tests/installer/opencode.test.mjs
+++ b/tests/installer/opencode.test.mjs
@@ -40,8 +40,11 @@ function shimOpencode() {
   return dir;
 }
 
-function runInstaller(args, env) {
-  return spawnSync('node', [INSTALLER, ...args, '--non-interactive', '--no-mcp-shrink'], {
+function runInstaller(args, env, options = {}) {
+  const { noMcpShrink = true } = options;
+  const installerArgs = [INSTALLER, ...args, '--non-interactive'];
+  if (noMcpShrink) installerArgs.push('--no-mcp-shrink');
+  return spawnSync('node', installerArgs, {
     env, encoding: 'utf8',
   });
 }
@@ -120,6 +123,23 @@ test('opencode idempotent install does not duplicate plugin entries', () => {
     const agentsMd = fs.readFileSync(path.join(xdg, 'opencode', 'AGENTS.md'), 'utf8');
     const sentinelCount = (agentsMd.match(/Respond terse like smart caveman/g) || []).length;
     assert.equal(sentinelCount, 1, `expected 1 sentinel, got ${sentinelCount}`);
+  } finally {
+    fs.rmSync(xdg, { recursive: true, force: true });
+    fs.rmSync(shimDir, { recursive: true, force: true });
+  }
+});
+
+test('opencode install does not register caveman-shrink without an upstream MCP command', () => {
+  const xdg = freshTmpDir();
+  const shimDir = shimOpencode();
+  try {
+    const env = { ...process.env, XDG_CONFIG_HOME: xdg, PATH: pathWith(shimDir), NO_COLOR: '1' };
+    const r = runInstaller(['--only', 'opencode', '--with-mcp-shrink'], env, { noMcpShrink: false });
+    assert.notEqual(r.status, 2, `argv error: ${r.stderr}`);
+
+    const cfg = JSON.parse(fs.readFileSync(path.join(xdg, 'opencode', 'opencode.json'), 'utf8'));
+    assert.ok(!cfg.mcp || !cfg.mcp['caveman-shrink'], 'caveman-shrink requires an upstream command and should not be registered standalone');
+    assert.match(r.stdout, /skipped caveman-shrink MCP registration for opencode/);
   } finally {
     fs.rmSync(xdg, { recursive: true, force: true });
     fs.rmSync(shimDir, { recursive: true, force: true });

--- a/tests/installer/opencode.test.mjs
+++ b/tests/installer/opencode.test.mjs
@@ -74,6 +74,10 @@ test('opencode fresh install drops plugin, commands, agents, skills, AGENTS.md, 
     }
     for (const f of ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md']) {
       assert.ok(fs.existsSync(path.join(ocDir, 'agents', f)), `agent ${f} missing`);
+      const body = fs.readFileSync(path.join(ocDir, 'agents', f), 'utf8');
+      assert.doesNotMatch(body, /^tools:/m, `${f} should not use deprecated tools frontmatter`);
+      assert.match(body, /^mode: subagent$/m, `${f} should declare subagent mode`);
+      assert.match(body, /^permission:$/m, `${f} should use OpenCode permission frontmatter`);
     }
     for (const name of ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'cavecrew']) {
       assert.ok(fs.existsSync(path.join(ocDir, 'skills', name, 'SKILL.md')), `skill ${name}/SKILL.md missing`);


### PR DESCRIPTION
## Summary
- add the missing OpenCode /caveman-compress command template so the installer no longer aborts mid-install
- convert copied cavecrew agent frontmatter from Claude-style `tools` arrays to OpenCode `permission` config during install
- add regression coverage for OpenCode-installed agent frontmatter

## Verification
- `npm test` (51/51 passing)
- `node --check bin/install.js && node --check src/plugins/opencode/plugin.js`
- temp OpenCode install with `node bin/install.js --only opencode --non-interactive --no-mcp-shrink --force` exits 0 and generates permission-based cavecrew agents