### PR TITLE
fix(claude): SessionStart hook SKILL.md path broken after src/ restructure

### DIFF
--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -53,9 +53,11 @@ const modeLabel = mode === 'wenyan' ? 'wenyan-full' : mode;
 // Standalone installs:                __dirname = $CLAUDE_CONFIG_DIR/hooks/, SKILL.md won't exist — falls back to hardcoded rules.
 let skillContent = '';
 const skillCandidates = [
-  path.join(__dirname, '..', '..', 'skills', 'caveman', 'SKILL.md'), // src/hooks/ → plugin root (current layout)
   path.join(__dirname, '..', 'skills', 'caveman', 'SKILL.md'),       // hooks/ → plugin root (legacy layout)
 ];
+if (path.basename(path.dirname(__dirname)) === 'src') {
+  skillCandidates.unshift(path.join(__dirname, '..', '..', 'skills', 'caveman', 'SKILL.md')); // src/hooks/ → plugin root (current layout)
+}
 for (const candidate of skillCandidates) {
   try { skillContent = fs.readFileSync(candidate, 'utf8'); break; } catch (e) {}
 }

--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -48,14 +48,17 @@ if (INDEPENDENT_MODES.has(mode)) {
 const modeLabel = mode === 'wenyan' ? 'wenyan-full' : mode;
 
 // Read SKILL.md — the single source of truth for caveman behavior.
-// Plugin installs: __dirname = <plugin_root>/hooks/, SKILL.md at <plugin_root>/skills/caveman/SKILL.md
-// Standalone installs: __dirname = $CLAUDE_CONFIG_DIR/hooks/, SKILL.md won't exist — falls back to hardcoded rules.
+// Plugin installs (post-restructure): __dirname = <plugin_root>/src/hooks/, SKILL.md at <plugin_root>/skills/caveman/SKILL.md
+// Plugin installs (pre-restructure):  __dirname = <plugin_root>/hooks/,    SKILL.md at <plugin_root>/skills/caveman/SKILL.md
+// Standalone installs:                __dirname = $CLAUDE_CONFIG_DIR/hooks/, SKILL.md won't exist — falls back to hardcoded rules.
 let skillContent = '';
-try {
-  skillContent = fs.readFileSync(
-    path.join(__dirname, '..', 'skills', 'caveman', 'SKILL.md'), 'utf8'
-  );
-} catch (e) { /* standalone install — will use fallback below */ }
+const skillCandidates = [
+  path.join(__dirname, '..', '..', 'skills', 'caveman', 'SKILL.md'), // src/hooks/ → plugin root (current layout)
+  path.join(__dirname, '..', 'skills', 'caveman', 'SKILL.md'),       // hooks/ → plugin root (legacy layout)
+];
+for (const candidate of skillCandidates) {
+  try { skillContent = fs.readFileSync(candidate, 'utf8'); break; } catch (e) {}
+}
 
 let output;
 

--- a/tests/test_activate_skillmd_path.js
+++ b/tests/test_activate_skillmd_path.js
@@ -28,7 +28,7 @@ let failed = 0;
 function runHook(mode) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-activate-test-'));
   try {
-    return execFileSync('node', [HOOK], {
+    return execFileSync(process.execPath, [HOOK], {
       encoding: 'utf8',
       env: { ...process.env, CAVEMAN_DEFAULT_MODE: mode, CLAUDE_CONFIG_DIR: tmp },
     });

--- a/tests/test_activate_skillmd_path.js
+++ b/tests/test_activate_skillmd_path.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Tests for the SessionStart activation hook resolving SKILL.md after the
+// src/ restructure (issue #467). caveman-activate.js lives at src/hooks/, so
+// SKILL.md is two levels up at ../../skills/caveman/SKILL.md. A stale ../skills
+// path silently fell back to the weak hardcoded ruleset.
+//
+// RED/GREEN: reverting the candidate path to only ../skills makes
+// `activation_loads_full_skill` fail — the output drops to the fallback, which
+// has no `## Intensity` table.
+//
+// Run: node tests/test_activate_skillmd_path.js
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const HOOK = path.join(REPO_ROOT, 'src', 'hooks', 'caveman-activate.js');
+// `## Intensity` + the level table exist only in skills/caveman/SKILL.md, never
+// in the hardcoded fallback — so they prove the real file was loaded.
+const SKILL_ONLY_MARKER = '## Intensity';
+
+let passed = 0;
+let failed = 0;
+
+function runHook(mode) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-activate-test-'));
+  try {
+    return execFileSync('node', [HOOK], {
+      encoding: 'utf8',
+      env: { ...process.env, CAVEMAN_DEFAULT_MODE: mode, CLAUDE_CONFIG_DIR: tmp },
+    });
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${e.message}`);
+  }
+}
+
+test('activation loads full SKILL.md (not the weak fallback)', () => {
+  const out = runHook('full');
+  assert.ok(out.includes('CAVEMAN MODE ACTIVE — level: full'), 'missing activation header');
+  assert.ok(
+    out.includes(SKILL_ONLY_MARKER),
+    `expected SKILL.md content ("${SKILL_ONLY_MARKER}"), got fallback:\n${out}`
+  );
+});
+
+test('intensity table is filtered to the active level', () => {
+  const out = runHook('full');
+  assert.ok(out.includes('| **full** |'), 'active level row should be kept');
+  assert.ok(!out.includes('| **lite** |'), 'inactive level rows should be filtered out');
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Fixes #467

## Problem

After the `src/` restructure, `caveman-activate.js` moved from `hooks/` to `src/hooks/`, but the relative path to `skills/caveman/SKILL.md` was not updated. The hook resolved `__dirname/../skills/...` → `src/skills/...` — a path that doesn't exist. `readFileSync` threw, the `catch` swallowed it, and **every session silently served the weak hardcoded fallback ruleset** (no intensity table, no examples). Models drifted back to verbose prose within a few turns.

## Fix

Probe both layouts before falling back:

- `src/hooks/ → ../../skills/caveman/SKILL.md` (current layout)
- `hooks/     → ../skills/caveman/SKILL.md`    (legacy layout)

## Test — real RED → GREEN

`tests/test_activate_skillmd_path.js` spawns the real hook and asserts the full SKILL.md is loaded (the `## Intensity` table is SKILL.md-only — never in the fallback).

**GREEN (fix in place):**
```
✓ activation loads full SKILL.md (not the weak fallback)
✓ intensity table is filtered to the active level
2 passed, 0 failed
```

**RED (candidate path reverted to the stale `../skills`):**
```
✗ activation loads full SKILL.md (not the weak fallback)
    expected SKILL.md content ("## Intensity"), got fallback:
    CAVEMAN MODE ACTIVE — level: full
    Respond terse like smart caveman. … (hardcoded fallback, no ## Intensity)
✗ intensity table is filtered to the active level
0 passed, 2 failed
```
The reverted hook emits the weak fallback — the exact silent-degradation this issue reports. The test proves the SKILL.md path is actually resolved.

Run: `node tests/test_activate_skillmd_path.js`
