### PR TITLE
fix(hooks): load SKILL.md from plugin layout

### DIFF
--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -48,14 +48,26 @@ if (INDEPENDENT_MODES.has(mode)) {
 const modeLabel = mode === 'wenyan' ? 'wenyan-full' : mode;
 
 // Read SKILL.md — the single source of truth for caveman behavior.
-// Plugin installs: __dirname = <plugin_root>/hooks/, SKILL.md at <plugin_root>/skills/caveman/SKILL.md
-// Standalone installs: __dirname = $CLAUDE_CONFIG_DIR/hooks/, SKILL.md won't exist — falls back to hardcoded rules.
+// Plugin layout: hook at <plugin_root>/src/hooks/, SKILL.md two levels up at
+// <plugin_root>/skills/caveman/SKILL.md.
+// Legacy/flat layout: hook one level below skills/.
+// Standalone installs ($CLAUDE_CONFIG_DIR/hooks/) ship no SKILL.md — both
+// probes miss and fall through to the hardcoded fallback below.
 let skillContent = '';
-try {
-  skillContent = fs.readFileSync(
-    path.join(__dirname, '..', 'skills', 'caveman', 'SKILL.md'), 'utf8'
-  );
-} catch (e) { /* standalone install — will use fallback below */ }
+const skillRoots = [];
+if (path.basename(__dirname) === 'hooks' && path.basename(path.dirname(__dirname)) === 'src') {
+  skillRoots.push(['..', '..', 'skills']);
+}
+skillRoots.push(['..', 'skills']);
+
+for (const rel of skillRoots) {
+  try {
+    skillContent = fs.readFileSync(
+      path.join(__dirname, ...rel, 'caveman', 'SKILL.md'), 'utf8'
+    );
+    break;
+  } catch (e) { /* try next candidate layout */ }
+}
 
 let output;
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -155,6 +156,76 @@ class HookScriptTests(unittest.TestCase):
 
             self.assertNotIn("STATUSLINE SETUP NEEDED", result.stdout)
             self.assertEqual((claude_dir / ".caveman-active").read_text(), "full")
+
+    def test_activate_loads_skill_from_plugin_src_layout(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-plugin-layout-") as tmp:
+            plugin_root = Path(tmp) / "plugin"
+            hooks_dir = plugin_root / "src" / "hooks"
+            skill_dir = plugin_root / "skills" / "caveman"
+            claude_dir = Path(tmp) / ".claude"
+            unrelated_cwd = Path(tmp) / "cwd"
+            unrelated_skill_dir = unrelated_cwd / "skills" / "caveman"
+
+            hooks_dir.mkdir(parents=True)
+            skill_dir.mkdir(parents=True)
+            claude_dir.mkdir()
+            unrelated_skill_dir.mkdir(parents=True)
+
+            for name in ("caveman-activate.js", "caveman-config.js", "package.json"):
+                shutil.copy2(REPO_ROOT / "src" / "hooks" / name, hooks_dir / name)
+            shutil.copy2(REPO_ROOT / "skills" / "caveman" / "SKILL.md", skill_dir / "SKILL.md")
+            (unrelated_skill_dir / "SKILL.md").write_text("SENTINEL CWD SKILL\n")
+
+            env = os.environ.copy()
+            env["CAVEMAN_DEFAULT_MODE"] = "full"
+            env["CLAUDE_CONFIG_DIR"] = str(claude_dir)
+            env["HOME"] = str(Path(tmp) / "home")
+            env["USERPROFILE"] = str(Path(tmp) / "home")
+
+            result = subprocess.run(
+                ["node", str(hooks_dir / "caveman-activate.js")],
+                cwd=unrelated_cwd,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+            self.assertIn("## Intensity", result.stdout)
+            self.assertNotIn("Current level:", result.stdout)
+            self.assertNotIn("SENTINEL CWD SKILL", result.stdout)
+
+    def test_activate_standalone_layout_does_not_read_home_skills(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-standalone-layout-") as tmp:
+            home = Path(tmp) / "home"
+            claude_dir = home / ".claude"
+            hooks_dir = claude_dir / "hooks"
+            home_skill_dir = home / "skills" / "caveman"
+
+            hooks_dir.mkdir(parents=True)
+            home_skill_dir.mkdir(parents=True)
+
+            for name in ("caveman-activate.js", "caveman-config.js", "package.json"):
+                shutil.copy2(REPO_ROOT / "src" / "hooks" / name, hooks_dir / name)
+            (home_skill_dir / "SKILL.md").write_text("SENTINEL HOME SKILL\n")
+
+            env = os.environ.copy()
+            env["CAVEMAN_DEFAULT_MODE"] = "full"
+            env["CLAUDE_CONFIG_DIR"] = str(claude_dir)
+            env["HOME"] = str(home)
+            env["USERPROFILE"] = str(home)
+
+            result = subprocess.run(
+                ["node", str(hooks_dir / "caveman-activate.js")],
+                cwd=home,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+            self.assertIn("Current level:", result.stdout)
+            self.assertNotIn("SENTINEL HOME SKILL", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Load `skills/caveman/SKILL.md` from the current plugin `src/hooks` layout before falling back to the legacy flat hook layout.
- Gate the two-level plugin probe to real `src/hooks` installs so standalone hooks under `$CLAUDE_CONFIG_DIR/hooks` cannot accidentally read unrelated `~/skills` content.
- Add regression tests that verify plugin layout loads the real skill file, cwd-local skills are ignored, and standalone layout still falls back when only home-level skills exist.

## Root Cause

The Claude Code plugin manifest runs `${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-activate.js`, so `__dirname` is `<plugin_root>/src/hooks`. The hook still looked for `../skills/caveman/SKILL.md`, which resolves to `<plugin_root>/src/skills/caveman/SKILL.md`. That file does not exist, so the hook silently served the hardcoded fallback instead of the source-of-truth skill body.

That fallback is missing the intensity table and wenyan instructions, so plugin installs did not get the full behavior documented in `skills/caveman/SKILL.md`.

## Validation

- `uv run python -m unittest tests.test_hooks`
- `node src/hooks/caveman-activate.js | rg '## Intensity|Current level:'`
- `git diff --check`
- `uv run python -m unittest tests.test_compress_safety`
- `node tests/test_symlink_flag.js`

Additional documented checks were run and failed for existing baseline issues unrelated to this change:

- `npm test` fails in OpenCode installer tests (`caveman-compress.md` missing / temp OpenCode files absent / JSONC parse expectation). This same failure was observed on clean upstream `main` before this branch.
- `node tests/test_caveman_init.js` fails count-based assertions around current init targets/OpenClaw handling. This same failure was observed on clean upstream `main`.

## Review Notes

Additional review found two hardening gaps in the first draft: the ungated `../../skills` probe could escape standalone hook installs into `~/skills`, and the plugin-layout test used `cwd=plugin_root`. This version gates the plugin probe to `src/hooks`, runs the regression from an unrelated cwd with a sentinel cwd skill, and adds a standalone-home sentinel test.

## Overlap

Several open PRs touch `src/hooks/caveman-activate.js`, including #483, #448, #411, #407, #401, and #377. This PR keeps the scope to the SKILL.md path lookup and its regression test so it can be rebased independently. Older dirty PRs such as #285 and #269 touch the pre-`src` hook path and may need the same path logic if revived.

Fixes #467
