### PR TITLE
feat(codex): add native caveman hooks

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -2,13 +2,27 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume",
+        "matcher": "startup|resume|clear|compact",
         "hooks": [
           {
             "type": "command",
-            "command": "echo 'CAVEMAN MODE ACTIVE. Rules: Drop articles/filler/pleasantries/hedging. Fragments OK. Short synonyms. Pattern: [thing] [action] [reason]. [next step]. Not: Sure! I would be happy to help you with that. Yes: Bug in auth middleware. Fix: Code/commits/security: write normal. User says stop caveman or normal mode to deactivate.'",
+            "command": "node \"$(git rev-parse --show-toplevel)/plugins/caveman/scripts/caveman-codex-hook.js\" SessionStart",
+            "commandWindows": "for /f \"delims=\" %i in ('git rev-parse --show-toplevel') do node \"%i\\plugins\\caveman\\scripts\\caveman-codex-hook.js\" SessionStart",
             "timeout": 5,
             "statusMessage": "Loading caveman mode"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$(git rev-parse --show-toplevel)/plugins/caveman/scripts/caveman-codex-hook.js\" UserPromptSubmit",
+            "commandWindows": "for /f \"delims=\" %i in ('git rev-parse --show-toplevel') do node \"%i\\plugins\\caveman\\scripts\\caveman-codex-hook.js\" UserPromptSubmit",
+            "timeout": 5,
+            "statusMessage": "Tracking caveman mode"
           }
         ]
       }

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ What it does:
 
 - Auto-detects every supported agent installed on your machine (Claude Code, Cursor, Codex, etc.).
 - For each one, runs that agent's native install path (plugin / extension / rule file / `npx skills add`).
-- Wires Claude Code hooks and statusline badge on top. (`caveman-shrink` MCP middleware is opt-in via `--with-mcp-shrink` — see flag table below.)
+- Wires Claude Code and Codex hooks, plus the Claude Code statusline badge. (`caveman-shrink` MCP middleware is opt-in via `--with-mcp-shrink` — see flag table below.)
 - Skips anything you don't have. Safe to re-run. ~30 seconds end-to-end.
 
 Want to preview before installing? Use `--dry-run`:
@@ -43,7 +43,7 @@ If you want to install for one agent (or want to know exactly what command runs 
 | **Gemini CLI** | `gemini extensions install https://github.com/JuliusBrussee/caveman` | Yes |
 | **opencode** | `node bin/install.js --only opencode` *(or `npx -y github:JuliusBrussee/caveman -- --only opencode`)* | Yes (plugin + AGENTS.md) |
 | **OpenClaw** | `npx -y github:JuliusBrussee/caveman -- --only openclaw` | Yes (workspace skill + SOUL.md) |
-| **Codex CLI** | `npx skills add JuliusBrussee/caveman -a codex` | Per-session: `/caveman` |
+| **Codex CLI** | `npx -y github:JuliusBrussee/caveman -- --only codex` | Yes (`hooks.json`) |
 | **Cursor** | `npx skills add JuliusBrussee/caveman -a cursor` | Per-session by default; `--with-init` for an always-on rule file |
 | **Windsurf** | `npx skills add JuliusBrussee/caveman -a windsurf` | Per-session by default; `--with-init` for an always-on rule file |
 | **Cline** | `npx skills add JuliusBrussee/caveman -a cline` | Per-session by default; `--with-init` for an always-on rule file |
@@ -121,9 +121,9 @@ Useful flags:
 | `--with-init` | Drop always-on rule files into the current repo (`.cursor/`, `.windsurf/`, `.clinerules/`, `.github/copilot-instructions.md`, `.opencode/AGENTS.md`, `AGENTS.md`) and, if OpenClaw is on the box, append the bootstrap block to `~/.openclaw/workspace/SOUL.md`. |
 | `--with-mcp-shrink="<upstream cmd>"` | Register `caveman-shrink` MCP proxy wrapping the given upstream MCP server. **Off by default.** A value is required — caveman-shrink is a proxy and exits immediately without one. Example: `--with-mcp-shrink="npx @modelcontextprotocol/server-filesystem /tmp"`. The value is split on whitespace; for paths-with-spaces, install via `node bin/install.js` from a clone or edit `~/.claude.json` after a stub install. |
 | `--no-mcp-shrink` | Skip MCP-shrink registration. (Default.) |
-| `--with-hooks` / `--no-hooks` | Force-on or force-off the Claude Code hook installer. (Default: on.) |
+| `--with-hooks` / `--no-hooks` | Force-on or force-off the Claude Code and Codex hook installers. (Default: on.) |
 | `--skip-skills` | Don't run the npx-skills auto-detect fallback when nothing else matched. |
-| `--config-dir <path>` | Claude Code config dir for hook files + `settings.json`. **Does NOT scope** `claude plugin install`, `gemini extensions install`, opencode (`XDG_CONFIG_HOME`), or openclaw (`OPENCLAW_WORKSPACE`) — those use their own paths. Default: `$CLAUDE_CONFIG_DIR` or `~/.claude`. `~` is expanded. |
+| `--config-dir <path>` | Hook config dir override. Claude writes hook files + `settings.json`; Codex writes hook files + `hooks.json`. **Does NOT scope** `claude plugin install`, `gemini extensions install`, opencode (`XDG_CONFIG_HOME`), or openclaw (`OPENCLAW_WORKSPACE`) — those use their own paths. Defaults: `$CLAUDE_CONFIG_DIR` or `~/.claude` for Claude; `$CODEX_HOME` or `~/.codex` for Codex. `~` is expanded. |
 | `--non-interactive` | Never prompt; use defaults. (Auto when stdin is not a TTY.) |
 | `--no-color` | Disable ANSI colors. |
 | `--list` | Print full agent matrix and exit. |
@@ -157,7 +157,7 @@ node bin/install.js --list
 
 You should see ~30 rows. Detected agents are marked. Anything you wanted but isn't marked → not detected (likely the binary isn't on `PATH`).
 
-**2. Talk to Claude Code.**
+**2. Talk to Claude Code or Codex.**
 
 Open Claude Code, type `/caveman`. Response should be terse fragments — "Got it. Caveman mode on." or similar. Try a real question: "What is closures in JS?" — answer should drop articles and read like grunts.
 
@@ -166,6 +166,9 @@ Open Claude Code, type `/caveman`. Response should be terse fragments — "Got i
 ```bash
 cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.caveman-active"
 # expected output: full
+
+cat "${XDG_CONFIG_HOME:-$HOME/.config}/caveman/active-mode"
+# expected output after Codex hook activation: full
 ```
 
 If it's missing or empty, the SessionStart hook didn't fire. See troubleshooting below.
@@ -182,6 +185,7 @@ What it removes:
 
 - Caveman hook entries from `$CLAUDE_CONFIG_DIR/settings.json` (default `~/.claude/`; matched by the substring `caveman`).
 - Hook files in `$CLAUDE_CONFIG_DIR/hooks/` (`caveman-activate.js`, `caveman-mode-tracker.js`, `caveman-stats.js`, `caveman-config.js`, `caveman-statusline.{sh,ps1}`, plus the dir's `package.json` marker).
+- Codex hook entries from `$CODEX_HOME/hooks.json` (default `~/.codex/hooks.json`) and `$CODEX_HOME/hooks/caveman-codex-hook.js`.
 - The Claude Code plugin and the Gemini CLI extension (if installed).
 - The opencode native plugin (`~/.config/opencode/plugins/caveman/`, the `plugin` and `mcp.caveman-shrink` entries from `opencode.json`, our skill/agent/command files, the caveman block from `AGENTS.md`, and the opencode flag file).
 - The OpenClaw workspace skill folder and the marker-fenced block from `~/.openclaw/workspace/SOUL.md` (when present).
@@ -211,6 +215,12 @@ Still broken? [Open an issue](https://github.com/JuliusBrussee/caveman/issues).
 3. Check `$CLAUDE_CONFIG_DIR/.caveman-active` exists with content `full`. If not, the SessionStart hook silent-failed — check `$CLAUDE_CONFIG_DIR/hooks/` for the JS files and try `node $CLAUDE_CONFIG_DIR/hooks/caveman-activate.js < /dev/null` to see if it errors.
 4. Restart Claude Code. The SessionStart hook only fires on session start, not mid-session.
 
+**"I ran the installer but Codex isn't talking caveman."**
+
+1. Run `node bin/install.js --list` — confirm `codex` is on the detected list. If not, `codex` isn't on `PATH`.
+2. Open `${CODEX_HOME:-$HOME/.codex}/hooks.json` and look for `"hooks"` containing `caveman-codex-hook.js`. If missing, re-run with `--only codex --force`.
+3. Check `${XDG_CONFIG_HOME:-$HOME/.config}/caveman/active-mode` after starting a new Codex session. Expected content: `full`.
+
 **"Hooks failing on Windows."**
 
 - Use `install.ps1`, not `install.sh`. Git Bash works for the shell version, but the hook side wires PowerShell counterparts (`caveman-statusline.ps1`).
@@ -228,7 +238,7 @@ The installer uses a JSONC-tolerant parser (`bin/lib/settings.js`) so comments a
 
 **"I'm in a managed env where I can't install hooks."**
 
-Use the rule-file-only path. Hooks are Claude Code-specific; everything else works via static rule files:
+Use the rule-file-only path. Hooks are Claude Code/Codex-specific; everything else works via static rule files:
 
 ```bash
 # Just install for one agent, no Claude hooks
@@ -249,6 +259,7 @@ The profile slug must exist in [vercel-labs/skills](https://github.com/vercel-la
 The installer doesn't phone home. It writes to:
 
 - `$CLAUDE_CONFIG_DIR` (default `~/.claude/`) — hooks, flag file, `settings.json` merge.
+- `$CODEX_HOME` (default `~/.codex/`) — Codex hook file and `hooks.json` merge.
 - Each agent's own config location — Cursor's `.cursor/rules/`, Windsurf's `.windsurf/rules/`, opencode's `~/.config/opencode/`, etc.
 - Your current working directory (only with `--with-init`) — repo-local rule files.
 - `~/.openclaw/workspace/` (only with `--only openclaw` or `--with-init` when OpenClaw is detected) — the one `--with-init` side-effect outside the cwd.

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ A March 2026 paper ["Brevity Constraints Reverse Performance Hierarchies in Lang
 
 1. Install drop skill file in agent.
 2. Skill tell agent: drop filler, keep substance, use fragments.
-3. For Claude Code, hook also write tiny flag file each session — agent see flag, talk caveman from message one. No need say `/caveman`.
-4. Stats command read Claude Code session log, count tokens saved, write number to statusline.
+3. For Claude Code and Codex, hook also write tiny flag file each session — agent see flag, talk caveman from message one. No need say `/caveman`.
+4. Stats command read Claude Code or Codex session log, count tokens saved, write number to statusline when agent supports one.
 5. Caveman-compress sub-skill rewrite memory files (CLAUDE.md, project notes) so each session start with smaller context. Save tokens forever, not just one reply.
 
 Maintainer detail (hook architecture, file ownership, CI sync) live in [CLAUDE.md](./CLAUDE.md).

--- a/bin/install.js
+++ b/bin/install.js
@@ -50,6 +50,8 @@ const HOOK_FILES = [
   'caveman-statusline.sh',
   'caveman-statusline.ps1',
 ];
+const CODEX_HOOK_FILE = 'caveman-codex-hook.js';
+const CODEX_HOOK_REMOTE = `${RAW_BASE}/plugins/caveman/scripts/${CODEX_HOOK_FILE}`;
 
 // ── Argv ───────────────────────────────────────────────────────────────────
 function parseArgs(argv) {
@@ -207,7 +209,7 @@ const PROVIDERS = [
   { id: 'gemini',     label: 'Gemini CLI',          mech: 'gemini extensions install',     detect: 'command:gemini' },
   { id: 'opencode',   label: 'opencode',            mech: 'native opencode plugin',        detect: 'command:opencode' },
   { id: 'openclaw',   label: 'OpenClaw',            mech: 'workspace skill + SOUL.md',     detect: 'command:openclaw||dir:$HOME/.openclaw/workspace' },
-  { id: 'codex',      label: 'Codex CLI',           mech: 'npx skills add (codex)',        detect: 'command:codex',           profile: 'codex' },
+  { id: 'codex',      label: 'Codex CLI',           mech: 'npx skills add + native hooks', detect: 'command:codex',           profile: 'codex' },
 
   // IDE / VS Code-family — extension probes are precise. Cursor/Windsurf also
   // ship CLI binaries; we drop the dir fallback because the dir lingers after
@@ -557,6 +559,31 @@ function installViaSkills(ctx, prov) {
   const r = runSpawn('npx', args, null, opts.dryRun);
   if ((r.status || 0) === 0) results.installed.push(prov.id);
   else results.failed.push([prov.id, `npx skills add (${prov.profile}) failed`]);
+  process.stdout.write('\n');
+}
+
+async function installCodex(ctx) {
+  const { say, note, opts, results } = ctx;
+  results.detected++;
+  say('→ Codex CLI detected');
+
+  if (opts.skipSkills) {
+    note('  skipping npx skills install (--skip-skills)');
+  } else {
+    const args = ['-y', 'skills', 'add', REPO, '-a', 'codex', '--yes', '--all'];
+    const r = runSpawn('npx', args, null, opts.dryRun);
+    if ((r.status || 0) === 0) results.installed.push('codex');
+    else results.failed.push(['codex', 'npx skills add (codex) failed']);
+  }
+
+  if (opts.withHooks) {
+    say('  → installing native Codex hooks (--with-hooks)');
+    const r = await installCodexHooks(ctx);
+    if (r === 'ok') results.installed.push('codex-hooks');
+    else if (r === 'skip') results.skipped.push(['codex-hooks', 'already wired']);
+    else results.failed.push(['codex-hooks', r]);
+  }
+
   process.stdout.write('\n');
 }
 
@@ -916,6 +943,102 @@ async function installHooks(ctx) {
   return 'ok';
 }
 
+async function installCodexHooks(ctx) {
+  const { note, warn, opts, repoRoot } = ctx;
+  const codexHome = codexConfigDir(opts);
+  const hooksDir = path.join(codexHome, 'hooks');
+  const hooksJsonPath = path.join(codexHome, 'hooks.json');
+  const scriptDest = path.join(hooksDir, CODEX_HOOK_FILE);
+  const scriptSource = repoRoot ? path.join(repoRoot, 'plugins', 'caveman', 'scripts', CODEX_HOOK_FILE) : null;
+
+  if (opts.dryRun) {
+    note(`  would mkdir -p ${hooksDir}`);
+    note(`  would install ${scriptDest}`);
+    note(`  would merge SessionStart + UserPromptSubmit into ${hooksJsonPath}`);
+    return 'ok';
+  }
+
+  fs.mkdirSync(hooksDir, { recursive: true });
+  if (scriptSource && fs.existsSync(scriptSource)) {
+    fs.copyFileSync(scriptSource, scriptDest);
+  } else {
+    try { await downloadTo(CODEX_HOOK_REMOTE, scriptDest); }
+    catch (e) { return `download ${CODEX_HOOK_FILE} failed: ${e.message}`; }
+  }
+  process.stdout.write(`  installed: ${scriptDest}\n`);
+
+  let config = SETTINGS.readSettings(hooksJsonPath);
+  if (config === null) {
+    warn('  hooks.json unparseable; will not touch it. Edit manually then re-run.');
+    return 'hooks.json unparseable';
+  }
+  if (!config || typeof config !== 'object' || Array.isArray(config)) config = {};
+
+  const bak = hooksJsonPath + '.bak';
+  if (fs.existsSync(hooksJsonPath) && !fs.existsSync(bak)) {
+    try { fs.copyFileSync(hooksJsonPath, bak); } catch (_) {}
+  }
+
+  const node = absoluteNodePath();
+  addCodexCommandHook(config, 'SessionStart', {
+    command: `"${node}" "${scriptDest}" SessionStart`,
+    marker: CODEX_HOOK_FILE,
+    matcher: 'startup|resume|clear|compact',
+    timeout: 5,
+    statusMessage: 'Loading caveman mode',
+  });
+  addCodexCommandHook(config, 'UserPromptSubmit', {
+    command: `"${node}" "${scriptDest}" UserPromptSubmit`,
+    marker: CODEX_HOOK_FILE,
+    timeout: 5,
+    statusMessage: 'Tracking caveman mode',
+  });
+
+  SETTINGS.validateHookFields(config);
+  SETTINGS.writeSettings(hooksJsonPath, config);
+  process.stdout.write(`  hooks wired in ${hooksJsonPath}\n`);
+  return 'ok';
+}
+
+function addCodexCommandHook(config, event, opts) {
+  if (!config.hooks || typeof config.hooks !== 'object') config.hooks = {};
+  if (!Array.isArray(config.hooks[event])) config.hooks[event] = [];
+  const marker = opts.marker || opts.command;
+  const exists = config.hooks[event].some(entry =>
+    entry && Array.isArray(entry.hooks) &&
+    entry.hooks.some(h => h && typeof h.command === 'string' && h.command.includes(marker))
+  );
+  if (exists) return false;
+
+  const hook = { type: 'command', command: opts.command };
+  if (typeof opts.timeout === 'number') hook.timeout = opts.timeout;
+  if (typeof opts.statusMessage === 'string') hook.statusMessage = opts.statusMessage;
+
+  const entry = { hooks: [hook] };
+  if (typeof opts.matcher === 'string') entry.matcher = opts.matcher;
+  config.hooks[event].push(entry);
+  return true;
+}
+
+function codexConfigDir(opts = {}) {
+  if (opts.configDir) return opts.configDir;
+  if (process.env.CODEX_HOME) return process.env.CODEX_HOME;
+  return path.join(os.homedir(), '.codex');
+}
+
+function cavemanConfigDir() {
+  if (process.env.XDG_CONFIG_HOME) {
+    return path.join(process.env.XDG_CONFIG_HOME, 'caveman');
+  }
+  if (process.platform === 'win32') {
+    return path.join(
+      process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'),
+      'caveman'
+    );
+  }
+  return path.join(os.homedir(), '.config', 'caveman');
+}
+
 // ── MCP shrink wiring ─────────────────────────────────────────────────────
 function installMcpShrink(ctx) {
   const { note, warn, opts } = ctx;
@@ -1071,6 +1194,8 @@ function uninstall(ctx) {
     // Don't rmdir hooksDir — other plugins may use it.
   }
 
+  uninstallCodexHooks(ctx);
+
   // Plugin uninstall on Claude. Probe `plugin list` first so a re-run on a
   // machine where caveman was never installed (or was already removed) doesn't
   // print "Plugin not installed" stderr noise.
@@ -1192,10 +1317,46 @@ function uninstall(ctx) {
   const flag = path.join(configDir, '.caveman-active');
   if (fs.existsSync(flag) && !opts.dryRun) { try { fs.unlinkSync(flag); } catch (_) {} }
 
+  const codexFlag = path.join(cavemanConfigDir(), 'active-mode');
+  if (fs.existsSync(codexFlag) && !opts.dryRun) { try { fs.unlinkSync(codexFlag); } catch (_) {} }
+
   process.stdout.write('\n');
   ok('uninstall done.');
   ok('npx-skills installs (Cursor/Windsurf/etc.) — remove via your IDE\'s skill manager');
   ok('per-repo init files (.cursor/, .windsurf/, AGENTS.md) — remove with your editor');
+}
+
+function uninstallCodexHooks(ctx) {
+  const { note, warn, ok, opts } = ctx;
+  const codexHome = codexConfigDir(opts);
+  const hooksDir = path.join(codexHome, 'hooks');
+  const hooksJsonPath = path.join(codexHome, 'hooks.json');
+  const hookScript = path.join(hooksDir, CODEX_HOOK_FILE);
+
+  if (fs.existsSync(hooksJsonPath)) {
+    const config = SETTINGS.readSettings(hooksJsonPath);
+    if (config) {
+      const removed = SETTINGS.removeCavemanHooks(config, CODEX_HOOK_FILE);
+      if (removed > 0) {
+        SETTINGS.validateHookFields(config);
+        if (!opts.dryRun) {
+          const bak = hooksJsonPath + '.bak';
+          if (!fs.existsSync(bak)) {
+            try { fs.copyFileSync(hooksJsonPath, bak); } catch (_) {}
+          }
+          SETTINGS.writeSettings(hooksJsonPath, config);
+        }
+      }
+      ok(`  removed ${removed} Codex caveman hook entr${removed === 1 ? 'y' : 'ies'} from hooks.json`);
+    } else {
+      warn('  hooks.json unparseable; leaving Codex hooks in place.');
+    }
+  }
+
+  if (fs.existsSync(hookScript)) {
+    if (!opts.dryRun) { try { fs.unlinkSync(hookScript); } catch (_) {} }
+    note(`  removed ${hookScript}`);
+  }
 }
 
 // ── Interactive prompt (TTY-only) ─────────────────────────────────────────
@@ -1253,8 +1414,8 @@ FLAGS
   --all                 Turn on hooks + init. (mcp-shrink needs an upstream;
                         pass --with-mcp-shrink="<cmd>" to add it.)
   --minimal             Just the plugin/extension install.
-  --with-hooks          Claude Code: install SessionStart/UserPromptSubmit hooks
-                        + statusline badge. (Default ON.)
+  --with-hooks          Claude Code + Codex: install SessionStart/UserPromptSubmit
+                        hooks. Claude also gets statusline badge. (Default ON.)
   --no-hooks            Skip the hooks installer.
   --with-init           Write per-repo IDE rule files into \$PWD.
   --with-mcp-shrink="<upstream cmd>"
@@ -1265,11 +1426,13 @@ FLAGS
                         Example: --with-mcp-shrink="npx @modelcontextprotocol/server-filesystem /tmp"
   --no-mcp-shrink       Skip MCP shrink. (Default.)
   --uninstall, -u       Remove caveman from this machine.
-  --config-dir <path>   Claude Code config dir for hook files + settings.json.
-                        Default: \$CLAUDE_CONFIG_DIR or ~/.claude. Does NOT
-                        scope \`claude plugin install\`, \`gemini extensions
-                        install\`, opencode (XDG_CONFIG_HOME), or openclaw
-                        (OPENCLAW_WORKSPACE) — those use their own paths.
+  --config-dir <path>   Hook config dir override. Claude writes settings.json;
+                        Codex writes hooks.json. Defaults: \$CLAUDE_CONFIG_DIR
+                        or ~/.claude for Claude; \$CODEX_HOME or ~/.codex for
+                        Codex. Does NOT scope \`claude plugin install\`,
+                        \`gemini extensions install\`, opencode
+                        (XDG_CONFIG_HOME), or openclaw (OPENCLAW_WORKSPACE) —
+                        those use their own paths.
   --non-interactive     Never prompt; use defaults. (Auto when stdin is not a TTY.)
   --list                Print provider matrix and exit.
   --no-color            Disable ANSI colors.
@@ -1340,6 +1503,7 @@ async function main() {
     // missing without --force).
     if (!explicit(prov.id) && !detectMatch(prov.detect)) continue;
     if (prov.id === 'claude')   { await installClaude(ctx); continue; }
+    if (prov.id === 'codex')    { await installCodex(ctx); continue; }
     if (prov.id === 'gemini')   { installGemini(ctx); continue; }
     if (prov.id === 'opencode') { installOpencode(ctx); continue; }
     if (prov.id === 'openclaw') { installOpenclaw(ctx); continue; }

--- a/bin/lib/settings.js
+++ b/bin/lib/settings.js
@@ -150,7 +150,8 @@ function addCommandHook(settings, event, opts) {
 }
 
 // ── removeCavemanHooks ────────────────────────────────────────────────────
-// Strip every entry whose any hook command mentions `marker`. Empties events.
+// Strip every hook command mentioning `marker`. Preserve non-caveman hooks even
+// when they share the same event entry. Empties events.
 // Tolerates malformed pre-existing settings (non-array hook lists, foreign
 // shapes) — those get dropped by validateHookFields first so we never call
 // .length / .filter on a non-array.
@@ -161,12 +162,15 @@ function removeCavemanHooks(settings, marker = 'caveman') {
   let removed = 0;
   for (const ev of Object.keys(settings.hooks)) {
     if (!Array.isArray(settings.hooks[ev])) { delete settings.hooks[ev]; continue; }
-    const before = settings.hooks[ev].length;
     settings.hooks[ev] = settings.hooks[ev].filter(entry => {
       if (!entry || !Array.isArray(entry.hooks)) return true;
-      return !entry.hooks.some(h => h && typeof h.command === 'string' && h.command.includes(marker));
+      const before = entry.hooks.length;
+      entry.hooks = entry.hooks.filter(h =>
+        !(h && typeof h.command === 'string' && h.command.includes(marker))
+      );
+      removed += before - entry.hooks.length;
+      return entry.hooks.length > 0;
     });
-    removed += before - settings.hooks[ev].length;
     if (settings.hooks[ev].length === 0) delete settings.hooks[ev];
   }
   if (Object.keys(settings.hooks).length === 0) delete settings.hooks;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "plugins/",
     "commands/",
     "dist/caveman.skill",
+    "!**/__pycache__/**",
+    "!**/*.pyc",
     "README.md",
     "LICENSE"
   ]

--- a/plugins/caveman/.codex-plugin/plugin.json
+++ b/plugins/caveman/.codex-plugin/plugin.json
@@ -16,6 +16,7 @@
     "writing"
   ],
   "skills": "./skills/",
+  "hooks": "./hooks/hooks.json",
   "interface": {
     "displayName": "Caveman",
     "shortDescription": "Talk like caveman. Cut filler. Keep technical accuracy.",

--- a/plugins/caveman/hooks/hooks.json
+++ b/plugins/caveman/hooks/hooks.json
@@ -1,0 +1,31 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/caveman-codex-hook.js\" SessionStart",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\caveman-codex-hook.js\" SessionStart",
+            "timeout": 5,
+            "statusMessage": "Loading caveman mode"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/caveman-codex-hook.js\" UserPromptSubmit",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\scripts\\caveman-codex-hook.js\" UserPromptSubmit",
+            "timeout": 5,
+            "statusMessage": "Tracking caveman mode"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/caveman/scripts/caveman-codex-hook.js
+++ b/plugins/caveman/scripts/caveman-codex-hook.js
@@ -1,0 +1,526 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const VALID_MODES = new Set([
+  'off',
+  'lite',
+  'full',
+  'ultra',
+  'wenyan-lite',
+  'wenyan',
+  'wenyan-full',
+  'wenyan-ultra',
+]);
+
+const CONFIG_DIR = cavemanConfigDir();
+const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
+const FLAG_PATH = path.join(CONFIG_DIR, 'active-mode');
+const SAVINGS_LEDGER_PATH = path.join(CONFIG_DIR, 'savings-ledger.json');
+const LIFETIME_SAVED_PATH = path.join(CONFIG_DIR, 'lifetime-saved-tokens');
+const LIFETIME_SUFFIX_PATH = path.join(CONFIG_DIR, 'lifetime-savings-suffix');
+const MAX_CONFIG_BYTES = 16 * 1024;
+const MAX_FLAG_BYTES = 64;
+const MAX_LEDGER_BYTES = 1024 * 1024;
+const MAX_TRANSCRIPT_BYTES = 10 * 1024 * 1024;
+const SKILL_PATHS = [
+  path.join(__dirname, '..', 'skills', 'caveman', 'SKILL.md'),
+  path.join(os.homedir(), '.agents', 'skills', 'caveman', 'SKILL.md'),
+];
+const SESSIONS_DIR = process.env.CODEX_HOME
+  ? path.join(process.env.CODEX_HOME, 'sessions')
+  : path.join(os.homedir(), '.codex', 'sessions');
+
+const eventArg = process.argv[2] || '';
+
+let input = '';
+process.stdin.on('data', chunk => {
+  input += chunk;
+});
+process.stdin.on('end', () => {
+  let data = {};
+  try {
+    data = input.trim() ? JSON.parse(input) : {};
+  } catch (_) {
+    data = {};
+  }
+
+  const event = data.hook_event_name || data.hookEventName || eventArg;
+  if (event === 'SessionStart') {
+    activate();
+    return;
+  }
+  if (event === 'UserPromptSubmit') {
+    if (isStatsPrompt(extractPrompt(data))) {
+      reportStats(data);
+      return;
+    }
+    trackPrompt(data);
+  }
+});
+
+function cavemanConfigDir() {
+  if (process.env.XDG_CONFIG_HOME) {
+    return path.join(process.env.XDG_CONFIG_HOME, 'caveman');
+  }
+  if (process.platform === 'win32') {
+    return path.join(
+      process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'),
+      'caveman'
+    );
+  }
+  return path.join(os.homedir(), '.config', 'caveman');
+}
+
+function activate() {
+  const mode = defaultMode();
+  if (mode === 'off') {
+    removeFlag();
+    writeContext('SessionStart', 'CAVEMAN MODE OFF. Config defaultMode=off.');
+    return;
+  }
+
+  writeFlag(mode);
+  writeContext('SessionStart', rulesFor(mode));
+}
+
+function trackPrompt(data) {
+  const prompt = extractPrompt(data).trim().toLowerCase();
+  if (prompt) {
+    const mode = modeFromPrompt(prompt);
+    if (mode === 'off') {
+      removeFlag();
+    } else if (mode) {
+      writeFlag(mode);
+    }
+  }
+
+  const active = readFlag();
+  if (active && active !== 'off') {
+    writeContext(
+      'UserPromptSubmit',
+      'CAVEMAN MODE ACTIVE (' + canonicalMode(active) + '). Drop articles/filler/pleasantries/hedging. Fragments OK. Code/commits/security: write normal.'
+    );
+  }
+}
+
+function extractPrompt(data) {
+  if (typeof data.prompt === 'string') return data.prompt;
+  if (typeof data.user_prompt === 'string') return data.user_prompt;
+  if (typeof data.userPrompt === 'string') return data.userPrompt;
+  if (typeof data.message === 'string') return data.message;
+  if (typeof data.text === 'string') return data.text;
+  if (data.input && typeof data.input === 'string') return data.input;
+  return '';
+}
+
+function isStatsPrompt(prompt) {
+  const normalized = String(prompt || '').trim().toLowerCase();
+  return normalized === '/caveman-stats' ||
+    normalized === '$caveman-stats' ||
+    normalized === '/caveman stats' ||
+    normalized === '$caveman stats' ||
+    normalized === 'caveman stats';
+}
+
+function modeFromPrompt(prompt) {
+  if (
+    /\b(do not|don\'t|dont|never)\b.*\b(use|enable|activate|start|turn on|talk like)\b.*\bcaveman\b/.test(prompt) ||
+    /\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/.test(prompt) ||
+    /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/.test(prompt) ||
+    /\bnormal mode\b/.test(prompt) ||
+    /^\/caveman(?::caveman)?\s+(off|stop|disable)\b/.test(prompt) ||
+    /^\$caveman\s+(off|stop|disable)\b/.test(prompt)
+  ) {
+    return 'off';
+  }
+
+  const command = /^(?:\/caveman(?::caveman)?|\$caveman)(?:\s+(\S+))?/.exec(prompt);
+  if (command) {
+    const arg = command[1];
+    if (!arg) return defaultMode();
+    if (arg === 'wenyan-full') return 'wenyan';
+    if (VALID_MODES.has(arg) && arg !== 'off') return arg;
+    return null;
+  }
+
+  if (
+    /\b(activate|enable|turn on|start|talk like|use)\b.*\bcaveman\b/.test(prompt) ||
+    /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/.test(prompt)
+  ) {
+    return defaultMode();
+  }
+
+  return null;
+}
+
+function defaultMode() {
+  const envMode = (process.env.CAVEMAN_DEFAULT_MODE || '').toLowerCase();
+  if (VALID_MODES.has(envMode)) return envMode;
+
+  try {
+    const config = JSON.parse(safeReadFile(CONFIG_PATH, MAX_CONFIG_BYTES) || '{}');
+    const mode = String(config.defaultMode || '').toLowerCase();
+    if (VALID_MODES.has(mode)) return mode;
+  } catch (_) {
+    // Missing config is fine.
+  }
+
+  return 'full';
+}
+
+function rulesFor(mode) {
+  const modeLabel = canonicalMode(mode);
+  const fallback = [
+    'CAVEMAN MODE ACTIVE - level: ' + modeLabel,
+    '',
+    'Respond terse like smart caveman. All technical substance stay. Only fluff die.',
+    '',
+    'Drop: articles (a/an/the), filler, pleasantries, hedging. Fragments OK. Short synonyms. Technical terms exact. Code blocks unchanged. Errors quoted exact.',
+    'Pattern: [thing] [action] [reason]. [next step].',
+    'Auto-clarity: security warnings, irreversible confirmations, and ambiguous multi-step sequences use normal clear prose.',
+    'Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert.',
+  ].join('\n');
+
+  for (const skillPath of SKILL_PATHS) {
+    try {
+      const body = fs.readFileSync(skillPath, 'utf8').replace(/^---[\s\S]*?---\s*/, '');
+      return 'CAVEMAN MODE ACTIVE - level: ' + modeLabel + '\n\n' + filterSkill(body, modeLabel);
+    } catch (_) {
+      // Try next source.
+    }
+  }
+  return fallback;
+}
+
+function filterSkill(body, modeLabel) {
+  return body
+    .split('\n')
+    .filter(line => {
+      const row = line.match(/^\|\s*\*\*(\S+?)\*\*\s*\|/);
+      if (row) return row[1] === modeLabel;
+      const example = line.match(/^- (\S+?):\s/);
+      if (example) return example[1] === modeLabel;
+      return true;
+    })
+    .join('\n');
+}
+
+function canonicalMode(mode) {
+  return mode === 'wenyan' ? 'wenyan-full' : mode;
+}
+
+function reportStats(data) {
+  const transcript = transcriptPath(data);
+  if (!transcript) {
+    writeBlock('Caveman stats unavailable: no Codex session transcript found.');
+    return;
+  }
+
+  let stats;
+  try {
+    stats = readSessionStats(transcript);
+  } catch (error) {
+    writeBlock('Caveman stats unavailable: failed to read ' + transcript + ': ' + error.message);
+    return;
+  }
+
+  if (!stats.usage) {
+    writeBlock('Caveman stats unavailable: no token_count receipt found in ' + transcript + '.');
+    return;
+  }
+
+  const mode = canonicalMode(readFlag() || defaultMode());
+  const rate = savingsRate(mode);
+  const inputTokens = numeric(stats.usage.input_tokens);
+  const outputTokens = numeric(stats.usage.output_tokens);
+  const baselineTokens = Math.max(outputTokens, Math.round(outputTokens / (1 - rate)));
+  const savedTokens = Math.max(0, baselineTokens - outputTokens);
+  const totalSaved = writeSavingsFiles(transcript, savedTokens);
+
+  writeBlock([
+    'Session: ' + formatNumber(stats.turns) + ' turns',
+    'Input:   ' + formatNumber(inputTokens) + ' tokens',
+    'Output:  ' + formatNumber(outputTokens) + ' tokens (caveman)',
+    'Baseline: ' + formatNumber(baselineTokens) + ' tokens (estimated without caveman)',
+    'Saved:    ' + formatNumber(savedTokens) + ' tokens (~' + Math.round(rate * 100) + '%)',
+    'Lifetime: ' + formatNumber(totalSaved) + ' tokens saved',
+  ].join('\n'));
+}
+
+function transcriptPath(data) {
+  const candidates = [
+    data.transcript_path,
+    data.transcriptPath,
+    data.session_transcript_path,
+    data.sessionTranscriptPath,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate) {
+      const safePath = safeTranscriptPath(candidate);
+      if (safePath) return safePath;
+    }
+  }
+  return null;
+}
+
+function safeTranscriptPath(candidate) {
+  let sessionsRoot;
+  let realFile;
+  try {
+    sessionsRoot = fs.realpathSync(SESSIONS_DIR);
+    const absolute = path.resolve(candidate);
+    const stat = fs.lstatSync(absolute);
+    if (stat.isSymbolicLink() || !stat.isFile() || stat.size > MAX_TRANSCRIPT_BYTES) return null;
+    realFile = fs.realpathSync(absolute);
+  } catch (_) {
+    return null;
+  }
+
+  return pathInside(realFile, sessionsRoot) ? realFile : null;
+}
+
+function readSessionStats(file) {
+  const stats = {
+    turns: 0,
+    fallbackTurns: 0,
+    usage: null,
+  };
+
+  const body = safeReadFile(file, MAX_TRANSCRIPT_BYTES);
+  if (body === null) {
+    throw new Error('transcript is missing, unsafe, or larger than ' + formatNumber(MAX_TRANSCRIPT_BYTES) + ' bytes');
+  }
+
+  const lines = body.split('\n');
+  for (const line of lines) {
+    if (!line.trim()) continue;
+
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch (_) {
+      continue;
+    }
+
+    const payload = event.payload || {};
+    if (event.type === 'event_msg' && payload.type === 'user_message') {
+      stats.turns += 1;
+    }
+    if (event.type === 'response_item' && payload.type === 'message' && payload.role === 'user') {
+      stats.fallbackTurns += 1;
+    }
+    if (payload.type === 'token_count' && payload.info && payload.info.total_token_usage) {
+      stats.usage = payload.info.total_token_usage;
+    }
+  }
+
+  if (stats.turns === 0) stats.turns = stats.fallbackTurns;
+  delete stats.fallbackTurns;
+  return stats;
+}
+
+function savingsRate(mode) {
+  switch (canonicalMode(mode)) {
+    case 'lite':
+      return 0.35;
+    case 'ultra':
+      return 0.75;
+    case 'wenyan-lite':
+      return 0.75;
+    case 'wenyan-full':
+      return 0.85;
+    case 'wenyan-ultra':
+      return 0.9;
+    case 'full':
+    default:
+      return 0.65;
+  }
+}
+
+function numeric(value) {
+  return Number.isFinite(value) ? value : 0;
+}
+
+function formatNumber(value) {
+  return String(Math.round(value)).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+function writeSavingsFiles(transcript, savedTokens) {
+  let ledger = {};
+  try {
+    const parsed = JSON.parse(safeReadFile(SAVINGS_LEDGER_PATH, MAX_LEDGER_BYTES) || '{}');
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) ledger = parsed;
+  } catch (_) {
+    ledger = {};
+  }
+
+  ledger[transcript] = savedTokens;
+  const totalSaved = Object.values(ledger).reduce((sum, value) => sum + numeric(value), 0);
+
+  try {
+    safeWriteFile(SAVINGS_LEDGER_PATH, JSON.stringify(ledger, null, 2) + '\n');
+    safeWriteFile(LIFETIME_SAVED_PATH, String(totalSaved) + '\n');
+    safeWriteFile(LIFETIME_SUFFIX_PATH, 'saved ' + compactNumber(totalSaved) + '\n');
+  } catch (_) {
+    // Stats should still display if statusline files cannot be written.
+  }
+
+  return totalSaved;
+}
+
+function compactNumber(value) {
+  const rounded = Math.round(value);
+  if (rounded >= 1000000) return trimDecimal(rounded / 1000000) + 'm';
+  if (rounded >= 1000) return trimDecimal(rounded / 1000) + 'k';
+  return String(rounded);
+}
+
+function trimDecimal(value) {
+  return value.toFixed(1).replace(/\.0$/, '');
+}
+
+function writeFlag(mode) {
+  safeWriteFile(FLAG_PATH, mode + '\n');
+}
+
+function readFlag() {
+  try {
+    const mode = (safeReadFile(FLAG_PATH, MAX_FLAG_BYTES) || '').trim().toLowerCase();
+    return VALID_MODES.has(mode) ? mode : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function removeFlag() {
+  try {
+    fs.unlinkSync(FLAG_PATH);
+  } catch (_) {
+    // Missing flag is fine.
+  }
+}
+
+function safeWriteFile(filePath, content) {
+  let tempPath = null;
+  let fd;
+  try {
+    const realPath = safeTargetPath(filePath);
+    if (!realPath) return false;
+
+    try {
+      const st = fs.lstatSync(realPath);
+      if (st.isSymbolicLink() || !st.isFile()) return false;
+    } catch (error) {
+      if (error.code !== 'ENOENT') return false;
+    }
+
+    const dir = path.dirname(realPath);
+    const base = path.basename(realPath);
+    const nonce = String(Date.now()) + '.' + Math.random().toString(16).slice(2);
+    tempPath = path.join(dir, '.' + base + '.' + process.pid + '.' + nonce + '.tmp');
+    const nofollow = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0;
+    const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | nofollow;
+    fd = fs.openSync(tempPath, flags, 0o600);
+    fs.writeSync(fd, String(content));
+    try { fs.fchmodSync(fd, 0o600); } catch (_) {}
+    fs.closeSync(fd);
+    fd = undefined;
+    fs.renameSync(tempPath, realPath);
+    tempPath = null;
+    return true;
+  } catch (_) {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch (_) {}
+    }
+    if (tempPath) {
+      try { fs.unlinkSync(tempPath); } catch (_) {}
+    }
+  }
+}
+
+function safeReadFile(filePath, maxBytes) {
+  let fd;
+  try {
+    const st = fs.lstatSync(filePath);
+    if (st.isSymbolicLink() || !st.isFile()) return null;
+    if (typeof maxBytes === 'number' && st.size > maxBytes) return null;
+
+    const size = typeof maxBytes === 'number' ? Math.min(st.size, maxBytes) : st.size;
+    const nofollow = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0;
+    fd = fs.openSync(filePath, fs.constants.O_RDONLY | nofollow);
+    const buffer = Buffer.alloc(size);
+    const bytes = fs.readSync(fd, buffer, 0, size, 0);
+    return buffer.slice(0, bytes).toString('utf8');
+  } catch (_) {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch (_) {}
+    }
+  }
+}
+
+function safeTargetPath(filePath) {
+  try {
+    const dir = path.dirname(filePath);
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+    let realDir = dir;
+    const dirStat = fs.lstatSync(dir);
+    if (dirStat.isSymbolicLink()) {
+      realDir = fs.realpathSync(dir);
+      const realStat = fs.statSync(realDir);
+      if (!realStat.isDirectory()) return null;
+      if (typeof process.getuid === 'function') {
+        if (realStat.uid !== process.getuid()) return null;
+      } else if (!pathUnderHome(realDir)) {
+        return null;
+      }
+    } else if (!dirStat.isDirectory()) {
+      return null;
+    }
+
+    return path.join(realDir, path.basename(filePath));
+  } catch (_) {
+    return null;
+  }
+}
+
+function pathUnderHome(candidate) {
+  const home = path.resolve(os.homedir()).toLowerCase();
+  const real = path.resolve(candidate).toLowerCase();
+  return real === home || real.startsWith(home + path.sep);
+}
+
+function pathInside(candidate, root) {
+  let real = path.resolve(candidate);
+  let base = path.resolve(root);
+  if (process.platform === 'win32') {
+    real = real.toLowerCase();
+    base = base.toLowerCase();
+  }
+  return real === base || real.startsWith(base + path.sep);
+}
+
+function writeContext(event, context) {
+  process.stdout.write(JSON.stringify({
+    continue: true,
+    hookSpecificOutput: {
+      hookEventName: event,
+      additionalContext: context,
+    },
+  }));
+}
+
+function writeBlock(reason) {
+  process.stdout.write(JSON.stringify({
+    decision: 'block',
+    reason,
+  }));
+}

--- a/plugins/caveman/skills/caveman-stats/SKILL.md
+++ b/plugins/caveman/skills/caveman-stats/SKILL.md
@@ -2,9 +2,9 @@
 name: caveman-stats
 description: >
   Show real token usage and estimated savings for the current session.
-  Reads directly from the Claude Code session log — no AI estimation.
-  Triggers on /caveman-stats. Output is injected by the mode-tracker hook;
+  Reads directly from the Claude Code or Codex session log — no AI estimation.
+  Triggers on /caveman-stats. Output is injected by the runtime hook;
   the model itself does not compute the numbers.
 ---
 
-This skill is delivered by `hooks/caveman-stats.js` (read by `hooks/caveman-mode-tracker.js` on `/caveman-stats`). The model does not need to do anything when this skill fires — the hook returns `decision: "block"` with the formatted stats as the reason. The user sees the numbers immediately.
+This skill is delivered by `hooks/caveman-stats.js` for Claude Code and `plugins/caveman/scripts/caveman-codex-hook.js` for Codex. The model does not need to do anything when this skill fires — the hook returns `decision: "block"` with the formatted stats as the reason. The user sees the numbers immediately.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,43 @@
       "source": "JuliusBrussee/caveman",
       "sourceType": "github",
       "skillPath": "skills/cavecrew/SKILL.md",
-      "computedHash": "06d45a7308d8603365313decf400020106b985cb5ce500ee169bfba9c71dd147"
+      "computedHash": "505d836228d1c5e14834ff5d62aad72390c7d27f79c6aa7f9a7a55ed6606d6a2"
+    },
+    "caveman": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman/SKILL.md",
+      "computedHash": "dfbf85749fd474feeb0bbe60c779795ecd5dbec0083299b56e68916bc3ddd8c9"
+    },
+    "caveman-commit": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-commit/SKILL.md",
+      "computedHash": "f456ea0564875e46858890ac39ee701ecb9c601c72a2da1e6ce6bd5f9fc5d817"
+    },
+    "caveman-compress": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-compress/SKILL.md",
+      "computedHash": "b8cbfec00b620f0944960a9bb4072f262cf816c1d3c82e6dbded35c30b4c5d0b"
+    },
+    "caveman-help": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-help/SKILL.md",
+      "computedHash": "2c21437427e98df1eacabaa0b055b5256a308b2191feea3ca2df6a9418e76cb1"
+    },
+    "caveman-review": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-review/SKILL.md",
+      "computedHash": "fb7214a1c5793bae6ba8b1be4329e2e6f40dbec6dd911dfb335ad29f09c316a1"
+    },
+    "caveman-stats": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-stats/SKILL.md",
+      "computedHash": "47ce2de3d6cb39a75047b5c962e4eb3da15594e7397c94103e9a104d42626553"
     }
   }
 }

--- a/skills/caveman-stats/README.md
+++ b/skills/caveman-stats/README.md
@@ -4,7 +4,7 @@ Real session token receipts. No AI estimation.
 
 ## What it does
 
-Reads the current Claude Code session log directly and reports actual input/output token usage plus estimated savings versus a non-caveman baseline. Numbers come from the JSONL session log on disk — the model itself does not compute or estimate them. Output is injected by the `caveman-mode-tracker` hook, which intercepts `/caveman-stats` and returns the formatted stats as a blocked-decision reason.
+Reads the current Claude Code or Codex session log directly and reports actual input/output token usage plus estimated savings versus a non-caveman baseline. Numbers come from the JSONL session log on disk — the model itself does not compute or estimate them. Output is injected by the runtime hook, which intercepts `/caveman-stats` and returns the formatted stats as a blocked-decision reason.
 
 Each run also writes a lifetime-savings suffix file used by the statusline badge (`⛏ 12.4k`).
 

--- a/skills/caveman-stats/SKILL.md
+++ b/skills/caveman-stats/SKILL.md
@@ -2,9 +2,9 @@
 name: caveman-stats
 description: >
   Show real token usage and estimated savings for the current session.
-  Reads directly from the Claude Code session log — no AI estimation.
-  Triggers on /caveman-stats. Output is injected by the mode-tracker hook;
+  Reads directly from the Claude Code or Codex session log — no AI estimation.
+  Triggers on /caveman-stats. Output is injected by the runtime hook;
   the model itself does not compute the numbers.
 ---
 
-This skill is delivered by `hooks/caveman-stats.js` (read by `hooks/caveman-mode-tracker.js` on `/caveman-stats`). The model does not need to do anything when this skill fires — the hook returns `decision: "block"` with the formatted stats as the reason. The user sees the numbers immediately.
+This skill is delivered by `hooks/caveman-stats.js` for Claude Code and `plugins/caveman/scripts/caveman-codex-hook.js` for Codex. The model does not need to do anything when this skill fires — the hook returns `decision: "block"` with the formatted stats as the reason. The user sees the numbers immediately.

--- a/tests/installer/e2e.codex.test.mjs
+++ b/tests/installer/e2e.codex.test.mjs
@@ -1,0 +1,190 @@
+// End-to-end: real Codex hook install against an isolated CODEX_HOME.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const INSTALLER = path.resolve(HERE, '..', '..', 'bin', 'install.js');
+
+function freshTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-codex-install-'));
+}
+
+test('explicit codex install writes hook script and hooks.json without npx skills', () => {
+  const cfg = freshTmpDir();
+  try {
+    const r = spawnSync(process.execPath, [INSTALLER,
+      '--only', 'codex', '--skip-skills', '--non-interactive', '--no-mcp-shrink',
+      '--config-dir', cfg,
+    ], { encoding: 'utf8', env: { ...process.env, CODEX_HOME: cfg, NO_COLOR: '1' } });
+
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /Codex CLI detected/);
+
+    const hookScript = path.join(cfg, 'hooks', 'caveman-codex-hook.js');
+    assert.ok(fs.existsSync(hookScript), 'caveman-codex-hook.js missing');
+
+    const hooksJson = JSON.parse(fs.readFileSync(path.join(cfg, 'hooks.json'), 'utf8'));
+    const sessionHooks = hooksJson.hooks.SessionStart.flatMap(entry => entry.hooks);
+    const promptHooks = hooksJson.hooks.UserPromptSubmit.flatMap(entry => entry.hooks);
+    assert.equal(sessionHooks.length, 1);
+    assert.equal(promptHooks.length, 1);
+    assert.match(sessionHooks[0].command, /caveman-codex-hook\.js" SessionStart$/);
+    assert.match(promptHooks[0].command, /caveman-codex-hook\.js" UserPromptSubmit$/);
+    assert.equal(sessionHooks[0].timeout, 5);
+    assert.equal(promptHooks[0].timeout, 5);
+  } finally {
+    fs.rmSync(cfg, { recursive: true, force: true });
+  }
+});
+
+test('explicit codex install is idempotent', () => {
+  const cfg = freshTmpDir();
+  try {
+    for (let i = 0; i < 2; i++) {
+      const r = spawnSync(process.execPath, [INSTALLER,
+        '--only', 'codex', '--skip-skills', '--non-interactive', '--no-mcp-shrink',
+        '--config-dir', cfg,
+      ], { encoding: 'utf8', env: { ...process.env, CODEX_HOME: cfg, NO_COLOR: '1' } });
+      assert.equal(r.status, 0, r.stderr);
+    }
+
+    const hooksJson = JSON.parse(fs.readFileSync(path.join(cfg, 'hooks.json'), 'utf8'));
+    assert.equal(hooksJson.hooks.SessionStart.length, 1);
+    assert.equal(hooksJson.hooks.UserPromptSubmit.length, 1);
+  } finally {
+    fs.rmSync(cfg, { recursive: true, force: true });
+  }
+});
+
+test('codex install treats existing unquoted hooks as already wired', () => {
+  const cfg = freshTmpDir();
+  try {
+    fs.writeFileSync(path.join(cfg, 'hooks.json'), JSON.stringify({
+      hooks: {
+        SessionStart: [{
+          matcher: 'startup|resume|clear|compact',
+          hooks: [{ type: 'command', command: 'node ./hooks/caveman-codex-hook.js SessionStart' }],
+        }],
+        UserPromptSubmit: [{
+          hooks: [{ type: 'command', command: 'node ./hooks/caveman-codex-hook.js UserPromptSubmit' }],
+        }],
+      },
+    }, null, 2));
+
+    const r = spawnSync(process.execPath, [INSTALLER,
+      '--only', 'codex', '--skip-skills', '--non-interactive', '--no-mcp-shrink',
+      '--config-dir', cfg,
+    ], { encoding: 'utf8', env: { ...process.env, CODEX_HOME: cfg, NO_COLOR: '1' } });
+    assert.equal(r.status, 0, r.stderr);
+
+    const hooksJson = JSON.parse(fs.readFileSync(path.join(cfg, 'hooks.json'), 'utf8'));
+    const sessionHooks = hooksJson.hooks.SessionStart.flatMap(entry => entry.hooks);
+    const promptHooks = hooksJson.hooks.UserPromptSubmit.flatMap(entry => entry.hooks);
+    assert.equal(sessionHooks.length, 1);
+    assert.equal(promptHooks.length, 1);
+    assert.equal(sessionHooks[0].command, 'node ./hooks/caveman-codex-hook.js SessionStart');
+    assert.equal(promptHooks[0].command, 'node ./hooks/caveman-codex-hook.js UserPromptSubmit');
+  } finally {
+    fs.rmSync(cfg, { recursive: true, force: true });
+  }
+});
+
+test('codex uninstall removes native hook and preserves user hooks', () => {
+  const cfg = freshTmpDir();
+  try {
+    const hooksDir = path.join(cfg, 'hooks');
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'caveman-codex-hook.js'), '// installed hook\n');
+    fs.writeFileSync(path.join(cfg, 'hooks.json'), JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { hooks: [
+            { type: 'command', command: 'echo user-owned-hook' },
+            { type: 'command', command: `"${process.execPath}" "${path.join(hooksDir, 'caveman-codex-hook.js')}" SessionStart` },
+          ] },
+        ],
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: `"${process.execPath}" "${path.join(hooksDir, 'caveman-codex-hook.js')}" UserPromptSubmit` }] },
+        ],
+      },
+    }, null, 2));
+
+    const r = spawnSync(process.execPath, [INSTALLER,
+      '--uninstall', '--non-interactive', '--no-mcp-shrink', '--config-dir', cfg,
+    ], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CODEX_HOME: cfg,
+        CLAUDE_CONFIG_DIR: path.join(cfg, 'claude'),
+        PATH: '',
+        NO_COLOR: '1',
+      },
+    });
+    assert.equal(r.status, 0, r.stderr);
+
+    assert.equal(fs.existsSync(path.join(hooksDir, 'caveman-codex-hook.js')), false);
+    assert.equal(
+      fs.readFileSync(path.join(cfg, 'hooks.json.bak'), 'utf8'),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            { hooks: [
+              { type: 'command', command: 'echo user-owned-hook' },
+              { type: 'command', command: `"${process.execPath}" "${path.join(hooksDir, 'caveman-codex-hook.js')}" SessionStart` },
+            ] },
+          ],
+          UserPromptSubmit: [
+            { hooks: [{ type: 'command', command: `"${process.execPath}" "${path.join(hooksDir, 'caveman-codex-hook.js')}" UserPromptSubmit` }] },
+          ],
+        },
+      }, null, 2)
+    );
+    const hooksJson = JSON.parse(fs.readFileSync(path.join(cfg, 'hooks.json'), 'utf8'));
+    const sessionCommands = hooksJson.hooks.SessionStart.flatMap(entry => entry.hooks).map(hook => hook.command);
+    assert.deepEqual(sessionCommands, ['echo user-owned-hook']);
+    assert.equal(hooksJson.hooks.UserPromptSubmit, undefined);
+  } finally {
+    fs.rmSync(cfg, { recursive: true, force: true });
+  }
+});
+
+test('codex uninstall leaves user-only hooks.json byte-for-byte unchanged', () => {
+  const cfg = freshTmpDir();
+  try {
+    const before = `{
+  // User-owned Codex hook config.
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "echo user-owned-hook" }] },
+    ],
+  },
+}
+`;
+    fs.writeFileSync(path.join(cfg, 'hooks.json'), before);
+
+    const r = spawnSync(process.execPath, [INSTALLER,
+      '--uninstall', '--non-interactive', '--no-mcp-shrink', '--config-dir', cfg,
+    ], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CODEX_HOME: cfg,
+        CLAUDE_CONFIG_DIR: path.join(cfg, 'claude'),
+        PATH: '',
+        NO_COLOR: '1',
+      },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(fs.readFileSync(path.join(cfg, 'hooks.json'), 'utf8'), before);
+    assert.equal(fs.existsSync(path.join(cfg, 'hooks.json.bak')), false);
+  } finally {
+    fs.rmSync(cfg, { recursive: true, force: true });
+  }
+});

--- a/tests/installer/e2e.dryrun.test.mjs
+++ b/tests/installer/e2e.dryrun.test.mjs
@@ -39,6 +39,33 @@ test('dry-run --only claude prints plan and writes nothing', () => {
   assert.equal(fs.existsSync(path.join(cfg, 'hooks')), false);
 });
 
+test('dry-run --only codex prints native hook plan and writes nothing', () => {
+  const cfg = freshTmpDir();
+  const r = spawnSync('node', [INSTALLER,
+    '--dry-run', '--only', 'codex', '--skip-skills', '--no-mcp-shrink', '--non-interactive',
+    '--config-dir', cfg,
+  ], { encoding: 'utf8', env: { ...process.env, CODEX_HOME: cfg } });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /Codex CLI detected/);
+  assert.match(r.stdout, /would mkdir -p .*\/hooks/);
+  assert.match(r.stdout, /would install .*caveman-codex-hook\.js/);
+  assert.match(r.stdout, /would merge SessionStart \+ UserPromptSubmit into .*\/hooks\.json/);
+  assert.equal(fs.existsSync(path.join(cfg, 'hooks.json')), false);
+  assert.equal(fs.existsSync(path.join(cfg, 'hooks')), false);
+});
+
+test('dry-run --only codex installs skills and hooks by default', () => {
+  const cfg = freshTmpDir();
+  const r = spawnSync('node', [INSTALLER,
+    '--dry-run', '--only', 'codex', '--no-mcp-shrink', '--non-interactive',
+    '--config-dir', cfg,
+  ], { encoding: 'utf8', env: { ...process.env, CODEX_HOME: cfg } });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /Codex CLI detected/);
+  assert.match(r.stdout, /would run: npx -y skills add JuliusBrussee\/caveman -a codex --yes --all/);
+  assert.match(r.stdout, /would merge SessionStart \+ UserPromptSubmit into .*\/hooks\.json/);
+});
+
 test('dry-run --uninstall does not delete files', () => {
   const cfg = freshTmpDir();
   // Seed a fake installation

--- a/tests/installer/unit.settings.test.mjs
+++ b/tests/installer/unit.settings.test.mjs
@@ -140,6 +140,23 @@ test('removeCavemanHooks strips by marker and cleans empties', () => {
   assert.equal(s.hooks.UserPromptSubmit, undefined);
 });
 
+test('removeCavemanHooks preserves user hooks sharing an entry', () => {
+  const s = {
+    hooks: {
+      SessionStart: [{ hooks: [
+        { type: 'command', command: 'echo user-owned-hook' },
+        { type: 'command', command: 'node /abs/hooks/caveman-codex-hook.js SessionStart' },
+      ] }],
+    },
+  };
+  const removed = SETTINGS.removeCavemanHooks(s, 'caveman-codex-hook.js');
+  assert.equal(removed, 1);
+  assert.equal(s.hooks.SessionStart.length, 1);
+  assert.deepEqual(s.hooks.SessionStart[0].hooks, [
+    { type: 'command', command: 'echo user-owned-hook' },
+  ]);
+});
+
 test('rewriteLegacyManagedHookCommands rewrites bare-node managed scripts', () => {
   const s = {
     hooks: {

--- a/tests/test_codex_hooks.py
+++ b/tests/test_codex_hooks.py
@@ -1,0 +1,270 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CODEX_HOOK = REPO_ROOT / "plugins/caveman/scripts/caveman-codex-hook.js"
+CODEX_PLUGIN_MANIFEST = REPO_ROOT / "plugins/caveman/.codex-plugin/plugin.json"
+CODEX_HOOKS_JSON = REPO_ROOT / "plugins/caveman/hooks/hooks.json"
+REPO_CODEX_HOOKS_JSON = REPO_ROOT / ".codex/hooks.json"
+
+
+class CodexHookScriptTests(unittest.TestCase):
+    def run_hook(self, home, event, payload):
+        self.assertTrue(CODEX_HOOK.is_file(), f"missing Codex hook script: {CODEX_HOOK}")
+        result = subprocess.run(
+            ["node", str(CODEX_HOOK), event],
+            cwd=REPO_ROOT,
+            env={
+                **os.environ,
+                "HOME": str(home),
+                "USERPROFILE": str(home),
+                "XDG_CONFIG_HOME": str(home / ".config"),
+                "CODEX_HOME": str(home / ".codex"),
+            },
+            input=json.dumps(payload),
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+            check=True,
+        )
+        self.assertEqual(result.stderr, "")
+        return result.stdout
+
+    def with_home(self):
+        return tempfile.TemporaryDirectory(prefix="caveman-codex-hooks-")
+
+    def test_plugin_hooks_json_wires_codex_lifecycle_events(self):
+        manifest = json.loads(CODEX_PLUGIN_MANIFEST.read_text(encoding="utf-8"))
+        self.assertEqual(manifest["hooks"], "./hooks/hooks.json")
+        self.assertTrue(CODEX_HOOKS_JSON.is_file(), f"missing Codex hooks config: {CODEX_HOOKS_JSON}")
+        hooks = json.loads(CODEX_HOOKS_JSON.read_text(encoding="utf-8"))
+        session_hook = hooks["hooks"]["SessionStart"][0]["hooks"][0]
+        prompt_hook = hooks["hooks"]["UserPromptSubmit"][0]["hooks"][0]
+
+        self.assertEqual(hooks["hooks"]["SessionStart"][0]["matcher"], "startup|resume|clear|compact")
+        self.assertEqual(session_hook["type"], "command")
+        self.assertEqual(session_hook["timeout"], 5)
+        self.assertIn('node "${PLUGIN_ROOT}/scripts/caveman-codex-hook.js" SessionStart', session_hook["command"])
+        self.assertIn("%PLUGIN_ROOT%", session_hook["commandWindows"])
+        self.assertEqual(prompt_hook["type"], "command")
+        self.assertEqual(prompt_hook["timeout"], 5)
+        self.assertIn('node "${PLUGIN_ROOT}/scripts/caveman-codex-hook.js" UserPromptSubmit', prompt_hook["command"])
+        self.assertIn("%PLUGIN_ROOT%", prompt_hook["commandWindows"])
+
+    def test_repo_hooks_json_wires_native_codex_hook(self):
+        self.assertTrue(REPO_CODEX_HOOKS_JSON.is_file(), f"missing repo Codex hooks config: {REPO_CODEX_HOOKS_JSON}")
+        hooks = json.loads(REPO_CODEX_HOOKS_JSON.read_text(encoding="utf-8"))
+        session_hook = hooks["hooks"]["SessionStart"][0]["hooks"][0]
+        prompt_hook = hooks["hooks"]["UserPromptSubmit"][0]["hooks"][0]
+
+        self.assertEqual(hooks["hooks"]["SessionStart"][0]["matcher"], "startup|resume|clear|compact")
+        self.assertIn("git rev-parse --show-toplevel", session_hook["command"])
+        self.assertIn("plugins/caveman/scripts/caveman-codex-hook.js", session_hook["command"])
+        self.assertIn("SessionStart", session_hook["command"])
+        self.assertIn("git rev-parse --show-toplevel", prompt_hook["command"])
+        self.assertIn("plugins/caveman/scripts/caveman-codex-hook.js", prompt_hook["command"])
+        self.assertIn("UserPromptSubmit", prompt_hook["command"])
+        self.assertIn("git rev-parse --show-toplevel", session_hook["commandWindows"])
+        self.assertIn("git rev-parse --show-toplevel", prompt_hook["commandWindows"])
+
+    def test_session_start_emits_codex_context_and_records_default_mode(self):
+        with self.with_home() as tmp:
+            home = Path(tmp)
+            stdout = self.run_hook(home, "SessionStart", {"hook_event_name": "SessionStart"})
+            output = json.loads(stdout)
+
+            self.assertTrue(output["continue"])
+            self.assertEqual(output["hookSpecificOutput"]["hookEventName"], "SessionStart")
+            self.assertIn("CAVEMAN MODE ACTIVE - level: full", output["hookSpecificOutput"]["additionalContext"])
+            self.assertEqual((home / ".config/caveman/active-mode").read_text(encoding="utf-8"), "full\n")
+
+    def test_session_start_does_not_overwrite_symlinked_active_mode(self):
+        with self.with_home() as tmp:
+            home = Path(tmp)
+            config_dir = home / ".config/caveman"
+            config_dir.mkdir(parents=True)
+            decoy = home / "decoy.txt"
+            decoy.write_text("SECRET\n", encoding="utf-8")
+            try:
+                os.symlink(decoy, config_dir / "active-mode")
+            except (AttributeError, NotImplementedError, OSError):
+                self.skipTest("symlinks unavailable")
+
+            self.run_hook(home, "SessionStart", {"hook_event_name": "SessionStart"})
+
+            self.assertEqual(decoy.read_text(encoding="utf-8"), "SECRET\n")
+
+    def test_prompt_submit_tracks_alias_modes_and_emits_reinforcement(self):
+        with self.with_home() as tmp:
+            home = Path(tmp)
+            stdout = self.run_hook(
+                home,
+                "UserPromptSubmit",
+                {"hook_event_name": "UserPromptSubmit", "prompt": "$caveman ultra"},
+            )
+            output = json.loads(stdout)
+
+            self.assertEqual(output["hookSpecificOutput"]["hookEventName"], "UserPromptSubmit")
+            self.assertIn("CAVEMAN MODE ACTIVE (ultra)", output["hookSpecificOutput"]["additionalContext"])
+            self.assertEqual((home / ".config/caveman/active-mode").read_text(encoding="utf-8"), "ultra\n")
+
+    def test_normal_mode_clears_active_mode_without_context(self):
+        with self.with_home() as tmp:
+            home = Path(tmp)
+            flag = home / ".config/caveman/active-mode"
+            flag.parent.mkdir(parents=True)
+            flag.write_text("full\n", encoding="utf-8")
+
+            stdout = self.run_hook(
+                home,
+                "UserPromptSubmit",
+                {"hook_event_name": "UserPromptSubmit", "prompt": "normal mode"},
+            )
+
+            self.assertEqual(stdout, "")
+            self.assertFalse(flag.exists())
+
+    def test_negated_caveman_prompt_clears_active_mode_without_context(self):
+        with self.with_home() as tmp:
+            home = Path(tmp)
+            flag = home / ".config/caveman/active-mode"
+            flag.parent.mkdir(parents=True)
+            flag.write_text("full\n", encoding="utf-8")
+
+            stdout = self.run_hook(
+                home,
+                "UserPromptSubmit",
+                {"hook_event_name": "UserPromptSubmit", "prompt": "do not use caveman"},
+            )
+
+            self.assertEqual(stdout, "")
+            self.assertFalse(flag.exists())
+
+    def test_caveman_stats_blocks_prompt_with_codex_transcript_usage(self):
+        with self.with_home() as tmp:
+            home = Path(tmp)
+            transcript = home / ".codex/sessions/session.jsonl"
+            transcript.parent.mkdir(parents=True)
+            transcript.write_text(
+                "\n".join(
+                    json.dumps(line)
+                    for line in [
+                        {"type": "event_msg", "payload": {"type": "user_message", "message": "/caveman"}},
+                        {"type": "event_msg", "payload": {"type": "user_message", "message": "/caveman-stats"}},
+                        {
+                            "type": "event_msg",
+                            "payload": {
+                                "type": "token_count",
+                                "info": {
+                                    "total_token_usage": {
+                                        "input_tokens": 1234,
+                                        "output_tokens": 456,
+                                        "total_tokens": 1690,
+                                    }
+                                },
+                            },
+                        },
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            stdout = self.run_hook(
+                home,
+                "UserPromptSubmit",
+                {
+                    "hook_event_name": "UserPromptSubmit",
+                    "prompt": "/caveman-stats",
+                    "transcript_path": str(transcript),
+                },
+            )
+            output = json.loads(stdout)
+
+            self.assertEqual(output["decision"], "block")
+            self.assertIn("Session: 2 turns", output["reason"])
+            self.assertIn("Input:   1,234 tokens", output["reason"])
+            self.assertIn("Output:  456 tokens (caveman)", output["reason"])
+            self.assertIn("Saved:    847 tokens (~65%)", output["reason"])
+
+    def test_caveman_stats_requires_explicit_safe_codex_transcript(self):
+        with self.with_home() as tmp:
+            home = Path(tmp)
+            sessions = home / ".codex/sessions"
+            sessions.mkdir(parents=True)
+            (sessions / "latest.jsonl").write_text(
+                json.dumps(
+                    {
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "token_count",
+                            "info": {
+                                "total_token_usage": {
+                                    "input_tokens": 1,
+                                    "output_tokens": 1,
+                                    "total_tokens": 2,
+                                }
+                            },
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            stdout = self.run_hook(
+                home,
+                "UserPromptSubmit",
+                {"hook_event_name": "UserPromptSubmit", "prompt": "/caveman-stats"},
+            )
+            output = json.loads(stdout)
+
+            self.assertEqual(output["decision"], "block")
+            self.assertIn("no Codex session transcript found", output["reason"])
+
+    def test_caveman_stats_rejects_transcript_outside_codex_sessions(self):
+        with self.with_home() as tmp:
+            home = Path(tmp)
+            outside = home / "session.jsonl"
+            outside.write_text(
+                json.dumps(
+                    {
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "token_count",
+                            "info": {
+                                "total_token_usage": {
+                                    "input_tokens": 1234,
+                                    "output_tokens": 456,
+                                    "total_tokens": 1690,
+                                }
+                            },
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            stdout = self.run_hook(
+                home,
+                "UserPromptSubmit",
+                {
+                    "hook_event_name": "UserPromptSubmit",
+                    "prompt": "/caveman-stats",
+                    "transcript_path": str(outside),
+                },
+            )
+            output = json.loads(stdout)
+
+            self.assertEqual(output["decision"], "block")
+            self.assertIn("no Codex session transcript found", output["reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/verify_repo.py
+++ b/tests/verify_repo.py
@@ -154,6 +154,31 @@ def verify_synced_files() -> None:
     print("Synced copies, caveman.skill zip, and installer entrypoints OK")
 
 
+def verify_package_contents() -> None:
+    section("Package Contents")
+
+    result = run(["npm", "pack", "--dry-run", "--json"])
+    packages = json.loads(result.stdout)
+    ensure(isinstance(packages, list) and packages, "npm pack returned no package metadata")
+
+    paths = {entry["path"] for entry in packages[0].get("files", [])}
+    required = {
+        "bin/install.js",
+        "skills/caveman/SKILL.md",
+        "skills/caveman-compress/scripts/cli.py",
+        "plugins/caveman/scripts/caveman-codex-hook.js",
+        "plugins/caveman/hooks/hooks.json",
+    }
+    missing = sorted(required - paths)
+    ensure(not missing, f"npm package missing required files: {', '.join(missing)}")
+    ensure(
+        not any("__pycache__" in path or path.endswith(".pyc") for path in paths),
+        "npm package includes Python cache files",
+    )
+
+    print("npm package includes root skills, Codex hook files, and no Python caches")
+
+
 def verify_manifests_and_syntax() -> None:
     section("Manifests And Syntax")
 
@@ -163,6 +188,7 @@ def verify_manifests_and_syntax() -> None:
         ROOT / ".codex/hooks.json",
         ROOT / "gemini-extension.json",
         ROOT / "plugins/caveman/.codex-plugin/plugin.json",
+        ROOT / "plugins/caveman/hooks/hooks.json",
     ]
     for path in manifest_paths:
         read_json(path)
@@ -170,6 +196,7 @@ def verify_manifests_and_syntax() -> None:
     run(["node", "--check", "src/hooks/caveman-config.js"])
     run(["node", "--check", "src/hooks/caveman-activate.js"])
     run(["node", "--check", "src/hooks/caveman-mode-tracker.js"])
+    run(["node", "--check", "plugins/caveman/scripts/caveman-codex-hook.js"])
     run(["node", "--check", "bin/install.js"])
     run(["node", "--check", "bin/lib/settings.js"])
     run(["bash", "-n", "src/hooks/install.sh"])
@@ -237,7 +264,7 @@ def verify_compress_cli() -> None:
     section("Compress CLI")
 
     skip_result = run(
-        ["python3", "-m", "scripts", "../../src/hooks/install.sh"],
+        ["python3", "-m", "scripts", str(ROOT / "src/hooks/install.sh")],
         cwd=ROOT / "skills/caveman-compress",
         check=False,
     )
@@ -249,7 +276,7 @@ def verify_compress_cli() -> None:
     )
 
     missing_result = run(
-        ["python3", "-m", "scripts", "../../does-not-exist.md"],
+        ["python3", "-m", "scripts", str(ROOT / "does-not-exist.md")],
         cwd=ROOT / "skills/caveman-compress",
         check=False,
     )
@@ -392,15 +419,26 @@ def verify_hook_install_flow() -> None:
     print("Claude hook install/uninstall flow OK")
 
 
+def verify_codex_hook_flow() -> None:
+    section("Codex Hook Flow")
+
+    ensure(shutil.which("node") is not None, "node is required for Codex hook verification")
+    run(["python3", "-m", "unittest", "tests.test_codex_hooks"])
+
+    print("Codex hook activation, mode tracking, and stats flow OK")
+
+
 def main() -> int:
     checks = [
         verify_skill_frontmatter_upload_compatibility,
         verify_synced_files,
+        verify_package_contents,
         verify_manifests_and_syntax,
         verify_powershell_static,
         verify_compress_fixtures,
         verify_compress_cli,
         verify_hook_install_flow,
+        verify_codex_hook_flow,
     ]
 
     try:


### PR DESCRIPTION
## Summary

Adds native Codex support for caveman mode without depending on Claude hook semantics.

- Add a Codex hook runtime for `SessionStart` and `UserPromptSubmit`.
- Wire installer-managed hooks through `CODEX_HOME/hooks.json` with idempotent merge and uninstall behavior.
- Bundle plugin lifecycle hooks through `plugins/caveman/hooks/hooks.json` and `PLUGIN_ROOT`.
- Support mode tracking, normal-mode deactivation, negated-prompt deactivation, and `/caveman-stats` from explicit safe Codex transcripts.
- Keep root `skills/` as publishable package content and guard npm packages against Python cache files.

## Changes

- `plugins/caveman/scripts/caveman-codex-hook.js` — native Codex hook runtime.
- `plugins/caveman/hooks/hooks.json` and `plugins/caveman/.codex-plugin/plugin.json` — plugin hook registration.
- `.codex/hooks.json` — repo-local fallback hook wiring.
- `bin/install.js` and `bin/lib/settings.js` — Codex install/uninstall merge, dedupe, and safe no-op uninstall behavior.
- `tests/test_codex_hooks.py`, `tests/installer/e2e.codex.test.mjs`, and `tests/verify_repo.py` — Codex regression coverage.

## Test plan

- [x] `git diff --check`
- [x] `python3 -m unittest tests.test_codex_hooks` — 10 passed
- [x] `TMPDIR=/home/dmartino/.cache/tmp mise exec -- npm test` — 77 passed, 4 skipped, 0 failed
- [x] `uv run --python 3.10 python tests/verify_repo.py` — all checks passed, including package contents
- [x] Isolated `CODEX_HOME` plugin smoke test — marketplace add, plugin install, installed cache hook invocation
- [x] Live Codex install smoke test — installer run twice, existing user hooks preserved, caveman hook entries stayed idempotent
- [x] Direct hook smoke test — installed hook and plugin-cache hook returned valid Codex hook JSON; `/caveman-stats` worked with an explicit transcript path

## Related

Fixes #185.
Fixes #343.
Refs #178 — adds a manual Codex installer/hook path, but does not change Codex VS Code extension plugin discovery.
Refs #251 — extends `/caveman-stats` to Codex session logs, but does not close the broader cross-agent stats request.
Refs #286 — older Codex PR against stale hook semantics.

This PR keeps installer-managed hooks separate from plugin-bundled hooks and follows the current Codex plugin hook layout (`hooks/hooks.json` plus `PLUGIN_ROOT`).
