### PR TITLE
fix(mode-tracker): honor off default in per-turn reinforcement

### DIFF
--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -119,16 +119,28 @@ process.stdin.on('end', () => {
     // If the flag is missing, corrupted, oversized, or a symlink pointing at
     // something like ~/.ssh/id_rsa, readFlag returns null and we emit nothing
     // — never inject untrusted bytes into model context.
-    const activeMode = readFlag(flagPath);
-    if (activeMode && !INDEPENDENT_MODES.has(activeMode)) {
-      process.stdout.write(JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "UserPromptSubmit",
-          additionalContext: "CAVEMAN MODE ACTIVE (" + activeMode + "). " +
-            "Drop articles/filler/pleasantries/hedging. Fragments OK. " +
-            "Code/commits/security: write normal."
-        }
-      }));
+    // Honor an explicit "off" default (env CAVEMAN_DEFAULT_MODE=off or config
+    // defaultMode=off) in the per-turn reinforcement, not just at SessionStart.
+    // The flag file is global (~/.caveman-active), so a session in another repo
+    // can leave it set to a non-off mode; without this check that stale global
+    // flag bleeds into repos/sessions that explicitly opted out, re-injecting
+    // "CAVEMAN MODE ACTIVE" every turn. getDefaultMode() reads the per-context
+    // env/config first, so an off default both suppresses the reminder and
+    // clears the stale flag.
+    if (getDefaultMode() === 'off') {
+      try { fs.unlinkSync(flagPath); } catch (e) {}
+    } else {
+      const activeMode = readFlag(flagPath);
+      if (activeMode && !INDEPENDENT_MODES.has(activeMode)) {
+        process.stdout.write(JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "UserPromptSubmit",
+            additionalContext: "CAVEMAN MODE ACTIVE (" + activeMode + "). " +
+              "Drop articles/filler/pleasantries/hedging. Fragments OK. " +
+              "Code/commits/security: write normal."
+          }
+        }));
+      }
     }
   } catch (e) {
     // Silent fail


### PR DESCRIPTION
## Problem

`CAVEMAN_DEFAULT_MODE=off` (env) / `defaultMode: "off"` (config) makes the **SessionStart** hook skip activation and delete the flag. But the **UserPromptSubmit** per-turn reinforcement in `src/hooks/caveman-mode-tracker.js` read only the global flag file (`~/.caveman-active`) and never consulted the resolved default mode.

Because that flag is **global** (shared across all sessions/repos), a session in any other repo where caveman is on sets it to a non-off mode — and it then bleeds into repos/sessions that explicitly opted out, re-injecting `CAVEMAN MODE ACTIVE (...)` on every turn. A per-repo / per-context off cannot be expressed when the per-turn check is flag-only.

## Fix

Bring the per-turn path in line with SessionStart: if `getDefaultMode() === 'off'`, clear the stale global flag and emit nothing. `getDefaultMode()` already reads env → config → default, so this respects per-context opt-out. No behavior change when caveman is genuinely active.

## Test

- env off + flag=full → no emit, stale flag cleared ✅
- env unset + flag=full → emits as before ✅
- `node --check` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)