### PR TITLE
used triple equals to be inline with the theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Raw data and reproduction script: [`benchmarks/`](./benchmarks/). Three-arm eval
 > [!IMPORTANT]
 > Caveman only affects output tokens — thinking/reasoning tokens untouched. Caveman no make brain smaller. Caveman make *mouth* smaller. Biggest win is **readability and speed**, cost savings a bonus.
 
-A March 2026 paper ["Brevity Constraints Reverse Performance Hierarchies in Language Models"](https://arxiv.org/abs/2604.00025) found that constraining large models to brief responses **improved accuracy by 26 points** on certain benchmarks. Verbose not always better. Sometimes less word = more correct.
+A March 2026 paper ["Brevity Constraints Reverse Performance Hierarchies in Language Models"](https://arxiv.org/abs/2604.00025) found that constraining large models to brief responses **improved accuracy by 26 points** on certain benchmarks. Verbose not always better. Sometimes less word === more correct.
 
 ## How It Work
 


### PR DESCRIPTION
the wording "Sometimes less word === more correct." better suits the theme of the README than "Sometimes less word = more correct."