### PR TITLE
fix(install): remove missing caveman-compress.md from OpenCode command files

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -464,7 +464,7 @@ function installViaSkills(ctx, prov) {
 // (opencode's TUI exposes no plugin-writable badge).
 const OPENCODE_SKILL_DIRS  = ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'cavecrew'];
 const OPENCODE_AGENT_FILES = ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md'];
-const OPENCODE_COMMAND_FILES = ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-compress.md', 'caveman-stats.md', 'caveman-help.md'];
+const OPENCODE_COMMAND_FILES = ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-stats.md', 'caveman-help.md'];
 const OPENCODE_PLUGIN_REL = './plugins/caveman/plugin.js';
 const OPENCODE_AGENTS_MD_SENTINEL = 'Respond terse like smart caveman';
 // Marker fence for the opencode AGENTS.md ruleset block. Same convention as
@@ -552,6 +552,7 @@ function installOpencode(ctx) {
     for (const f of OPENCODE_COMMAND_FILES) {
       const src = path.join(cmdSrcDir, f);
       const dest = path.join(commandsDir, f);
+      if (!fs.existsSync(src)) { note(`  skipped ${src} (source missing)`); continue; }
       if (fs.existsSync(dest) && !opts.force) { note(`  skipped ${dest} (exists; --force to overwrite)`); continue; }
       fs.copyFileSync(src, dest);
       process.stdout.write(`  installed: ${dest}\n`);

--- a/tests/installer/opencode.test.mjs
+++ b/tests/installer/opencode.test.mjs
@@ -69,7 +69,7 @@ test('opencode fresh install drops plugin, commands, agents, skills, AGENTS.md, 
     assert.ok(fs.existsSync(path.join(ocDir, 'plugins', 'caveman', 'package.json')), 'plugin package.json missing');
     assert.ok(fs.existsSync(path.join(ocDir, 'plugins', 'caveman', 'caveman-config.cjs')), 'caveman-config.cjs sibling missing');
 
-    for (const f of ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-compress.md', 'caveman-stats.md', 'caveman-help.md']) {
+    for (const f of ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-stats.md', 'caveman-help.md']) {
       assert.ok(fs.existsSync(path.join(ocDir, 'commands', f)), `command ${f} missing`);
     }
     for (const f of ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md']) {


### PR DESCRIPTION
Fixes #491

## Summary

OpenCode install crashes with `ENOENT` because `OPENCODE_COMMAND_FILES` in `bin/install.js` lists `caveman-compress.md`, which does not exist in `src/plugins/opencode/commands/`. The missing source file triggers an uncaught `fs.copyFileSync` error that aborts the entire OpenCode install path before `opencode.json` and `AGENTS.md` are written — cascading into 4 test failures.

### Changes

- **`bin/install.js`**: Remove `'caveman-compress.md'` from `OPENCODE_COMMAND_FILES`. Add `fs.existsSync(src)` guard to the command-copy loop (matching the existing guards in the agent and skill copy loops) so future manifest mismatches degrade gracefully instead of aborting the install.
- **`tests/installer/opencode.test.mjs`**: Remove `'caveman-compress.md'` from the expected command files list so the test assertion matches the canonical manifest.

## Test verification (RED → GREEN)

### RED (fix reverted, commit 655b7d9):

```
# tests 51
# pass 47
# fail 4

not ok 13 - opencode fresh install drops plugin, commands, agents, skills, AGENTS.md, opencode.json
  error: 'command caveman-compress.md missing'
  code: 'ERR_ASSERTION'
  expected: true
  actual: false

not ok 14 - opencode idempotent install does not duplicate plugin entries
  error: "ENOENT: no such file or directory, open '.../opencode/opencode.json'"

not ok 16 - opencode uninstall strips fenced AGENTS.md block, preserving user prefix and suffix
  error: "ENOENT: no such file or directory, open '.../opencode/AGENTS.md'"

not ok 17 - opencode install tolerates JSONC opencode.json (comments + trailing commas)
  error: 'Unexpected token ... is not valid JSON'
```

Tests 14, 16, 17 are cascading failures — the installer throws on the missing source file before it writes `opencode.json` or `AGENTS.md`.

### GREEN (with fix):

```
# tests 51
# pass 51
# fail 0
```

All 51 tests pass, including all 7 opencode tests. `npm test` baseline restored to 100%.
