### PR TITLE
fix(install): remap cavecrew agent tool names to Gemini ids on install

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -25,7 +25,7 @@ const crypto = require('crypto');
 const SETTINGS = require('./lib/settings');
 const OPENCLAW = require('./lib/openclaw');
 const { stripOpencodeAgentTools } = require('./lib/opencode-agent');
-const { mapGeminiAgentFrontmatter } = require('./lib/gemini-agent');
+const { mapGeminiAgentFrontmatter, geminiExtAgentsDir } = require('./lib/gemini-agent');
 
 const REPO = 'JuliusBrussee/caveman';
 // Pin remote fetches to an immutable release tag, not the moving `main`
@@ -529,6 +529,11 @@ function installGemini(ctx) {
     const r = captureSpawn('gemini', ['extensions', 'list']);
     if (r.status === 0 && /caveman/i.test(r.stdout || '')) {
       note('  caveman extension already installed (use --force to reinstall)');
+      // Still rewrite the installed agents to Gemini tool ids: upgraders who
+      // installed before the #473 fix have the broken Claude tool names on
+      // disk and would never get the fix without --force. The rewrite is
+      // idempotent (only writes when the frontmatter actually changes).
+      patchGeminiAgents(ctx);
       results.skipped.push(['gemini', 'extension already installed']);
       process.stdout.write('\n');
       return;
@@ -556,7 +561,9 @@ function patchGeminiAgents(ctx) {
     note(`  would rewrite ${GEMINI_AGENT_FILES.length} cavecrew agents to Gemini tool names`);
     return;
   }
-  const agentsDir = path.join(os.homedir(), '.gemini', 'extensions', 'caveman', 'agents');
+  // Honors GEMINI_CLI_HOME (see lib/gemini-agent.js) so the rewrite finds the
+  // install dir under that override instead of silently skipping the fix.
+  const agentsDir = geminiExtAgentsDir();
   if (!fs.existsSync(agentsDir)) {
     note('  cavecrew agents: install dir not found — skipping Gemini tool-name fix');
     return;

--- a/bin/install.js
+++ b/bin/install.js
@@ -25,6 +25,7 @@ const crypto = require('crypto');
 const SETTINGS = require('./lib/settings');
 const OPENCLAW = require('./lib/openclaw');
 const { stripOpencodeAgentTools } = require('./lib/opencode-agent');
+const { mapGeminiAgentFrontmatter } = require('./lib/gemini-agent');
 
 const REPO = 'JuliusBrussee/caveman';
 // Pin remote fetches to an immutable release tag, not the moving `main`
@@ -534,9 +535,45 @@ function installGemini(ctx) {
     }
   }
   const r = runSpawn('gemini', ['extensions', 'install', `https://github.com/${REPO}`], null, opts.dryRun);
-  if ((r.status || 0) === 0) results.installed.push('gemini');
-  else results.failed.push(['gemini', 'gemini extensions install failed']);
+  if ((r.status || 0) === 0) {
+    results.installed.push('gemini');
+    patchGeminiAgents(ctx);
+  } else results.failed.push(['gemini', 'gemini extensions install failed']);
   process.stdout.write('\n');
+}
+
+// Gemini loads the cavecrew subagents from the hardcoded `<ext>/agents/` path
+// with Claude Code tool names, which it rejects ("Invalid tool name") so the
+// agents fail to load. The source files must stay Claude-canonical (shared with
+// the Claude plugin), so we rewrite the *installed copy* to Gemini's tool ids —
+// mirroring the opencode install path. See lib/gemini-agent.js, issues
+// #373/#473/#492.
+const GEMINI_AGENT_FILES = ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md'];
+
+function patchGeminiAgents(ctx) {
+  const { note, opts } = ctx;
+  if (opts.dryRun) {
+    note(`  would rewrite ${GEMINI_AGENT_FILES.length} cavecrew agents to Gemini tool names`);
+    return;
+  }
+  const agentsDir = path.join(os.homedir(), '.gemini', 'extensions', 'caveman', 'agents');
+  if (!fs.existsSync(agentsDir)) {
+    note('  cavecrew agents: install dir not found — skipping Gemini tool-name fix');
+    return;
+  }
+  let patched = 0;
+  for (const f of GEMINI_AGENT_FILES) {
+    const p = path.join(agentsDir, f);
+    if (!fs.existsSync(p)) continue;
+    try {
+      const before = fs.readFileSync(p, 'utf8');
+      const after = mapGeminiAgentFrontmatter(before);
+      if (after !== before) { fs.writeFileSync(p, after); patched++; }
+    } catch (e) {
+      note(`  cavecrew agent ${f}: could not rewrite (${e.message})`);
+    }
+  }
+  if (patched) note(`  rewrote ${patched} cavecrew agent(s) to Gemini tool names (#473)`);
 }
 
 function installViaSkills(ctx, prov) {

--- a/bin/lib/gemini-agent.js
+++ b/bin/lib/gemini-agent.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const os = require('os');
+const path = require('path');
+
 // Rewrite a Claude-Code-style subagent frontmatter into Gemini CLI's schema.
 //
 // The Gemini extension loader reads agents from a hardcoded
@@ -84,4 +87,21 @@ function mapGeminiAgentFrontmatter(content) {
   return FRONTMATTER_FENCE + out.join('\n') + rest;
 }
 
-module.exports = { mapGeminiAgentFrontmatter, mapToolName, TOOL_MAP, MODEL_MAP };
+// Resolve the installed cavecrew agents directory. Gemini resolves its
+// extension storage from GEMINI_CLI_HOME when set (its homedir() returns that
+// env value, then ExtensionStorage.getUserExtensionsDir() builds on it), and
+// falls back to the real home otherwise. Hard-coding os.homedir() would miss
+// the install dir under that override and silently skip the tool-name fix.
+// Mirrors SETTINGS.claudeConfigDir's CLAUDE_CONFIG_DIR handling.
+function geminiExtAgentsDir() {
+  const home = process.env.GEMINI_CLI_HOME || os.homedir();
+  return path.join(home, '.gemini', 'extensions', 'caveman', 'agents');
+}
+
+module.exports = {
+  mapGeminiAgentFrontmatter,
+  mapToolName,
+  geminiExtAgentsDir,
+  TOOL_MAP,
+  MODEL_MAP,
+};

--- a/bin/lib/gemini-agent.js
+++ b/bin/lib/gemini-agent.js
@@ -1,0 +1,87 @@
+'use strict';
+
+// Rewrite a Claude-Code-style subagent frontmatter into Gemini CLI's schema.
+//
+// The Gemini extension loader reads agents from a hardcoded
+// `<extension>/agents/` path and validates every entry in an agent's `tools:`
+// array with `isValidToolName(name, { allowWildcards: true })`. That validator
+// only accepts Gemini's own builtin tool ids (`read_file`, `replace`, …), the
+// `*` wildcard, and MCP/discovered prefixes. Claude Code's tool names
+// (`Read`, `Edit`, `Write`, `Grep`, `Glob`, `Bash`) all fail, so the whole
+// cavecrew agent definition is rejected with:
+//
+//   [ExtensionManager] Error loading agent from caveman: ...cavecrew-builder.md:
+//     Validation failed: Agent Definition: tools.0: Invalid tool name ...
+//
+// `model: haiku` is an Anthropic id — it passes Gemini's permissive `model`
+// schema but fails at runtime when the subagent is invoked, so we remap the
+// known Claude tiers to their Gemini equivalents too.
+//
+// `agents/cavecrew-*.md` is a single source of truth shared with the Claude
+// Code plugin (which needs the Claude names), so the source files must stay
+// Claude-canonical. This transform is applied at install time on the *copy*
+// Gemini loaded — mirroring lib/opencode-agent.js's `stripOpencodeAgentTools`.
+//
+// See issues #373, #473, #492.
+
+// Claude Code tool name -> Gemini CLI builtin tool id.
+// Verified against the @google/gemini-cli bundle (ALL_BUILTIN_TOOL_NAMES):
+//   READ_FILE_TOOL_NAME="read_file", EDIT_TOOL_NAME="replace",
+//   WRITE_FILE_TOOL_NAME="write_file", GREP_TOOL_NAME="grep_search",
+//   GLOB_TOOL_NAME="glob", SHELL_TOOL_NAME="run_shell_command".
+const TOOL_MAP = {
+  Read: 'read_file',
+  Edit: 'replace',
+  Write: 'write_file',
+  Grep: 'grep_search',
+  Glob: 'glob',
+  Bash: 'run_shell_command',
+};
+
+// Anthropic model tier -> a sensible Gemini default. Only well-known Claude
+// tiers are remapped; any other value is left untouched.
+const MODEL_MAP = {
+  haiku: 'gemini-2.5-flash',
+  sonnet: 'gemini-2.5-pro',
+  opus: 'gemini-2.5-pro',
+};
+
+const FRONTMATTER_FENCE = '---\n';
+const TOOLS_INLINE_RE = /^(tools[ \t]*:[ \t]*)\[([^\]]*)\][ \t]*$/;
+const MODEL_RE = /^(model[ \t]*:[ \t]*)(.+?)[ \t]*$/;
+
+// Map a single tool name; unknown names pass through so a future tool the
+// agent files add isn't silently dropped (Gemini will still validate it).
+function mapToolName(name) {
+  return TOOL_MAP[name] || name;
+}
+
+function mapGeminiAgentFrontmatter(content) {
+  if (typeof content !== 'string' || !content.startsWith(FRONTMATTER_FENCE)) return content;
+  const fmEnd = content.indexOf('\n---', FRONTMATTER_FENCE.length);
+  if (fmEnd < 0) return content;
+
+  const fm = content.slice(FRONTMATTER_FENCE.length, fmEnd);
+  const rest = content.slice(fmEnd);
+
+  const out = fm.split('\n').map((line) => {
+    const tm = line.match(TOOLS_INLINE_RE);
+    if (tm) {
+      const mapped = tm[2]
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .map(mapToolName);
+      return `${tm[1]}[${mapped.join(', ')}]`;
+    }
+    const mm = line.match(MODEL_RE);
+    if (mm && MODEL_MAP[mm[2].trim()]) {
+      return `${mm[1]}${MODEL_MAP[mm[2].trim()]}`;
+    }
+    return line;
+  });
+
+  return FRONTMATTER_FENCE + out.join('\n') + rest;
+}
+
+module.exports = { mapGeminiAgentFrontmatter, mapToolName, TOOL_MAP, MODEL_MAP };

--- a/tests/installer/gemini-agent.test.mjs
+++ b/tests/installer/gemini-agent.test.mjs
@@ -23,9 +23,10 @@ import { createRequire } from 'node:module';
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '..', '..');
 const requireCjs = createRequire(import.meta.url);
-const { mapGeminiAgentFrontmatter, TOOL_MAP } = requireCjs(
+const { mapGeminiAgentFrontmatter, TOOL_MAP, geminiExtAgentsDir } = requireCjs(
   path.join(REPO_ROOT, 'bin', 'lib', 'gemini-agent.js'),
 );
+const osmod = requireCjs('os');
 
 const SHIPPED_AGENT_FILES = ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md'];
 
@@ -162,6 +163,34 @@ test('all shipped cavecrew agent files become Gemini-valid after transform (GREE
     const bodyOut = out.replace(/^---\n[\s\S]*?\n---\n/, '');
     const bodyIn = src.replace(/^---\n[\s\S]*?\n---\n/, '');
     assert.equal(bodyOut, bodyIn, `${f}: body must be byte-identical`);
+  }
+});
+
+// ── GEMINI_CLI_HOME override (issue #530 codex review) ────────────────────
+test('geminiExtAgentsDir honors GEMINI_CLI_HOME env', () => {
+  const orig = process.env.GEMINI_CLI_HOME;
+  process.env.GEMINI_CLI_HOME = '/tmp/__cm_gemini_home';
+  try {
+    assert.equal(
+      geminiExtAgentsDir(),
+      path.join('/tmp/__cm_gemini_home', '.gemini', 'extensions', 'caveman', 'agents'),
+    );
+  } finally {
+    if (orig === undefined) delete process.env.GEMINI_CLI_HOME;
+    else process.env.GEMINI_CLI_HOME = orig;
+  }
+});
+
+test('geminiExtAgentsDir falls back to os.homedir() when GEMINI_CLI_HOME unset', () => {
+  const orig = process.env.GEMINI_CLI_HOME;
+  delete process.env.GEMINI_CLI_HOME;
+  try {
+    assert.equal(
+      geminiExtAgentsDir(),
+      path.join(osmod.homedir(), '.gemini', 'extensions', 'caveman', 'agents'),
+    );
+  } finally {
+    if (orig !== undefined) process.env.GEMINI_CLI_HOME = orig;
   }
 });
 

--- a/tests/installer/gemini-agent.test.mjs
+++ b/tests/installer/gemini-agent.test.mjs
@@ -1,0 +1,185 @@
+// Subagent frontmatter remapper for the Gemini CLI extension (issues #373/#473/#492).
+//
+// Gemini's ExtensionManager loads agents from a hardcoded `<ext>/agents/` path
+// and validates each `tools:` entry against its own builtin tool ids. The
+// shipped agents/cavecrew-*.md use Claude Code names (`Read`, `Edit`, `Bash`…),
+// so Gemini rejects all three with:
+//   [ExtensionManager] Error loading agent ...cavecrew-builder.md:
+//     Validation failed: Agent Definition: tools.0: Invalid tool name ...
+//
+// Fix: rewrite the installed copy's tool names (and `model: haiku`) to Gemini
+// equivalents. The source files stay Claude-canonical (shared with the Claude
+// plugin). These tests prove the helper maps tool names + model, preserves
+// every other frontmatter key, keeps the body byte-identical, and that the
+// real shipped files transform to a Gemini-valid form.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const requireCjs = createRequire(import.meta.url);
+const { mapGeminiAgentFrontmatter, TOOL_MAP } = requireCjs(
+  path.join(REPO_ROOT, 'bin', 'lib', 'gemini-agent.js'),
+);
+
+const SHIPPED_AGENT_FILES = ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md'];
+
+// Gemini's ALL_BUILTIN_TOOL_NAMES (subset relevant to cavecrew), verified
+// against the @google/gemini-cli bundle.
+const GEMINI_BUILTIN = new Set([
+  'read_file', 'write_file', 'replace', 'grep_search', 'glob',
+  'run_shell_command', 'read_many_files', 'web_fetch', 'google_web_search',
+  'list_directory',
+]);
+
+function frontmatter(content) {
+  const m = content.match(/^---\n([\s\S]*?)\n---\n/);
+  assert.ok(m, 'frontmatter present');
+  return m[1];
+}
+
+function toolsArray(fm) {
+  const m = fm.match(/^tools:\s*\[([^\]]*)\]/m);
+  assert.ok(m, 'tools array present');
+  return m[1].split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+// ── Inline array form (the exact bug reported) ───────────────────────────
+test('maps inline `tools: [...]` Claude names to Gemini ids', () => {
+  const src = `---
+name: test-agent
+description: short description
+tools: [Read, Edit, Write, Grep, Glob]
+model: haiku
+---
+body line one
+body line two
+`;
+  const out = mapGeminiAgentFrontmatter(src);
+  const fm = frontmatter(out);
+  assert.deepEqual(toolsArray(fm), ['read_file', 'replace', 'write_file', 'grep_search', 'glob']);
+  assert.match(fm, /^name: test-agent$/m, '`name` preserved');
+  assert.match(fm, /^description: short description$/m, '`description` preserved');
+  assert.match(fm, /^model: gemini-2.5-flash$/m, '`model: haiku` remapped to a Gemini model');
+  assert.match(out, /^body line one$/m, 'body preserved');
+  assert.match(out, /^body line two$/m, 'body preserved');
+});
+
+// ── Bash maps to run_shell_command ───────────────────────────────────────
+test('maps Bash to run_shell_command', () => {
+  const src = `---
+name: x
+tools: [Read, Grep, Bash]
+---
+body
+`;
+  assert.deepEqual(toolsArray(frontmatter(mapGeminiAgentFrontmatter(src))),
+    ['read_file', 'grep_search', 'run_shell_command']);
+});
+
+// ── Folded `description: >` block must NOT be touched ─────────────────────
+test('preserves folded `description: >` continuation lines', () => {
+  const src = `---
+name: cavecrew-reviewer
+description: >
+  Diff/branch/file reviewer. One line per finding, severity-tagged, no praise,
+  no scope creep.
+tools: [Read, Grep, Bash]
+model: haiku
+---
+body
+`;
+  const fm = frontmatter(mapGeminiAgentFrontmatter(src));
+  assert.match(fm, /^description: >$/m, 'folded scalar header preserved');
+  assert.match(fm, /Diff\/branch\/file reviewer/, 'folded scalar body preserved');
+  assert.match(fm, /no scope creep/, 'second folded line preserved');
+});
+
+// ── Unknown tool names pass through (not silently dropped) ────────────────
+test('passes unknown tool names through unchanged', () => {
+  const src = `---
+name: x
+tools: [Read, SomeFutureTool]
+---
+body
+`;
+  assert.deepEqual(toolsArray(frontmatter(mapGeminiAgentFrontmatter(src))),
+    ['read_file', 'SomeFutureTool']);
+});
+
+// ── No frontmatter / no tools: pass content through untouched ─────────────
+test('returns input unchanged when no frontmatter fence', () => {
+  const src = 'just body, no frontmatter\ntools: [Read]\n';
+  assert.equal(mapGeminiAgentFrontmatter(src), src);
+});
+
+test('leaves frontmatter without a `tools:` field structurally intact', () => {
+  const src = `---
+name: x
+model: sonnet
+---
+body
+`;
+  const out = mapGeminiAgentFrontmatter(src);
+  assert.match(frontmatter(out), /^model: gemini-2.5-pro$/m, 'known model still remapped');
+});
+
+// ── Non-string input: pass through (defensive) ───────────────────────────
+test('non-string input returns unchanged', () => {
+  assert.equal(mapGeminiAgentFrontmatter(null), null);
+  assert.equal(mapGeminiAgentFrontmatter(undefined), undefined);
+  assert.deepEqual(mapGeminiAgentFrontmatter({ x: 1 }), { x: 1 });
+});
+
+// ── RED proof: shipped files contain Claude tool names today ─────────────
+test('all shipped cavecrew agent files contain Claude tool names (RED proof)', () => {
+  for (const f of SHIPPED_AGENT_FILES) {
+    const fm = frontmatter(fs.readFileSync(path.join(REPO_ROOT, 'agents', f), 'utf8'));
+    const tools = toolsArray(fm);
+    const claudeNames = tools.filter((t) => Object.prototype.hasOwnProperty.call(TOOL_MAP, t));
+    assert.ok(claudeNames.length > 0, `source ${f} should contain Claude tool names (this is the bug)`);
+  }
+});
+
+// ── GREEN proof: every shipped file becomes Gemini-valid after transform ──
+test('all shipped cavecrew agent files become Gemini-valid after transform (GREEN proof)', () => {
+  for (const f of SHIPPED_AGENT_FILES) {
+    const src = fs.readFileSync(path.join(REPO_ROOT, 'agents', f), 'utf8');
+    const out = mapGeminiAgentFrontmatter(src);
+    const fm = frontmatter(out);
+
+    for (const t of toolsArray(fm)) {
+      assert.ok(GEMINI_BUILTIN.has(t), `${f}: tool "${t}" is not a Gemini builtin id`);
+    }
+    assert.doesNotMatch(fm, /^model:\s*haiku$/m, `${f}: model: haiku must be remapped`);
+    assert.match(fm, /^name: cavecrew-/m, `${f}: name field preserved`);
+
+    const bodyOut = out.replace(/^---\n[\s\S]*?\n---\n/, '');
+    const bodyIn = src.replace(/^---\n[\s\S]*?\n---\n/, '');
+    assert.equal(bodyOut, bodyIn, `${f}: body must be byte-identical`);
+  }
+});
+
+// ── End-to-end: installer-equivalent copy writes a Gemini-valid file ──────
+test('installer-equivalent copy writes Gemini-valid agent files (end-to-end)', () => {
+  const tmpDir = fs.mkdtempSync(path.join(REPO_ROOT, 'tests', '.tmp-gemini-agent-'));
+  try {
+    for (const f of SHIPPED_AGENT_FILES) {
+      const src = path.join(REPO_ROOT, 'agents', f);
+      const dest = path.join(tmpDir, f);
+      fs.writeFileSync(dest, mapGeminiAgentFrontmatter(fs.readFileSync(src, 'utf8')));
+
+      const fm = frontmatter(fs.readFileSync(dest, 'utf8'));
+      for (const t of toolsArray(fm)) {
+        assert.ok(GEMINI_BUILTIN.has(t), `${f}: invalid tool "${t}" survived in installed file`);
+      }
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

Installing caveman as a **Gemini CLI extension** fails to load all three `cavecrew` subagents:

```
[ExtensionManager] Error loading agent from caveman: Failed to load agent from
  ~/.gemini/extensions/caveman/agents/cavecrew-builder.md:
  Validation failed: Agent Definition: tools.0: Invalid tool name ...
```

Gemini's `ExtensionManager` loads agents from the hardcoded `<ext>/agents/` path and validates every entry in an agent's `tools:` array with `isValidToolName(name, { allowWildcards: true })`, which only accepts Gemini's own builtin tool ids. The shipped `agents/cavecrew-*.md` use **Claude Code** tool names, so all entries are rejected and the agents never load. `model: haiku` is also Anthropic-only and fails at runtime.

Reproduces on every platform (verified against `@google/gemini-cli@0.44.1`). Tracked in #373, #473, #492.

## Why it's awkward

`agents/cavecrew-*.md` is a single source of truth **shared with the Claude Code plugin** (`.claude-plugin/plugin.json` → `source: "./"`), which needs the Claude names. The two tool namespaces are disjoint, so the source files can't satisfy both — they must stay Claude-canonical.

## Fix

Rewrite the **installed copy** at Gemini-install time, exactly mirroring the opencode path's `stripOpencodeAgentTools`:

- New `bin/lib/gemini-agent.js` → `mapGeminiAgentFrontmatter()` maps tool names and `model: haiku`.
- `installGemini()` post-processes `~/.gemini/extensions/caveman/agents/*.md` after a successful `gemini extensions install`.
- **Source `agents/*.md` are untouched** — Claude plugin behavior is unchanged.

Tool-name map (verified against the gemini-cli `ALL_BUILTIN_TOOL_NAMES`):

| Claude | Gemini |
|---|---|
| `Read` | `read_file` |
| `Edit` | `replace` |
| `Write` | `write_file` |
| `Grep` | `grep_search` |
| `Glob` | `glob` |
| `Bash` | `run_shell_command` |

`model: haiku` → `gemini-2.5-flash` (sonnet/opus → `gemini-2.5-pro`). Unknown tool names pass through unchanged.

## Tests

`tests/installer/gemini-agent.test.mjs` — 10 new tests (inline-array mapping, `Bash`→`run_shell_command`, folded `description: >` preservation, unknown-name passthrough, non-string defensive, RED proof the shipped files carry Claude names today, GREEN proof they transform to Gemini-valid ids with byte-identical body, installer-equivalent end-to-end).

```
node --test tests/installer/*.test.mjs   ->  83 pass / 0 fail
```

## Known limitation

The patch runs through `bin/install.js`. A direct `gemini extensions install <url>` (without the caveman installer) won't be patched, and a Gemini auto-update re-clones the source tree and reverts it — same constraint as the opencode mirror. A fuller fix (CI-generated Gemini agent mirror) is noted in #473 option 1; this keeps the change small and focused per CONTRIBUTING.
