### PR TITLE
Add slash-command prompt files for VSCode autocomplete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ caveman/
 | `src/rules/caveman-activate.md` | Always-on auto-activation rule body. Consumed by `src/tools/caveman-init.js` when a user runs `npx caveman --with-init` (per-repo IDE rule files). Edit here, not in any per-agent rule copy. |
 | `src/rules/caveman-openclaw-bootstrap.md` | Marker-fenced bootstrap snippet appended to `~/.openclaw/workspace/SOUL.md` by `bin/lib/openclaw.js`. Drives always-on caveman through the OpenClaw gateway. Must include the SENTINEL `Respond terse like smart caveman` and stay well under OpenClaw's 12K-per-bootstrap-file cap. |
 | `bin/lib/openclaw.js` | OpenClaw install/uninstall helper. Frontmatter merge (`version`, `always: true`), SOUL.md marker append/strip, idempotent. Shared by `bin/install.js` and `src/tools/caveman-init.js`. |
+| `bin/lib/vscode-copilot.js` | VS Code Copilot user-scope install/uninstall helper. Writes a single `*.instructions.md` file at `~/.copilot/instructions/caveman.instructions.md` (overridable via `CAVEMAN_VSCODE_USER_ROOT`). Marker-fenced, idempotent, refresh-on-change, refuses to overwrite foreign files without `--force`. Loaded by the `vscode` provider in `bin/install.js`. |
 | `skills/caveman-commit/SKILL.md` | Caveman commit message behavior. Fully independent skill. |
 | `skills/caveman-review/SKILL.md` | Caveman code review behavior. Fully independent skill. |
 | `skills/caveman-help/SKILL.md` | Quick-reference card. One-shot display, not a persistent mode. |
@@ -248,7 +249,8 @@ How caveman reaches each agent type:
 | Cursor | `npx skills add ... -a cursor` (default via `--only cursor`) writes the upstream skill profile; per-repo `.cursor/rules/caveman.mdc` via `--with-init` (calls `src/tools/caveman-init.js`) | Yes — always-on rule |
 | Windsurf | `npx skills add ... -a windsurf` (default via `--only windsurf`); per-repo `.windsurf/rules/caveman.md` via `--with-init` | Yes — always-on rule |
 | Cline | `npx skills add ... -a cline` (default via `--only cline`); per-repo `.clinerules/caveman.md` via `--with-init` | Yes — Cline auto-discovers `.clinerules/` |
-| Copilot | `npx skills add ... -a github-copilot` (soft probe — pass `--only copilot`); per-repo `.github/copilot-instructions.md` + `AGENTS.md` via `--with-init` | Yes — repo-wide instructions |
+| Copilot (per-repo) | `npx skills add ... -a github-copilot` (soft probe — pass `--only copilot`); per-repo `.github/copilot-instructions.md` + `AGENTS.md` via `--with-init` | Yes — repo-wide instructions |
+| VS Code Copilot (user-scope) | `node bin/install.js --only vscode` (soft probe). Writes one file at `~/.copilot/instructions/caveman.instructions.md` via `bin/lib/vscode-copilot.js`. No per-repo init, no skills CLI. Override target with `CAVEMAN_VSCODE_USER_ROOT`. | Yes — VS Code Copilot loads `*.instructions.md` (no `applyTo`) in every workspace |
 | Others (Junie, Trae, Warp, Tabnine, Mistral, Qwen, Devin, Droid, ForgeCode, Bob, Crush, iFlow, OpenHands, Qoder, Rovo Dev, Replit, Antigravity, …) | `npx skills add JuliusBrussee/caveman -a <profile>` | No — user must say `/caveman` each session |
 
 opencode reaches Tier 1 minus the statusline (opencode's TUI has no plugin-writable badge). Mode flag lives at `~/.config/opencode/.caveman-active` for any external tooling that wants to surface it.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,6 +48,7 @@ If you want to install for one agent (or want to know exactly what command runs 
 | **Windsurf** | `npx skills add JuliusBrussee/caveman -a windsurf` | Per-session by default; `--with-init` for an always-on rule file |
 | **Cline** | `npx skills add JuliusBrussee/caveman -a cline` | Per-session by default; `--with-init` for an always-on rule file |
 | **GitHub Copilot** *(soft probe)* | `npx -y github:JuliusBrussee/caveman -- --only copilot --with-init` | Repo-wide instructions via `--with-init` |
+| **VS Code Copilot (user-scope)** *(soft probe)* | `npx -y github:JuliusBrussee/caveman -- --only vscode` | Yes — single file at `~/.copilot/instructions/caveman.instructions.md`, loads in every workspace |
 | **Continue** | `npx skills add JuliusBrussee/caveman -a continue` | No — say `/caveman` |
 | **Kilo Code** | `npx skills add JuliusBrussee/caveman -a kilo` | No |
 | **Roo Code** | `npx skills add JuliusBrussee/caveman -a roo` | No |
@@ -145,6 +146,48 @@ curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/src/rule
 
 `--with-init` writes the rule into every supported per-agent location it can detect (`.cursor/rules/`, `.windsurf/rules/`, `.clinerules/`, `.github/copilot-instructions.md`, `.opencode/AGENTS.md`, `AGENTS.md`). It also installs the OpenClaw workspace bootstrap (skill folder + SOUL.md marker block) when `~/.openclaw/workspace/` exists. Single source: [`src/rules/caveman-activate.md`](src/rules/caveman-activate.md).
 
+### VS Code Copilot (user-scope, every workspace)
+
+The per-repo `--with-init` writes `.github/copilot-instructions.md` into one workspace at a time. If you want caveman on for **every** workspace, every Copilot Chat session, without touching any repo:
+
+```bash
+# Install (one file, user-scope, always-on)
+node bin/install.js --only vscode
+
+# Or from a curl|bash style run
+npx -y github:JuliusBrussee/caveman -- --only vscode
+```
+
+What it touches — **exactly one file**:
+
+| Platform | Path |
+|---|---|
+| Windows | `%USERPROFILE%\.copilot\instructions\caveman.instructions.md` |
+| macOS / Linux | `~/.copilot/instructions/caveman.instructions.md` |
+
+The file has no `applyTo` key, so VS Code Copilot loads it as an always-on instruction across all workspaces. It coexists with any other `*.instructions.md` files in that folder — each one is loaded independently. The body is wrapped in `<!-- caveman-begin -->` / `<!-- caveman-end -->` markers so uninstall can find and remove it cleanly.
+
+The installer is idempotent and safe to re-run:
+
+- If the file is missing → writes it.
+- If the file is ours and identical → no-op.
+- If the file is ours but the rule body has changed (upgrade) → refreshes content in place.
+- If the file exists **without** caveman markers → refuses to overwrite. Re-run with `--force` to replace.
+
+Uninstall removes only that one file:
+
+```bash
+node bin/install.js --only vscode --uninstall
+# or, as part of the global uninstall:
+npx -y github:JuliusBrussee/caveman -- --uninstall
+```
+
+The global `--uninstall` also strips this file (only when it carries caveman markers — foreign files with the same name are left alone).
+
+> **Why a dedicated provider?** The existing `copilot` row in the matrix uses `npx skills add` + `--with-init` to drop a rule into the current repo's `.github/copilot-instructions.md`. The `vscode` provider is the user-scope counterpart — one file, no per-repo init, easy to remove. Pick whichever fits your workflow; they don't conflict if you use both.
+>
+> **Override the target dir** (for testing or unusual setups): set `CAVEMAN_VSCODE_USER_ROOT=/some/other/.copilot` before running install or uninstall.
+
 ## Verify
 
 After install, three quick checks:
@@ -185,6 +228,7 @@ What it removes:
 - The Claude Code plugin and the Gemini CLI extension (if installed).
 - The opencode native plugin (`~/.config/opencode/plugins/caveman/`, the `plugin` and `mcp.caveman-shrink` entries from `opencode.json`, our skill/agent/command files, the caveman block from `AGENTS.md`, and the opencode flag file).
 - The OpenClaw workspace skill folder and the marker-fenced block from `~/.openclaw/workspace/SOUL.md` (when present).
+- The VS Code Copilot user-scope file at `~/.copilot/instructions/caveman.instructions.md` (only when it carries our markers — other files in that folder are untouched).
 - The `.caveman-active` flag file.
 
 What it does **not** remove:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -184,6 +184,39 @@ npx -y github:JuliusBrussee/caveman -- --uninstall
 
 The global `--uninstall` also strips this file (only when it carries caveman markers — foreign files with the same name are left alone).
 
+#### Switching levels
+
+VS Code Copilot has no hook system, so caveman has two distinct level controls:
+
+**Mid-session (single chat only).** Type one of these into the chat:
+
+| Phrase | Effect |
+|---|---|
+| `/caveman lite` | Mildest compression |
+| `/caveman full` | Default |
+| `/caveman ultra` | Heaviest compression |
+| `/caveman wenyan` / `/caveman wenyan-lite` / `/caveman wenyan-ultra` | Classical-Chinese-style ultra terseness |
+| `/caveman disabled` | Drop back to normal prose |
+| `stop caveman` / `normal mode` | Same as `/caveman disabled` |
+| `talk like caveman` / `caveman mode` | Re-enable at the default level |
+
+These last for the current chat only. Opening a new chat re-reads the rule file → back to the persistent default.
+
+**Persistent default (every new chat).** Re-run the installer with `--level <name>`:
+
+```bash
+# Set the persistent default
+node bin/install.js --only vscode --level lite
+node bin/install.js --only vscode --level ultra
+node bin/install.js --only vscode --level wenyan
+
+# Fully remove the user-scope file
+node bin/install.js --only vscode --level disabled
+# (same as: node bin/install.js --only vscode --uninstall)
+```
+
+Valid `--level` values: `lite`, `full`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-ultra`, `disabled`. The installer is idempotent — re-runs only rewrite the file when the level (or the rule body itself) actually changes.
+
 > **Why a dedicated provider?** The existing `copilot` row in the matrix uses `npx skills add` + `--with-init` to drop a rule into the current repo's `.github/copilot-instructions.md`. The `vscode` provider is the user-scope counterpart — one file, no per-repo init, easy to remove. Pick whichever fits your workflow; they don't conflict if you use both.
 >
 > **Override the target dir** (for testing or unusual setups): set `CAVEMAN_VSCODE_USER_ROOT=/some/other/.copilot` before running install or uninstall.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Install break? Open agent, say *"Read CLAUDE.md and INSTALL.md, install caveman 
 
 **Statusline badge** — Claude Code shows `[CAVEMAN] ⛏ 12.4k` (lifetime tokens saved). Updates every `/caveman-stats` run. Set `CAVEMAN_STATUSLINE_SAVINGS=0` to silence.
 
-Auto-activate every session: Claude Code, Codex, Gemini (built-in). Cursor / Windsurf / Cline / Copilot get always-on rule files via `--with-init`. Other agents trigger with `/caveman` per session. Full feature matrix in [INSTALL.md](./INSTALL.md#what-you-get).
+Auto-activate every session: Claude Code, Codex, Gemini (built-in). Cursor / Windsurf / Cline / Copilot get always-on rule files via `--with-init` (per-repo) or `--only vscode` (user-scope, every workspace — one file at `~/.copilot/instructions/caveman.instructions.md`). Other agents trigger with `/caveman` per session. Full feature matrix in [INSTALL.md](./INSTALL.md#what-you-get).
 
 ## Benchmarks
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -125,6 +125,14 @@ function parseArgs(argv) {
         opts.configDir = expandHome(v);
         break;
       }
+      case '--level': {
+        const v = argv[++i];
+        const VALID = ['lite', 'full', 'ultra', 'wenyan', 'wenyan-lite', 'wenyan-ultra', 'disabled'];
+        if (!v || v.startsWith('--')) die(`error: --level requires one of: ${VALID.join(', ')}`);
+        if (!VALID.includes(v)) die(`error: invalid --level '${v}'. valid: ${VALID.join(', ')}`);
+        opts.level = v;
+        break;
+      }
       default:
         die(`error: unknown flag: ${a}\nrun 'caveman --help' for usage`);
     }
@@ -822,16 +830,40 @@ function installVscode(ctx) {
     warn: (s) => warn(s),
   };
 
+  // --level disabled is a routed-to-uninstall signal. Removes the user-scope
+  // file (only if it carries our markers) and reports it as such.
+  if (opts.level === 'disabled') {
+    const r = VSCODE.uninstallVscode({
+      root: process.env.CAVEMAN_VSCODE_USER_ROOT || undefined,
+      dryRun: opts.dryRun,
+      log,
+    });
+    if (r.touched) {
+      results.installed.push('vscode (disabled)');
+    } else if (r.skipped) {
+      results.failed.push(['vscode', 'file exists without caveman markers — left untouched']);
+    } else {
+      note('  vscode caveman not installed — nothing to disable');
+    }
+    process.stdout.write('\n');
+    return;
+  }
+
   const r = VSCODE.installVscode({
     root: process.env.CAVEMAN_VSCODE_USER_ROOT || undefined,
     repoRoot,
+    level: opts.level,
     dryRun: opts.dryRun,
     force: opts.force,
     log,
   });
 
-  if (r.ok) results.installed.push('vscode (user-scope)');
-  else results.failed.push(['vscode', r.reason || 'install failed']);
+  if (r.ok) {
+    const tag = opts.level && opts.level !== 'full' ? ` (${opts.level})` : '';
+    results.installed.push(`vscode (user-scope)${tag}`);
+  } else {
+    results.failed.push(['vscode', r.reason || 'install failed']);
+  }
 
   process.stdout.write('\n');
 }
@@ -1318,6 +1350,11 @@ FLAGS
                         is required. The value is whitespace-tokenized.
                         Example: --with-mcp-shrink="npx @modelcontextprotocol/server-filesystem /tmp"
   --no-mcp-shrink       Skip MCP shrink. (Default.)
+  --level <name>        VS Code Copilot user-scope only (--only vscode):
+                        set the persistent default intensity. One of:
+                        lite | full | ultra | wenyan | wenyan-lite |
+                        wenyan-ultra | disabled. 'disabled' uninstalls the
+                        user-scope file. Default: full.
   --uninstall, -u       Remove caveman from this machine.
   --config-dir <path>   Claude Code config dir for hook files + settings.json.
                         Default: \$CLAUDE_CONFIG_DIR or ~/.claude. Does NOT

--- a/bin/install.js
+++ b/bin/install.js
@@ -24,6 +24,7 @@ const crypto = require('crypto');
 
 const SETTINGS = require('./lib/settings');
 const OPENCLAW = require('./lib/openclaw');
+const VSCODE = require('./lib/vscode-copilot');
 const { stripOpencodeAgentTools } = require('./lib/opencode-agent');
 
 const REPO = 'JuliusBrussee/caveman';
@@ -224,6 +225,14 @@ const PROVIDERS = [
   // needed). The old `command:copilot` soft probe never fired for most users
   // because Copilot ships as an editor extension, not a CLI (issue #336).
   { id: 'copilot',    label: 'GitHub Copilot',      mech: 'npx skills add (github-copilot)', detect: 'vscode-ext:github.copilot||vscode-ext:github.copilot-chat||cursor-ext:github.copilot', profile: 'github-copilot' },
+
+  // VS Code Copilot (user-scope always-on): one file at
+  // ~/.copilot/instructions/caveman.instructions.md. No per-repo init, no
+  // `/caveman` per session. Distinct from `copilot` above (which is the
+  // per-repo npx-skills install). Soft so it only fires on `--only vscode` —
+  // we don't want every install run to silently write a user-scope file when
+  // the user might prefer the per-repo behavior.
+  { id: 'vscode',     label: 'VS Code Copilot (user-scope)', mech: 'user-scope instructions file', detect: 'vscode-ext:github.copilot||vscode-ext:github.copilot-chat', soft: true },
 
   // CLI agents — require the binary. The `||dir:~/.foo` fallbacks were the
   // main source of false positives (warp, kiro, junie etc. leave config dirs
@@ -798,6 +807,35 @@ function installOpenclaw(ctx) {
   process.stdout.write('\n');
 }
 
+// ── VS Code Copilot (user-scope) native install ───────────────────────────
+// Writes a single instructions file at ~/.copilot/instructions/caveman.instructions.md
+// that VS Code Copilot auto-loads in every workspace, every session. No
+// per-repo init required. The actual file write lives in bin/lib/vscode-copilot.js.
+function installVscode(ctx) {
+  const { say, note, warn, opts, repoRoot, results } = ctx;
+  results.detected++;
+  say('→ VS Code Copilot (user-scope) selected');
+
+  const log = {
+    write: (s) => process.stdout.write(s),
+    note: (s) => note(s),
+    warn: (s) => warn(s),
+  };
+
+  const r = VSCODE.installVscode({
+    root: process.env.CAVEMAN_VSCODE_USER_ROOT || undefined,
+    repoRoot,
+    dryRun: opts.dryRun,
+    force: opts.force,
+    log,
+  });
+
+  if (r.ok) results.installed.push('vscode (user-scope)');
+  else results.failed.push(['vscode', r.reason || 'install failed']);
+
+  process.stdout.write('\n');
+}
+
 // ── Hooks installer ────────────────────────────────────────────────────────
 // Replaces src/hooks/install.sh + src/hooks/install.ps1.
 async function installHooks(ctx) {
@@ -1188,6 +1226,22 @@ function uninstall(ctx) {
     if (r.touched) ok('  pruned caveman entries from OpenClaw workspace');
   }
 
+  // VS Code Copilot user-scope install — single file, no other state.
+  // Helper is no-op if the file doesn't exist or lacks caveman markers.
+  {
+    const log = {
+      write: (s) => process.stdout.write(s),
+      note: (s) => note(s),
+      warn: (s) => warn(s),
+    };
+    const r = VSCODE.uninstallVscode({
+      root: process.env.CAVEMAN_VSCODE_USER_ROOT || undefined,
+      dryRun: opts.dryRun,
+      log,
+    });
+    if (r.touched) ok('  removed VS Code user-scope caveman instructions');
+  }
+
   // Flag file
   const flag = path.join(configDir, '.caveman-active');
   if (fs.existsSync(flag) && !opts.dryRun) { try { fs.unlinkSync(flag); } catch (_) {} }
@@ -1343,6 +1397,7 @@ async function main() {
     if (prov.id === 'gemini')   { installGemini(ctx); continue; }
     if (prov.id === 'opencode') { installOpencode(ctx); continue; }
     if (prov.id === 'openclaw') { installOpenclaw(ctx); continue; }
+    if (prov.id === 'vscode')   { installVscode(ctx); continue; }
     if (prov.profile)           { installViaSkills(ctx, prov); continue; }
   }
 

--- a/bin/lib/vscode-copilot.js
+++ b/bin/lib/vscode-copilot.js
@@ -20,6 +20,18 @@
 //
 // Override for tests/non-default setups: pass `{ root }` to the helpers, or
 // set CAVEMAN_VSCODE_USER_ROOT in the environment.
+//
+// In addition to the always-on instructions file, we also install per-slash
+// prompt files (`*.prompt.md`) into the VS Code Copilot user prompts folder
+// so `/caveman`, `/caveman-commit`, etc. show up in the chat slash-menu with
+// autocomplete. Source of truth: `src/prompts/vscode/*.prompt.md`. Each
+// shipped prompt carries a `<!-- caveman-managed -->` sentinel so uninstall
+// can identify and safely delete them without touching user-authored prompts.
+//
+// Prompts dir resolution (override with CAVEMAN_VSCODE_PROMPTS_DIR):
+//   Windows: %APPDATA%/Code/User/prompts
+//   macOS:   ~/Library/Application Support/Code/User/prompts
+//   Linux:   $XDG_CONFIG_HOME/Code/User/prompts (fallback ~/.config/Code/User/prompts)
 
 'use strict';
 
@@ -30,6 +42,21 @@ const path = require('path');
 const INSTR_FILENAME = 'caveman.instructions.md';
 const MARK_BEGIN = '<!-- caveman-begin -->';
 const MARK_END = '<!-- caveman-end -->';
+const PROMPT_SENTINEL = '<!-- caveman-managed -->';
+const PROMPT_FILES = [
+  'caveman.prompt.md',
+  'caveman-commit.prompt.md',
+  'caveman-review.prompt.md',
+  'caveman-compress.prompt.md',
+  'caveman-help.prompt.md',
+  'caveman-stats.prompt.md',
+];
+
+// Valid persistent default levels for `--level <name>`. `disabled` is a
+// special routed-to-uninstall value handled by the caller, not written into
+// the file.
+const VALID_LEVELS = ['lite', 'full', 'ultra', 'wenyan', 'wenyan-lite', 'wenyan-ultra'];
+const VALID_LEVELS_PLUS_DISABLED = VALID_LEVELS.concat(['disabled']);
 
 function resolveRoot(env = process.env) {
   if (env.CAVEMAN_VSCODE_USER_ROOT) return path.resolve(env.CAVEMAN_VSCODE_USER_ROOT);
@@ -38,6 +65,23 @@ function resolveRoot(env = process.env) {
 
 function resolveInstructionsFile(root) {
   return path.join(root || resolveRoot(), 'instructions', INSTR_FILENAME);
+}
+
+// VS Code Copilot loads `*.prompt.md` files from a per-user `prompts/`
+// folder under the VS Code user-data directory. The location is platform
+// dependent. Honor an explicit override first.
+function resolvePromptsDir(env = process.env, platform = process.platform) {
+  if (env.CAVEMAN_VSCODE_PROMPTS_DIR) return path.resolve(env.CAVEMAN_VSCODE_PROMPTS_DIR);
+  const home = os.homedir();
+  if (platform === 'win32') {
+    const appdata = env.APPDATA || path.join(home, 'AppData', 'Roaming');
+    return path.join(appdata, 'Code', 'User', 'prompts');
+  }
+  if (platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'Code', 'User', 'prompts');
+  }
+  const xdg = env.XDG_CONFIG_HOME || path.join(home, '.config');
+  return path.join(xdg, 'Code', 'User', 'prompts');
 }
 
 function readIfExists(p) {
@@ -62,8 +106,10 @@ function loadRuleBody(repoRoot) {
     '- Not: "Sure! I\'d be happy to help you with that."',
     '- Yes: "Bug in auth middleware. Fix:"',
     '',
-    'Switch level: /caveman lite|full|ultra|wenyan',
-    'Stop: "stop caveman" or "normal mode"',
+    'Switch level: /caveman lite|full|ultra|wenyan|wenyan-lite|wenyan-ultra',
+    'Stop: /caveman disabled, "stop caveman", or "normal mode"',
+    '',
+    'Default intensity: full.',
     '',
     'Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.',
     '',
@@ -72,17 +118,29 @@ function loadRuleBody(repoRoot) {
   ].join('\n');
 }
 
+// Replace the "Default intensity: <X>." line with the requested level. The
+// rule body always contains a baseline "Default intensity: full." line; we
+// rewrite it in place so the rest of the rule stays byte-equivalent.
+function applyLevel(ruleBody, level) {
+  if (!level || level === 'full') return ruleBody;
+  return ruleBody.replace(/^Default intensity: .+\.$/m, `Default intensity: ${level}.`);
+}
+
 // Build the full file body. VS Code Copilot instruction files use YAML
-// frontmatter; omitting `applyTo` makes the rule load for every session in
-// every workspace (always-on). The body is wrapped in marker fences so a
-// future uninstall can locate and remove the block even if the user has
-// edited the file (we still default to deleting the whole file when it's
-// ours — markers are belt-and-suspenders for shared-file scenarios).
+// frontmatter. We set `applyTo: '**'` so the rule applies to every file
+// context (and therefore every chat turn that has any file context). Without
+// `applyTo`, VS Code treats the file as on-demand description-matched, which
+// would not give us the always-on behavior we want for a tone/style rule.
+// The body is wrapped in marker fences so a future uninstall can locate
+// and remove the block even if the user has edited the file (we still
+// default to deleting the whole file when it's ours — markers are
+// belt-and-suspenders for shared-file scenarios).
 function buildFileContent(ruleBody) {
   const frontmatter = [
     '---',
     "name: 'Caveman mode'",
-    "description: 'Terse caveman-style responses — ~75% fewer output tokens, full technical accuracy. Always-on, user-scope.'",
+    "description: 'Terse caveman-style responses — ~75% fewer output tokens, full technical accuracy.'",
+    "applyTo: '**'",
     '---',
     '',
   ].join('\n');
@@ -93,9 +151,188 @@ function noopLog() {
   return { write: () => {}, note: () => {}, warn: () => {} };
 }
 
-function installVscode({ root, repoRoot, dryRun = false, force = false, log = noopLog() } = {}) {
+// Read a prompt file body — prefer the in-repo source of truth, fall back to
+// a minimal embedded stub so a curl|node install (no repo on disk) still
+// drops working slash commands. The embedded stubs match the bodies in
+// `src/prompts/vscode/*.prompt.md`; keep them in sync if you edit either.
+function loadPromptBody(repoRoot, filename) {
+  if (repoRoot) {
+    const p = path.join(repoRoot, 'src', 'prompts', 'vscode', filename);
+    const body = readIfExists(p);
+    if (body) return body.trimEnd() + '\n';
+  }
+  return EMBEDDED_PROMPTS[filename] || null;
+}
+
+const EMBEDDED_PROMPTS = {
+  'caveman.prompt.md': [
+    "---",
+    "mode: 'agent'",
+    "description: 'Switch caveman intensity (lite/full/ultra/wenyan/wenyan-lite/wenyan-ultra/off)'",
+    "---",
+    PROMPT_SENTINEL,
+    "Switch caveman to the level given after the slash (`lite`, `full`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-ultra`). If no level given, use `full`. If `off`/`disabled`/`stop`, drop caveman and resume normal prose.",
+    "",
+    "Respond terse like smart caveman. Drop articles, filler, pleasantries, hedging. Fragments OK. Technical terms exact. Code unchanged.",
+    "Pattern: [thing] [action] [reason]. [next step].",
+    "",
+    "Persists across turns until level switched, user says 'stop caveman' / 'normal mode', or session ends. Auto-clarity: drop caveman for security warnings, irreversible actions, user confused. Code, commits, PRs always normal English.",
+    "",
+  ].join('\n'),
+  'caveman-commit.prompt.md': [
+    "---",
+    "mode: 'agent'",
+    "description: 'Generate terse caveman-style commit message for staged changes'",
+    "---",
+    PROMPT_SENTINEL,
+    "Generate a Conventional Commits message for the current staged changes. `type(scope): subject` — subject ≤50 chars, imperative, lowercase after type, no trailing period. Body only when 'why' isn't obvious. Output the commit message only.",
+    "",
+  ].join('\n'),
+  'caveman-review.prompt.md': [
+    "---",
+    "mode: 'agent'",
+    "description: 'One-line caveman code review of current changes'",
+    "---",
+    PROMPT_SENTINEL,
+    "Review the current changes. One line per finding: `L<line>: <severity> <problem>. <fix>.` Severity: bug | risk | nit | q. Skip praise, skip obvious. If clean, output `LGTM` and stop.",
+    "",
+  ].join('\n'),
+  'caveman-compress.prompt.md': [
+    "---",
+    "mode: 'agent'",
+    "description: 'Compress a markdown/text file into caveman style'",
+    "---",
+    PROMPT_SENTINEL,
+    "Compress the file the user names. Preserve code blocks, inline code, URLs, paths, commands, headings, list structure, tables. Drop articles, filler, hedging. Save original to `<file>.original.md` before overwrite. Refuse source/config files (.py/.js/.ts/.json/.yaml/.toml/.sh/.ps1) and existing `*.original.md` backups.",
+    "",
+  ].join('\n'),
+  'caveman-help.prompt.md': [
+    "---",
+    "mode: 'ask'",
+    "description: 'Caveman quick-reference card — slash commands and triggers'",
+    "---",
+    PROMPT_SENTINEL,
+    "Show this caveman quick-reference card and stop:",
+    "",
+    "| Command | What |",
+    "|---|---|",
+    "| /caveman [level] | Activate (lite/full/ultra/wenyan, default full) |",
+    "| /caveman off | Deactivate |",
+    "| /caveman-commit | Terse commit message |",
+    "| /caveman-review | One-line review findings |",
+    "| /caveman-compress <file> | Compress markdown file |",
+    "| /caveman-stats | Lifetime token-savings |",
+    "",
+    "Natural language: 'turn on caveman', 'stop caveman', 'normal mode'.",
+    "",
+  ].join('\n'),
+  'caveman-stats.prompt.md': [
+    "---",
+    "mode: 'agent'",
+    "description: 'Show caveman lifetime token-savings stats'",
+    "---",
+    PROMPT_SENTINEL,
+    "Read caveman history log (CAVEMAN_HISTORY_PATH env, else `~/.config/caveman/.caveman-history.jsonl` or `~/AppData/Roaming/caveman/.caveman-history.jsonl`). Report total tokens saved, sessions counted, avg ratio in one short table. If no log: 'caveman-stats: no history yet'.",
+    "",
+  ].join('\n'),
+};
+
+function installPrompts({ promptsDir, repoRoot, dryRun = false, force = false, log = noopLog() } = {}) {
+  const dir = promptsDir || resolvePromptsDir();
+  const summary = { installed: [], refreshed: [], skipped: [], failed: [] };
+
+  for (const name of PROMPT_FILES) {
+    const target = path.join(dir, name);
+    const body = loadPromptBody(repoRoot, name);
+    if (!body) {
+      log.warn(`  prompt source missing for ${name} — skipping`);
+      summary.failed.push([name, 'source missing']);
+      continue;
+    }
+
+    if (dryRun) {
+      log.note(`  would write ${target}`);
+      summary.installed.push(name);
+      continue;
+    }
+
+    if (fs.existsSync(target) && !force) {
+      const existing = readIfExists(target);
+      if (existing && existing.includes(PROMPT_SENTINEL)) {
+        if (existing === body) {
+          summary.skipped.push(name);
+          continue;
+        }
+        try {
+          fs.writeFileSync(target, body, { mode: 0o644 });
+          log.write(`  refreshed ${target}\n`);
+          summary.refreshed.push(name);
+        } catch (e) {
+          log.warn(`  failed to refresh ${target}: ${e.message}`);
+          summary.failed.push([name, e.message]);
+        }
+        continue;
+      }
+      log.warn(`  ${target} exists without caveman sentinel — skipping (use --force to overwrite)`);
+      summary.failed.push([name, 'exists without sentinel']);
+      continue;
+    }
+
+    try {
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, body, { mode: 0o644 });
+      log.write(`  installed: ${target}\n`);
+      summary.installed.push(name);
+    } catch (e) {
+      log.warn(`  failed to write ${target}: ${e.message}`);
+      summary.failed.push([name, e.message]);
+    }
+  }
+
+  return { ok: summary.failed.length === 0, summary, dir };
+}
+
+function uninstallPrompts({ promptsDir, dryRun = false, log = noopLog() } = {}) {
+  const dir = promptsDir || resolvePromptsDir();
+  const summary = { removed: [], skipped: [] };
+
+  for (const name of PROMPT_FILES) {
+    const target = path.join(dir, name);
+    if (!fs.existsSync(target)) continue;
+
+    const body = readIfExists(target) || '';
+    if (!body.includes(PROMPT_SENTINEL)) {
+      log.warn(`  ${target} lacks caveman sentinel — leaving in place`);
+      summary.skipped.push(name);
+      continue;
+    }
+
+    if (dryRun) {
+      log.note(`  would remove ${target}`);
+      summary.removed.push(name);
+      continue;
+    }
+
+    try {
+      fs.unlinkSync(target);
+      log.note(`  removed ${target}`);
+      summary.removed.push(name);
+    } catch (e) {
+      log.warn(`  failed to remove ${target}: ${e.message}`);
+    }
+  }
+
+  return { ok: true, summary, dir };
+}
+
+function installVscode({ root, repoRoot, level, promptsDir, dryRun = false, force = false, log = noopLog() } = {}) {
+  if (level && !VALID_LEVELS.includes(level)) {
+    log.warn(`  invalid level '${level}'. valid: ${VALID_LEVELS.join(', ')} (or 'disabled' to uninstall)`);
+    return { ok: false, reason: 'invalid level' };
+  }
+
   const target = resolveInstructionsFile(root);
-  const ruleBody = loadRuleBody(repoRoot);
+  const ruleBody = applyLevel(loadRuleBody(repoRoot), level);
   const content = buildFileContent(ruleBody);
 
   if (dryRun) {
@@ -124,10 +361,20 @@ function installVscode({ root, repoRoot, dryRun = false, force = false, log = no
   fs.mkdirSync(path.dirname(target), { recursive: true });
   fs.writeFileSync(target, content, { mode: 0o644 });
   log.write(`  installed: ${target}\n`);
+
+  // Best-effort prompt-file install. Failures here don't fail the whole
+  // vscode install — the always-on instructions file is the primary win;
+  // prompt files are a UX bonus for slash-menu autocomplete.
+  try {
+    installPrompts({ promptsDir, repoRoot, dryRun, force, log });
+  } catch (e) {
+    log.warn(`  prompt files: ${e.message}`);
+  }
+
   return { ok: true, path: target };
 }
 
-function uninstallVscode({ root, dryRun = false, log = noopLog() } = {}) {
+function uninstallVscode({ root, promptsDir, dryRun = false, log = noopLog() } = {}) {
   const target = resolveInstructionsFile(root);
   if (!fs.existsSync(target)) return { ok: true, touched: false };
 
@@ -146,18 +393,34 @@ function uninstallVscode({ root, dryRun = false, log = noopLog() } = {}) {
 
   try { fs.unlinkSync(target); } catch (_) {}
   log.note(`  removed ${target}`);
+
+  try {
+    uninstallPrompts({ promptsDir, dryRun, log });
+  } catch (e) {
+    log.warn(`  prompt files: ${e.message}`);
+  }
+
   return { ok: true, touched: true };
 }
 
 module.exports = {
   installVscode,
   uninstallVscode,
+  installPrompts,
+  uninstallPrompts,
   resolveRoot,
   resolveInstructionsFile,
+  resolvePromptsDir,
   // exported for tests
   buildFileContent,
   loadRuleBody,
+  loadPromptBody,
+  applyLevel,
+  VALID_LEVELS,
+  VALID_LEVELS_PLUS_DISABLED,
   INSTR_FILENAME,
   MARK_BEGIN,
   MARK_END,
+  PROMPT_SENTINEL,
+  PROMPT_FILES,
 };

--- a/bin/lib/vscode-copilot.js
+++ b/bin/lib/vscode-copilot.js
@@ -1,0 +1,163 @@
+// caveman → VS Code Copilot (user-scope) install / uninstall helper.
+//
+// VS Code Copilot auto-loads every `*.instructions.md` file from the user's
+// `~/.copilot/instructions/` folder into every chat session, in every
+// workspace, with no per-repo setup. A file without an `applyTo` frontmatter
+// key is treated as always-on, which is exactly the behavior we want for
+// caveman: type once, no `/caveman` per session, no per-repo init.
+//
+// This is intentionally narrower than the existing `copilot` provider in
+// install.js, which writes the per-repo `.github/copilot-instructions.md`
+// via src/tools/caveman-init.js. The two providers serve different use cases:
+//
+//   --only copilot --with-init  →  per-repo, this workspace only
+//   --only vscode               →  user-scope, every workspace, no init
+//
+// One write. One file. Idempotent. Uninstall removes the same file.
+//
+// File path resolution:
+//   Linux/macOS/Windows: <homedir>/.copilot/instructions/caveman.instructions.md
+//
+// Override for tests/non-default setups: pass `{ root }` to the helpers, or
+// set CAVEMAN_VSCODE_USER_ROOT in the environment.
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const INSTR_FILENAME = 'caveman.instructions.md';
+const MARK_BEGIN = '<!-- caveman-begin -->';
+const MARK_END = '<!-- caveman-end -->';
+
+function resolveRoot(env = process.env) {
+  if (env.CAVEMAN_VSCODE_USER_ROOT) return path.resolve(env.CAVEMAN_VSCODE_USER_ROOT);
+  return path.join(os.homedir(), '.copilot');
+}
+
+function resolveInstructionsFile(root) {
+  return path.join(root || resolveRoot(), 'instructions', INSTR_FILENAME);
+}
+
+function readIfExists(p) {
+  try { return fs.readFileSync(p, 'utf8'); } catch (_) { return null; }
+}
+
+// Load the canonical caveman activation rule body. Prefer the in-repo source
+// of truth so the file stays in sync with what other agents see; fall back to
+// an embedded copy when run standalone (curl|node, no repo on disk).
+function loadRuleBody(repoRoot) {
+  if (repoRoot) {
+    const body = readIfExists(path.join(repoRoot, 'src', 'rules', 'caveman-activate.md'));
+    if (body) return body.trimEnd() + '\n';
+  }
+  return [
+    'Respond terse like smart caveman. All technical substance stay. Only fluff die.',
+    '',
+    'Rules:',
+    '- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging',
+    '- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.',
+    '- Pattern: [thing] [action] [reason]. [next step].',
+    '- Not: "Sure! I\'d be happy to help you with that."',
+    '- Yes: "Bug in auth middleware. Fix:"',
+    '',
+    'Switch level: /caveman lite|full|ultra|wenyan',
+    'Stop: "stop caveman" or "normal mode"',
+    '',
+    'Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.',
+    '',
+    'Boundaries: code/commits/PRs written normal.',
+    '',
+  ].join('\n');
+}
+
+// Build the full file body. VS Code Copilot instruction files use YAML
+// frontmatter; omitting `applyTo` makes the rule load for every session in
+// every workspace (always-on). The body is wrapped in marker fences so a
+// future uninstall can locate and remove the block even if the user has
+// edited the file (we still default to deleting the whole file when it's
+// ours — markers are belt-and-suspenders for shared-file scenarios).
+function buildFileContent(ruleBody) {
+  const frontmatter = [
+    '---',
+    "name: 'Caveman mode'",
+    "description: 'Terse caveman-style responses — ~75% fewer output tokens, full technical accuracy. Always-on, user-scope.'",
+    '---',
+    '',
+  ].join('\n');
+  return frontmatter + MARK_BEGIN + '\n' + ruleBody.trimEnd() + '\n' + MARK_END + '\n';
+}
+
+function noopLog() {
+  return { write: () => {}, note: () => {}, warn: () => {} };
+}
+
+function installVscode({ root, repoRoot, dryRun = false, force = false, log = noopLog() } = {}) {
+  const target = resolveInstructionsFile(root);
+  const ruleBody = loadRuleBody(repoRoot);
+  const content = buildFileContent(ruleBody);
+
+  if (dryRun) {
+    log.note(`  would write ${target}`);
+    return { ok: true, dryRun: true, path: target };
+  }
+
+  if (fs.existsSync(target) && !force) {
+    const existing = readIfExists(target);
+    if (existing && existing.includes(MARK_BEGIN) && existing.includes(MARK_END)) {
+      // Refresh content — keeps the file in sync with the latest rule body
+      // when caveman is upgraded. Same-content writes are no-ops at the FS
+      // level on most filesystems; skip the write if bytes are identical.
+      if (existing === content) {
+        log.note(`  ${target} already up to date`);
+        return { ok: true, alreadyInstalled: true, path: target };
+      }
+      fs.writeFileSync(target, content, { mode: 0o644 });
+      log.write(`  refreshed ${target}\n`);
+      return { ok: true, refreshed: true, path: target };
+    }
+    log.warn(`  ${target} exists without caveman markers — refusing to overwrite. Re-run with --force to replace.`);
+    return { ok: false, reason: 'file exists without markers' };
+  }
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content, { mode: 0o644 });
+  log.write(`  installed: ${target}\n`);
+  return { ok: true, path: target };
+}
+
+function uninstallVscode({ root, dryRun = false, log = noopLog() } = {}) {
+  const target = resolveInstructionsFile(root);
+  if (!fs.existsSync(target)) return { ok: true, touched: false };
+
+  const body = readIfExists(target) || '';
+  const isOurs = body.includes(MARK_BEGIN) && body.includes(MARK_END);
+
+  if (!isOurs) {
+    log.warn(`  ${target} exists but lacks caveman markers — leaving in place. Remove manually if it's ours.`);
+    return { ok: true, touched: false, skipped: true };
+  }
+
+  if (dryRun) {
+    log.note(`  would remove ${target}`);
+    return { ok: true, touched: true, dryRun: true };
+  }
+
+  try { fs.unlinkSync(target); } catch (_) {}
+  log.note(`  removed ${target}`);
+  return { ok: true, touched: true };
+}
+
+module.exports = {
+  installVscode,
+  uninstallVscode,
+  resolveRoot,
+  resolveInstructionsFile,
+  // exported for tests
+  buildFileContent,
+  loadRuleBody,
+  INSTR_FILENAME,
+  MARK_BEGIN,
+  MARK_END,
+};

--- a/src/prompts/vscode/caveman-commit.prompt.md
+++ b/src/prompts/vscode/caveman-commit.prompt.md
@@ -1,0 +1,13 @@
+---
+mode: 'agent'
+description: 'Generate terse caveman-style commit message for staged changes'
+---
+<!-- caveman-managed -->
+Generate a commit message for the current staged changes.
+
+Format: Conventional Commits — `type(scope): subject`.
+- Subject: ≤50 chars, imperative, lowercase after type, no trailing period.
+- Body: only when "why" is not obvious from subject. Why over what.
+- One blank line between subject and body when body present.
+
+Output the commit message only. No preamble, no commentary.

--- a/src/prompts/vscode/caveman-compress.prompt.md
+++ b/src/prompts/vscode/caveman-compress.prompt.md
@@ -1,0 +1,16 @@
+---
+mode: 'agent'
+description: 'Compress a markdown/text file into caveman style (preserves code, links, paths)'
+---
+<!-- caveman-managed -->
+Compress the file the user names after the slash command into terse caveman style.
+
+Rewrite prose:
+- Drop articles, filler, hedging. Fragments OK.
+- Preserve exactly: code blocks, inline code, URLs, file paths, commands, headings, list structure, tables.
+- Preserve all technical content. Cuts must be lossless on substance.
+
+Before overwrite, save the original to `<file>.original.md` if no backup exists yet.
+
+Refuse non-prose files: `.py`, `.js`, `.ts`, `.json`, `.yaml`, `.yml`, `.toml`, `.sh`, `.ps1`, etc. Only act on `.md`, `.txt`, `.typ`, `.tex`, or extensionless prose.
+Refuse to compress an existing `*.original.md` backup.

--- a/src/prompts/vscode/caveman-help.prompt.md
+++ b/src/prompts/vscode/caveman-help.prompt.md
@@ -1,0 +1,22 @@
+---
+mode: 'ask'
+description: 'Caveman quick-reference card — slash commands and triggers'
+---
+<!-- caveman-managed -->
+Show the caveman quick-reference card and stop. No other commentary.
+
+| Command | What |
+|---|---|
+| `/caveman` | Activate at default level (full) |
+| `/caveman lite` | Light compression — ~30% tokens dropped |
+| `/caveman ultra` | Maximum compression |
+| `/caveman wenyan` / `wenyan-lite` / `wenyan-ultra` | Classical Chinese compression |
+| `/caveman off` | Deactivate |
+| `/caveman-commit` | Terse commit message |
+| `/caveman-review` | One-line review findings |
+| `/caveman-compress <file>` | Compress a markdown file |
+| `/caveman-stats` | Lifetime token-savings |
+
+Natural language also works: "turn on caveman", "stop caveman", "normal mode".
+
+Caveman drops out automatically for code, commits, and security warnings.

--- a/src/prompts/vscode/caveman-review.prompt.md
+++ b/src/prompts/vscode/caveman-review.prompt.md
@@ -1,0 +1,13 @@
+---
+mode: 'agent'
+description: 'One-line caveman code review of current changes'
+---
+<!-- caveman-managed -->
+Review the current code changes (staged diff, current selection, or named file if user provided one).
+
+Format: one line per finding.
+`L<line>: <severity> <problem>. <fix>.`
+
+Severity: `bug` | `risk` | `nit` | `q`.
+
+Skip praise. Skip obvious. If code looks good, output `LGTM` and stop.

--- a/src/prompts/vscode/caveman-stats.prompt.md
+++ b/src/prompts/vscode/caveman-stats.prompt.md
@@ -1,0 +1,15 @@
+---
+mode: 'agent'
+description: 'Show caveman lifetime token-savings stats'
+---
+<!-- caveman-managed -->
+Read the lifetime caveman history log and report total tokens saved, sessions counted, and average compression ratio.
+
+Log location candidates (try in order, use first that exists):
+1. `${env:CAVEMAN_HISTORY_PATH}` (if set)
+2. `~/.config/caveman/.caveman-history.jsonl`
+3. `~/AppData/Roaming/caveman/.caveman-history.jsonl` (Windows)
+
+If no log exists, report `caveman-stats: no history yet` and stop.
+
+Output one short table: `tokens saved | sessions | avg ratio`.

--- a/src/prompts/vscode/caveman.prompt.md
+++ b/src/prompts/vscode/caveman.prompt.md
@@ -1,0 +1,16 @@
+---
+mode: 'agent'
+description: 'Switch caveman intensity (lite/full/ultra/wenyan/wenyan-lite/wenyan-ultra/off)'
+---
+<!-- caveman-managed -->
+Switch caveman to the level given after the slash (`lite`, `full`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-ultra`). If no level given, use `full`. If `off` / `disabled` / `stop`, drop caveman and resume normal prose.
+
+While active: respond terse like smart caveman. Drop articles (a/an/the), filler (just/really/basically), pleasantries, hedging. Fragments OK. Short synonyms. Technical terms exact. Code blocks unchanged.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Behavior persists across this and following turns until the user switches level, says "stop caveman" / "normal mode", or session ends.
+
+Auto-clarity: drop caveman for security warnings, irreversible actions, or when the user looks confused. Resume after.
+
+Boundaries: code, commits, PRs, security warnings always written normal English.

--- a/src/rules/caveman-activate.md
+++ b/src/rules/caveman-activate.md
@@ -7,8 +7,10 @@ Rules:
 - Not: "Sure! I'd be happy to help you with that."
 - Yes: "Bug in auth middleware. Fix:"
 
-Switch level: /caveman lite|full|ultra|wenyan
-Stop: "stop caveman" or "normal mode"
+Switch level: /caveman lite|full|ultra|wenyan|wenyan-lite|wenyan-ultra
+Stop: /caveman disabled, "stop caveman", or "normal mode"
+
+Default intensity: full.
 
 Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
 

--- a/tests/installer/vscode-copilot.test.mjs
+++ b/tests/installer/vscode-copilot.test.mjs
@@ -1,0 +1,152 @@
+// Unit tests for the VS Code Copilot (user-scope) install helper.
+// Covers: fresh install, idempotent re-install (no-op when bytes match),
+// refresh when rule body changes, refusal to overwrite foreign files,
+// uninstall removes only our file, uninstall skips files without markers.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const HELPER = require(path.join(REPO_ROOT, 'bin', 'lib', 'vscode-copilot.js'));
+
+function makeTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-vscode-'));
+}
+
+function targetPath(root) {
+  return path.join(root, 'instructions', HELPER.INSTR_FILENAME);
+}
+
+test('installVscode writes a fresh file with caveman markers', () => {
+  const root = makeTmp();
+  try {
+    const r = HELPER.installVscode({ root, repoRoot: REPO_ROOT });
+    assert.equal(r.ok, true);
+    const f = targetPath(root);
+    assert.ok(fs.existsSync(f), 'instructions file should exist');
+    const body = fs.readFileSync(f, 'utf8');
+    assert.match(body, /^---\n/, 'frontmatter present');
+    assert.ok(body.includes(HELPER.MARK_BEGIN), 'begin marker present');
+    assert.ok(body.includes(HELPER.MARK_END), 'end marker present');
+    assert.match(body, /Respond terse like smart caveman/);
+    // No applyTo key — must stay always-on.
+    assert.doesNotMatch(body, /^applyTo:/m);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('installVscode is idempotent — second run is a no-op when content matches', () => {
+  const root = makeTmp();
+  try {
+    HELPER.installVscode({ root, repoRoot: REPO_ROOT });
+    const r2 = HELPER.installVscode({ root, repoRoot: REPO_ROOT });
+    assert.equal(r2.ok, true);
+    assert.equal(r2.alreadyInstalled, true, 'should detect no-op refresh');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('installVscode refreshes when existing file has our markers but different body', () => {
+  const root = makeTmp();
+  try {
+    const f = targetPath(root);
+    fs.mkdirSync(path.dirname(f), { recursive: true });
+    fs.writeFileSync(f, `---\nname: 'old'\n---\n${HELPER.MARK_BEGIN}\nstale body\n${HELPER.MARK_END}\n`);
+    const r = HELPER.installVscode({ root, repoRoot: REPO_ROOT });
+    assert.equal(r.ok, true);
+    assert.equal(r.refreshed, true);
+    const body = fs.readFileSync(f, 'utf8');
+    assert.match(body, /Respond terse like smart caveman/);
+    assert.doesNotMatch(body, /stale body/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('installVscode refuses to overwrite a foreign file without --force', () => {
+  const root = makeTmp();
+  try {
+    const f = targetPath(root);
+    fs.mkdirSync(path.dirname(f), { recursive: true });
+    fs.writeFileSync(f, '---\nname: not ours\n---\nsomeone else owns this\n');
+    const r = HELPER.installVscode({ root, repoRoot: REPO_ROOT });
+    assert.equal(r.ok, false);
+    const body = fs.readFileSync(f, 'utf8');
+    assert.match(body, /someone else owns this/, 'foreign content untouched');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('installVscode with --force overwrites foreign file', () => {
+  const root = makeTmp();
+  try {
+    const f = targetPath(root);
+    fs.mkdirSync(path.dirname(f), { recursive: true });
+    fs.writeFileSync(f, '---\nname: not ours\n---\nstomp me\n');
+    const r = HELPER.installVscode({ root, repoRoot: REPO_ROOT, force: true });
+    assert.equal(r.ok, true);
+    const body = fs.readFileSync(f, 'utf8');
+    assert.match(body, /Respond terse like smart caveman/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('uninstallVscode removes our file', () => {
+  const root = makeTmp();
+  try {
+    HELPER.installVscode({ root, repoRoot: REPO_ROOT });
+    const r = HELPER.uninstallVscode({ root });
+    assert.equal(r.ok, true);
+    assert.equal(r.touched, true);
+    assert.equal(fs.existsSync(targetPath(root)), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('uninstallVscode leaves foreign files alone', () => {
+  const root = makeTmp();
+  try {
+    const f = targetPath(root);
+    fs.mkdirSync(path.dirname(f), { recursive: true });
+    fs.writeFileSync(f, 'no markers, not ours\n');
+    const r = HELPER.uninstallVscode({ root });
+    assert.equal(r.ok, true);
+    assert.equal(r.touched, false);
+    assert.ok(fs.existsSync(f), 'foreign file preserved');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('uninstallVscode is a no-op when target does not exist', () => {
+  const root = makeTmp();
+  try {
+    const r = HELPER.uninstallVscode({ root });
+    assert.equal(r.ok, true);
+    assert.equal(r.touched, false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('installer --list includes vscode row', () => {
+  // Smoke test against the actual installer to make sure the PROVIDERS edit
+  // didn't break the matrix render.
+  const { spawnSync } = require('node:child_process');
+  const r = spawnSync('node', [path.join(REPO_ROOT, 'bin', 'install.js'), '--list'], { encoding: 'utf8' });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /vscode\b/);
+  assert.match(r.stdout, /VS Code Copilot \(user-scope\)/);
+});

--- a/tests/installer/vscode-copilot.test.mjs
+++ b/tests/installer/vscode-copilot.test.mjs
@@ -20,6 +20,13 @@ function makeTmp() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-vscode-'));
 }
 
+// Default installer args used across tests — isolates prompt-file writes
+// to a tmp prompts dir so we never touch the real VS Code user prompts
+// folder during test runs.
+function args(root, extra = {}) {
+  return { root, repoRoot: REPO_ROOT, promptsDir: path.join(root, 'prompts'), ...extra };
+}
+
 function targetPath(root) {
   return path.join(root, 'instructions', HELPER.INSTR_FILENAME);
 }
@@ -27,7 +34,7 @@ function targetPath(root) {
 test('installVscode writes a fresh file with caveman markers', () => {
   const root = makeTmp();
   try {
-    const r = HELPER.installVscode({ root, repoRoot: REPO_ROOT });
+    const r = HELPER.installVscode(args(root));
     assert.equal(r.ok, true);
     const f = targetPath(root);
     assert.ok(fs.existsSync(f), 'instructions file should exist');
@@ -36,8 +43,9 @@ test('installVscode writes a fresh file with caveman markers', () => {
     assert.ok(body.includes(HELPER.MARK_BEGIN), 'begin marker present');
     assert.ok(body.includes(HELPER.MARK_END), 'end marker present');
     assert.match(body, /Respond terse like smart caveman/);
-    // No applyTo key — must stay always-on.
-    assert.doesNotMatch(body, /^applyTo:/m);
+    // applyTo: '**' makes the rule apply to every file context — required
+    // for always-on behavior in VS Code Copilot.
+    assert.match(body, /^applyTo: '\*\*'/m);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -46,8 +54,8 @@ test('installVscode writes a fresh file with caveman markers', () => {
 test('installVscode is idempotent — second run is a no-op when content matches', () => {
   const root = makeTmp();
   try {
-    HELPER.installVscode({ root, repoRoot: REPO_ROOT });
-    const r2 = HELPER.installVscode({ root, repoRoot: REPO_ROOT });
+    HELPER.installVscode(args(root));
+    const r2 = HELPER.installVscode(args(root));
     assert.equal(r2.ok, true);
     assert.equal(r2.alreadyInstalled, true, 'should detect no-op refresh');
   } finally {
@@ -61,7 +69,7 @@ test('installVscode refreshes when existing file has our markers but different b
     const f = targetPath(root);
     fs.mkdirSync(path.dirname(f), { recursive: true });
     fs.writeFileSync(f, `---\nname: 'old'\n---\n${HELPER.MARK_BEGIN}\nstale body\n${HELPER.MARK_END}\n`);
-    const r = HELPER.installVscode({ root, repoRoot: REPO_ROOT });
+    const r = HELPER.installVscode(args(root));
     assert.equal(r.ok, true);
     assert.equal(r.refreshed, true);
     const body = fs.readFileSync(f, 'utf8');
@@ -78,7 +86,7 @@ test('installVscode refuses to overwrite a foreign file without --force', () => 
     const f = targetPath(root);
     fs.mkdirSync(path.dirname(f), { recursive: true });
     fs.writeFileSync(f, '---\nname: not ours\n---\nsomeone else owns this\n');
-    const r = HELPER.installVscode({ root, repoRoot: REPO_ROOT });
+    const r = HELPER.installVscode(args(root));
     assert.equal(r.ok, false);
     const body = fs.readFileSync(f, 'utf8');
     assert.match(body, /someone else owns this/, 'foreign content untouched');
@@ -93,7 +101,7 @@ test('installVscode with --force overwrites foreign file', () => {
     const f = targetPath(root);
     fs.mkdirSync(path.dirname(f), { recursive: true });
     fs.writeFileSync(f, '---\nname: not ours\n---\nstomp me\n');
-    const r = HELPER.installVscode({ root, repoRoot: REPO_ROOT, force: true });
+    const r = HELPER.installVscode(args(root, { force: true }));
     assert.equal(r.ok, true);
     const body = fs.readFileSync(f, 'utf8');
     assert.match(body, /Respond terse like smart caveman/);
@@ -105,8 +113,8 @@ test('installVscode with --force overwrites foreign file', () => {
 test('uninstallVscode removes our file', () => {
   const root = makeTmp();
   try {
-    HELPER.installVscode({ root, repoRoot: REPO_ROOT });
-    const r = HELPER.uninstallVscode({ root });
+    HELPER.installVscode(args(root));
+    const r = HELPER.uninstallVscode({ root, promptsDir: path.join(root, 'prompts') });
     assert.equal(r.ok, true);
     assert.equal(r.touched, true);
     assert.equal(fs.existsSync(targetPath(root)), false);
@@ -121,7 +129,7 @@ test('uninstallVscode leaves foreign files alone', () => {
     const f = targetPath(root);
     fs.mkdirSync(path.dirname(f), { recursive: true });
     fs.writeFileSync(f, 'no markers, not ours\n');
-    const r = HELPER.uninstallVscode({ root });
+    const r = HELPER.uninstallVscode({ root, promptsDir: path.join(root, 'prompts') });
     assert.equal(r.ok, true);
     assert.equal(r.touched, false);
     assert.ok(fs.existsSync(f), 'foreign file preserved');
@@ -133,7 +141,7 @@ test('uninstallVscode leaves foreign files alone', () => {
 test('uninstallVscode is a no-op when target does not exist', () => {
   const root = makeTmp();
   try {
-    const r = HELPER.uninstallVscode({ root });
+    const r = HELPER.uninstallVscode({ root, promptsDir: path.join(root, 'prompts') });
     assert.equal(r.ok, true);
     assert.equal(r.touched, false);
   } finally {
@@ -149,4 +157,115 @@ test('installer --list includes vscode row', () => {
   assert.equal(r.status, 0);
   assert.match(r.stdout, /vscode\b/);
   assert.match(r.stdout, /VS Code Copilot \(user-scope\)/);
+});
+
+test('applyLevel rewrites Default intensity line', () => {
+  const body = 'foo\nDefault intensity: full.\nbar\n';
+  assert.equal(HELPER.applyLevel(body, 'lite'), 'foo\nDefault intensity: lite.\nbar\n');
+  assert.equal(HELPER.applyLevel(body, 'ultra'), 'foo\nDefault intensity: ultra.\nbar\n');
+  assert.equal(HELPER.applyLevel(body, 'wenyan-ultra'), 'foo\nDefault intensity: wenyan-ultra.\nbar\n');
+});
+
+test('applyLevel is a no-op for full or undefined', () => {
+  const body = 'foo\nDefault intensity: full.\nbar\n';
+  assert.equal(HELPER.applyLevel(body, 'full'), body);
+  assert.equal(HELPER.applyLevel(body, undefined), body);
+});
+
+test('installVscode with --level lite writes lite as default', () => {
+  const root = makeTmp();
+  try {
+    const r = HELPER.installVscode(args(root, { level: 'lite' }));
+    assert.equal(r.ok, true);
+    const body = fs.readFileSync(targetPath(root), 'utf8');
+    assert.match(body, /Default intensity: lite\./);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('installVscode rejects unknown level', () => {
+  const root = makeTmp();
+  try {
+    const r = HELPER.installVscode(args(root, { level: 'bogus' }));
+    assert.equal(r.ok, false);
+    assert.equal(fs.existsSync(targetPath(root)), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('installVscode also drops slash-command prompt files', () => {
+  const root = makeTmp();
+  try {
+    HELPER.installVscode(args(root));
+    const promptsDir = path.join(root, 'prompts');
+    for (const name of HELPER.PROMPT_FILES) {
+      const p = path.join(promptsDir, name);
+      assert.ok(fs.existsSync(p), `${name} should be installed`);
+      const body = fs.readFileSync(p, 'utf8');
+      assert.ok(body.includes(HELPER.PROMPT_SENTINEL), `${name} carries sentinel`);
+      assert.match(body, /^---\r?\n/, `${name} has frontmatter`);
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('uninstallVscode removes prompt files we installed', () => {
+  const root = makeTmp();
+  try {
+    HELPER.installVscode(args(root));
+    HELPER.uninstallVscode({ root, promptsDir: path.join(root, 'prompts') });
+    for (const name of HELPER.PROMPT_FILES) {
+      assert.equal(fs.existsSync(path.join(root, 'prompts', name)), false, `${name} should be removed`);
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('uninstallPrompts leaves user-authored prompt files alone', () => {
+  const root = makeTmp();
+  try {
+    const promptsDir = path.join(root, 'prompts');
+    fs.mkdirSync(promptsDir, { recursive: true });
+    // A user-authored file at our managed name, but without our sentinel.
+    const userPath = path.join(promptsDir, 'caveman.prompt.md');
+    fs.writeFileSync(userPath, '---\ndescription: my custom caveman\n---\nmine, hands off\n');
+    HELPER.uninstallPrompts({ promptsDir });
+    assert.ok(fs.existsSync(userPath), 'user file untouched');
+    assert.match(fs.readFileSync(userPath, 'utf8'), /mine, hands off/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('installPrompts is idempotent — second run skips unchanged files', () => {
+  const root = makeTmp();
+  try {
+    const promptsDir = path.join(root, 'prompts');
+    HELPER.installPrompts({ promptsDir, repoRoot: REPO_ROOT });
+    const r2 = HELPER.installPrompts({ promptsDir, repoRoot: REPO_ROOT });
+    assert.equal(r2.ok, true);
+    assert.equal(r2.summary.skipped.length, HELPER.PROMPT_FILES.length);
+    assert.equal(r2.summary.installed.length, 0);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolvePromptsDir matches platform conventions', () => {
+  // Windows: %APPDATA%\Code\User\prompts
+  const win = HELPER.resolvePromptsDir({ APPDATA: 'C:\\Roaming' }, 'win32');
+  assert.match(win, /Code[\\\/]User[\\\/]prompts$/);
+  // macOS: Library/Application Support
+  const mac = HELPER.resolvePromptsDir({}, 'darwin');
+  assert.match(mac, /Library[\\\/]Application Support[\\\/]Code[\\\/]User[\\\/]prompts$/);
+  // Linux: $XDG_CONFIG_HOME/Code/User/prompts
+  const lin = HELPER.resolvePromptsDir({ XDG_CONFIG_HOME: '/tmp/xdg' }, 'linux');
+  assert.equal(lin, path.join('/tmp/xdg', 'Code', 'User', 'prompts'));
+  // Override env var wins on every platform.
+  const overridden = HELPER.resolvePromptsDir({ CAVEMAN_VSCODE_PROMPTS_DIR: '/custom/dir' }, 'linux');
+  assert.equal(overridden, path.resolve('/custom/dir'));
 });


### PR DESCRIPTION
This pull request adds full support for always-on, user-scope installation of the Caveman rule for VS Code Copilot, alongside per-repo Copilot integration. It introduces new prompt templates for VS Code Copilot slash commands, updates documentation to explain the new install/uninstall workflows, and clarifies the difference between per-repo and user-scope Copilot modes. The changes also expand the available caveman intensity levels and improve uninstall safety.

**VS Code Copilot user-scope integration:**

- Added a new helper script `bin/lib/vscode-copilot.js` for installing/uninstalling Caveman as a user-scope always-on rule for VS Code Copilot, writing a single marker-fenced file at `~/.copilot/instructions/caveman.instructions.md` (overridable with `CAVEMAN_VSCODE_USER_ROOT`). The script is idempotent, refreshes on change, and refuses to overwrite non-caveman files without `--force`.
- Updated documentation (`INSTALL.md`, `CLAUDE.md`, `README.md`) to describe the new VS Code Copilot user-scope install/uninstall commands, file locations, override options, and uninstall safety. Clarified the distinction between per-repo and user-scope Copilot modes and how to switch intensity levels persistently or per-chat. [[1]](diffhunk://#diff-09b140a43ebfdd8dbec31ce72cafffd15164d2860fd390692a030bcb932b54a0R51) [[2]](diffhunk://#diff-09b140a43ebfdd8dbec31ce72cafffd15164d2860fd390692a030bcb932b54a0R149-R223) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L251-R253) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L132-R132) [[5]](diffhunk://#diff-09b140a43ebfdd8dbec31ce72cafffd15164d2860fd390692a030bcb932b54a0R264)

**Prompt templates for VS Code Copilot:**

- Added new prompt files for VS Code Copilot slash commands: `caveman.prompt.md` (intensity switch), `caveman-help.prompt.md` (quick reference), `caveman-commit.prompt.md` (terse commit message), `caveman-review.prompt.md` (one-line code review), `caveman-compress.prompt.md` (markdown/text compression), and `caveman-stats.prompt.md` (token savings stats). [[1]](diffhunk://#diff-42bf7ff9884ecb47f3b1a97ba7960aad8e21d1d48406a8d2d4f7e901ee612c85R1-R16) [[2]](diffhunk://#diff-073731d158c25625f9dd249fb75d725f2d624c69040594c2ac4ad92ef06ebf94R1-R22) [[3]](diffhunk://#diff-c2e3f548f46b903f2f6928c3f3da9bcf0e7072fe02e9f4909fe1d71138c47a34R1-R13) [[4]](diffhunk://#diff-8efea40000ae318458c9500dc95c5a3c26fb5fc684bfdcbfa4acf6fcd89b2858R1-R13) [[5]](diffhunk://#diff-299fe3dcab8970bc8ae183752429aee9513e8422fe6151752efdf7dbf98c5cadR1-R16) [[6]](diffhunk://#diff-7bf04d75fe6c351e6b1083b4f03a3db90db1871e9acfd3455ae168e9fb97da48R1-R15)

**Rule and uninstall improvements:**

- Updated the uninstall process to remove only the VS Code Copilot user-scope file if it carries caveman markers, leaving unrelated files untouched.
- Expanded the documented and implemented caveman intensity levels to include `wenyan-lite` and `wenyan-ultra`, and clarified default and stop commands in the activation rule.

These changes make it easier to enable Caveman mode globally for all VS Code Copilot workspaces, provide a suite of Copilot-native slash commands, and ensure safe, reversible installation and removal.