### PR TITLE
feat(install): add Hermes Agent support

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -228,7 +228,8 @@ const PROVIDERS = [
   // CLI agents — require the binary. The `||dir:~/.foo` fallbacks were the
   // main source of false positives (warp, kiro, junie etc. leave config dirs
   // behind on uninstall).
-  { id: 'aider-desk', label: 'Aider Desk',          mech: 'npx skills add (aider-desk)',   detect: 'command:aider', profile: 'aider-desk' },
+    { id: 'hermes',     label: 'Hermes Agent',        mech: 'npx skills add (hermes)',       detect: 'command:hermes',        profile: 'hermes' },
+    { id: 'aider-desk', label: 'Aider Desk',          mech: 'npx skills add (aider-desk)',   detect: 'command:aider', profile: 'aider-desk' },
   { id: 'amp',        label: 'Sourcegraph Amp',     mech: 'npx skills add (amp)',          detect: 'command:amp',             profile: 'amp' },
   { id: 'bob',        label: 'IBM Bob',             mech: 'npx skills add (bob)',          detect: 'command:bob', profile: 'bob' },
   { id: 'crush',      label: 'Crush',               mech: 'npx skills add (crush)',        detect: 'command:crush', profile: 'crush' },
@@ -557,6 +558,63 @@ function installViaSkills(ctx, prov) {
   const r = runSpawn('npx', args, null, opts.dryRun);
   if ((r.status || 0) === 0) results.installed.push(prov.id);
   else results.failed.push([prov.id, `npx skills add (${prov.profile}) failed`]);
+  process.stdout.write('\n');
+}
+
+// ── hermes native install ──────────────────────────────────────────────────
+// Drops the caveman skills into ~/.hermes/skills/productivity/ (or HERMES_HOME if set).
+const HERMES_SKILL_DIRS = ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'cavecrew'];
+
+function hermesConfigDir() {
+  // Hermes uses ~/.hermes by default, or HERMES_HOME env var.
+  if (process.env.HERMES_HOME) return path.join(process.env.HERMES_HOME, 'skills');
+  return path.join(os.homedir(), '.hermes', 'skills');
+}
+
+function installHermes(ctx) {
+  const { say, note, warn, opts, repoRoot, results } = ctx;
+  results.detected++;
+  say('→ Hermes Agent detected');
+
+  if (!repoRoot) {
+    warn('  Hermes native install requires a local clone of the caveman repo.');
+    note('  Re-run from a clone: git clone https://github.com/' + REPO + ' && cd caveman && node bin/install.js --only hermes');
+    results.failed.push(['hermes', 'native install requires local repo clone']);
+    process.stdout.write('\n');
+    return;
+  }
+
+  const skillsRoot = path.join(hermesConfigDir(), 'productivity');
+
+  if (opts.dryRun) {
+    note(`  would mkdir ${skillsRoot}/`);
+    note(`  would copy ${HERMES_SKILL_DIRS.length} skill dirs into ${skillsRoot}/`);
+    results.installed.push('hermes');
+    process.stdout.write('\n');
+    return;
+  }
+
+  try {
+    fs.mkdirSync(skillsRoot, { recursive: true });
+
+    for (const skillDir of HERMES_SKILL_DIRS) {
+      const srcDir = path.join(repoRoot, 'skills', skillDir);
+      const destDir = path.join(skillsRoot, skillDir);
+      if (fs.existsSync(srcDir)) {
+        // Remove existing to ensure clean copy
+        if (fs.existsSync(destDir)) fs.rmSync(destDir, { recursive: true, force: true });
+        copyDirRecursive(srcDir, destDir);
+        note(`  copied ${skillDir} → ${destDir}`);
+      } else {
+        warn(`  skill dir not found: ${srcDir}`);
+      }
+    }
+
+    results.installed.push('hermes');
+  } catch (err) {
+    results.failed.push(['hermes', 'copy failed: ' + err.message]);
+  }
+
   process.stdout.write('\n');
 }
 
@@ -1340,10 +1398,11 @@ async function main() {
     // missing without --force).
     if (!explicit(prov.id) && !detectMatch(prov.detect)) continue;
     if (prov.id === 'claude')   { await installClaude(ctx); continue; }
-    if (prov.id === 'gemini')   { installGemini(ctx); continue; }
-    if (prov.id === 'opencode') { installOpencode(ctx); continue; }
-    if (prov.id === 'openclaw') { installOpenclaw(ctx); continue; }
-    if (prov.profile)           { installViaSkills(ctx, prov); continue; }
+      if (prov.id === 'gemini')   { installGemini(ctx); continue; }
+      if (prov.id === 'opencode') { installOpencode(ctx); continue; }
+      if (prov.id === 'openclaw') { installOpenclaw(ctx); continue; }
+      if (prov.id === 'hermes')   { installHermes(ctx); continue; }
+      if (prov.profile)           { installViaSkills(ctx, prov); continue; }
   }
 
   // Auto-detect fallback if nothing matched


### PR DESCRIPTION
Adds Hermes Agent as a supported provider with native skill installation.

## Changes
- Added 























╭─ Hermes Agent v0.16.0 (2026.6.5) · upstream 6b76284c · local 5a819d39 (+1 ca─╮
│                                       Available Tools                        │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⡀⠀⣀⣀⠀⢀⣀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀     browser: browser_back, browser_click,  │
│    ⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣇⠸⣿⣿⠇⣸⣿⣿⣷⣦⣄⡀⠀⠀⠀⠀⠀⠀     ...                                    │
│    ⠀⢀⣠⣴⣶⠿⠋⣩⡿⣿⡿⠻⣿⡇⢠⡄⢸⣿⠟⢿⣿⢿⣍⠙⠿⣶⣦⣄⡀⠀     browser-cdp: browser_cdp,              │
│    ⠀⠀⠉⠉⠁⠶⠟⠋⠀⠉⠀⢀⣈⣁⡈⢁⣈⣁⡀⠀⠉⠀⠙⠻⠶⠈⠉⠉⠀⠀     browser_dialog                         │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣴⣿⡿⠛⢁⡈⠛⢿⣿⣦⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀     clarify: clarify                       │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠿⣿⣦⣤⣈⠁⢠⣴⣿⠿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀     code_execution: execute_code           │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠻⢿⣿⣦⡉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀     computer_use: computer_use             │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠘⢷⣦⣈⠛⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀     cronjob: cronjob                       │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣴⠦⠈⠙⠿⣦⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀     delegation: delegate_task              │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠸⣿⣤⡈⠁⢤⣿⠇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀     discord: discord                       │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⠷⠄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀     (and 20 more toolsets...)              │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⠑⢶⣄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀                                            │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⠁⢰⡆⠈⡿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀     Available Skills                       │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠳⠈⣡⠞⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀     apple: apple-notes, apple-reminders,   │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀     findmy, imessage,...                   │
│                                       autonomous-ai-agents: claude-code,     │
│     nemotron-3-ultra:free · Nous      codex, hermes-agent, opencode          │
│               Research                creative: architecture-diagram,        │
│         /private/tmp/caveman          ascii-art, ascii-video, b...           │
│    Session: 20260614_123014_bfecad    data-science: jupyter-live-kernel      │
│                                       devops: kanban-orchestrator,           │
│                                       kanban-worker                          │
│                                       email: himalaya                        │
│                                       general: dogfood, yuanbao              │
│                                       github: codebase-inspection,           │
│                                       github-auth, github-code-r...          │
│                                       media: gif-search, heartmula,          │
│                                       songsee, youtube-content               │
│                                       mlops: audiocraft-audio-generation,    │
│                                       evaluating-llms-ha...                  │
│                                       note-taking: obsidian                  │
│                                       productivity: airtable, cavecrew,      │
│                                       caveman, caveman-commit, ca...         │
│                                       research: arxiv, blogwatcher,          │
│                                       llm-wiki, polymarket, resea...         │
│                                       smart-home: openhue                    │
│                                       social-media: xurl                     │
│                                       software-development:                  │
│                                       hermes-agent-skill-authoring,          │
│                                       node-inspect-debu...                   │
│                                                                              │
│                                       32 tools · 80 skills · /help for       │
│                                       commands                               │
│                                       ⚠ 150 commits behind — run hermes      │
│                                       update to update                       │
╰──────────────────────────────────────────────────────────────────────────────╯

Welcome to Hermes Agent! Type your message or /help for commands.
A legacy OpenClaw directory was detected at ~/.openclaw/.
To port your config, memory, and skills over to Hermes, run `hermes claw 
migrate`.
If you've already migrated and want to archive the old directory, run `hermes 
claw cleanup` (renames it to ~/.openclaw.pre-migration — OpenClaw will stop 
working after this).
This tip only shows once.
✦ Tip: hermes chat -q "query" runs a single non-interactive query and exits.

 ⚕ nemotron-3-ultra:free │ ctx -- │ [░░░░░░░░░░] -- │ 2s │ ⏲ 0s 
───────────────────────────────────────────────────────────────────────────────                                                                               ─
❯ 
───────────────────────────────────────────────────────────────────────────────                                                                               ─



   
Goodbye! ⚕ provider to the provider matrix
- Added  function that copies all 7 caveman skills to  (or  env var)
- Uses native copy approach (like opencode) since Hermes uses the same SKILL.md format with frontmatter

## Provider Details
- **ID**: `hermes`
- **Label**: Hermes Agent
- **Mechanism**: Native skill directory copy
- **Detection**: `command:hermes` (checks for `hermes` CLI on PATH)
- **Config dir**: `~/.hermes/skills` or `HERMES_HOME/skills`

## Skills Installed
- caveman (main communication mode)
- caveman-commit (commit messages)
- caveman-review (code review comments)
- caveman-help (quick reference)
- caveman-stats (token usage stats)
- caveman-compress (memory file compression)
- cavecrew (compressed subagents)

## Usage
Once merged, users can install caveman for Hermes Agent with:
```bash
npx -y github:JuliusBrussee/caveman -- --only hermes
```
Or just run the default install and it will auto-detect Hermes if the `hermes` CLI is on PATH.