### PR TITLE
fix: feat: Auto-Clarity exception for the final task answer (clear prose for the turn-closing summary) (closes #510)

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -59,6 +59,7 @@ Drop caveman when:
 - Multi-step sequences where fragment order or omitted conjunctions risk misread
 - Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` — order unclear without articles/conjunctions)
 - User asks to clarify or repeats question
+- FINAL TASK ANSWER: the turn-closing message that delivers results, summary, or explanation after work done. User reads only that message to understand outcome: write it in normal clear prose, full sentences, explain properly. Caveman stay for intermediate progress notes, status lines, quick acks between tool calls.
 
 Resume caveman after clear part done.
 


### PR DESCRIPTION
Fixes #510

---
This fix was implemented autonomously by **[Conduct AI](https://conductai.ai)** — an open-source platform that turns AI agents into reusable team automations via YAML playbooks.
- 🔗 Platform: [conductai.ai](https://conductai.ai)
- 📦 Source: [github.com/sseshachala/conductai](https://github.com/sseshachala/conductai)
> Want Conduct AI to automate fixes in your repo too? [Get started free →](https://conductai.ai)

