### PR TITLE
fix(caveman-compress): add UTF-8 encoding to all file I/O

### DIFF
--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import List
 
@@ -220,20 +221,29 @@ Return ONLY the fixed compressed file. No explanation.
 
 
 def _atomic_write(path: Path, text: str) -> None:
-    """Write text to path atomically via a sibling temp file + rename.
+    """Write text to path atomically via a unique sibling temp file + rename.
 
     Prevents truncation-to-zero-bytes when a write fails mid-way (e.g. a
     charmap error on Windows). The rename is atomic on POSIX; on Windows it
     is near-atomic (NTFS moves are transactional within the same volume).
+
+    Uses a uniquely-named temp file in the same directory (same filesystem,
+    required for atomic rename) rather than a fixed .tmp suffix — avoids
+    clobbering unrelated *.tmp files and handles the edge case where the
+    source path itself ends in .tmp.
     """
-    tmp = path.with_suffix(".tmp")
     try:
-        tmp.write_text(text, encoding="utf-8")
+        fd, tmp_str = tempfile.mkstemp(dir=path.parent, prefix=path.stem + ".", suffix=".tmp")
+        tmp = Path(tmp_str)
+        try:
+            os.write(fd, text.encode("utf-8"))
+        finally:
+            os.close(fd)
         tmp.replace(path)
     except Exception:
         try:
             tmp.unlink()
-        except OSError:
+        except (OSError, UnboundLocalError):
             pass
         raise
 
@@ -346,8 +356,9 @@ def compress_file(filepath: Path) -> bool:
             print(f"   - {err}")
 
         if attempt == MAX_RETRIES - 1:
-            # Restore original on failure
-            filepath.write_text(original_text, encoding="utf-8")
+            # Restore from the verified on-disk backup atomically so a
+            # failed restore write can't leave the file truncated to 0 bytes.
+            _atomic_write(filepath, backup_path.read_text(encoding="utf-8"))
             backup_path.unlink(missing_ok=True)
             print("❌ Failed after retries — original restored")
             return False

--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -219,6 +219,25 @@ Return ONLY the fixed compressed file. No explanation.
 # ---------- Core Logic ----------
 
 
+def _atomic_write(path: Path, text: str) -> None:
+    """Write text to path atomically via a sibling temp file + rename.
+
+    Prevents truncation-to-zero-bytes when a write fails mid-way (e.g. a
+    charmap error on Windows). The rename is atomic on POSIX; on Windows it
+    is near-atomic (NTFS moves are transactional within the same volume).
+    """
+    tmp = path.with_suffix(".tmp")
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        tmp.replace(path)
+    except Exception:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
 def compress_file(filepath: Path) -> bool:
     # Resolve and validate path
     filepath = filepath.resolve()
@@ -246,7 +265,7 @@ def compress_file(filepath: Path) -> bool:
         print("Skipping (not natural language)")
         return False
 
-    original_text = filepath.read_text(errors="ignore")
+    original_text = filepath.read_text(encoding="utf-8", errors="replace")
     # Store backup outside the source directory so skill auto-loaders don't
     # re-ingest the `.original.md` copy as a live file. Mirror the source's
     # parent-dir name + stem under a platform-aware base to reduce collisions.
@@ -300,8 +319,8 @@ def compress_file(filepath: Path) -> bool:
     # touching the input file. If the filesystem dropped bytes (encoding,
     # antivirus, disk full), unlink the bad backup and abort instead of
     # leaving the user with a corrupt backup + compressed primary.
-    backup_path.write_text(original_text)
-    backup_readback = backup_path.read_text(errors="ignore")
+    backup_path.write_text(original_text, encoding="utf-8")
+    backup_readback = backup_path.read_text(encoding="utf-8")
     if backup_readback != original_text:
         print(f"❌ Backup write verification failed: {backup_path}")
         print("   In-memory original differs from on-disk backup. Aborting before touching the input file.")
@@ -310,7 +329,7 @@ def compress_file(filepath: Path) -> bool:
         except OSError:
             pass
         return False
-    filepath.write_text(compressed)
+    _atomic_write(filepath, compressed)
 
     # Step 2: Validate + Retry
     for attempt in range(MAX_RETRIES):
@@ -328,7 +347,7 @@ def compress_file(filepath: Path) -> bool:
 
         if attempt == MAX_RETRIES - 1:
             # Restore original on failure
-            filepath.write_text(original_text)
+            filepath.write_text(original_text, encoding="utf-8")
             backup_path.unlink(missing_ok=True)
             print("❌ Failed after retries — original restored")
             return False
@@ -337,6 +356,6 @@ def compress_file(filepath: Path) -> bool:
         compressed = call_claude(
             build_fix_prompt(original_text, compressed, result.errors)
         )
-        filepath.write_text(compressed)
+        _atomic_write(filepath, compressed)
 
     return True

--- a/skills/caveman-compress/scripts/detect.py
+++ b/skills/caveman-compress/scripts/detect.py
@@ -76,7 +76,7 @@ def detect_file_type(filepath: Path) -> str:
     # Extensionless files (like CLAUDE.md, TODO) — check content
     if not ext:
         try:
-            text = filepath.read_text(errors="ignore")
+            text = filepath.read_text(encoding="utf-8", errors="replace")
         except (OSError, PermissionError):
             return "unknown"
 

--- a/skills/caveman-compress/scripts/validate.py
+++ b/skills/caveman-compress/scripts/validate.py
@@ -28,7 +28,7 @@ class ValidationResult:
 
 
 def read_file(path: Path) -> str:
-    return path.read_text(errors="ignore")
+    return path.read_text(encoding="utf-8", errors="replace")
 
 
 # ---------- Extractors ----------

--- a/tests/test_compress_safety.py
+++ b/tests/test_compress_safety.py
@@ -24,7 +24,7 @@ from scripts import compress as compress_mod  # noqa: E402
 class CompressSafetyTests(unittest.TestCase):
     def _file_with(self, dirpath: Path, text: str) -> Path:
         path = dirpath / "task.md"
-        path.write_text(text)
+        path.write_text(text, encoding="utf-8")
         return path
 
     def test_empty_input_refused(self):
@@ -34,7 +34,7 @@ class CompressSafetyTests(unittest.TestCase):
                 ok = compress_mod.compress_file(path)
             self.assertFalse(ok)
             call.assert_not_called()
-            self.assertEqual(path.read_text(), "")
+            self.assertEqual(path.read_text(encoding="utf-8"), "")
             self.assertFalse((Path(tmp) / "task.original.md").exists())
 
     def test_empty_compressed_output_does_not_touch_disk(self):
@@ -44,7 +44,7 @@ class CompressSafetyTests(unittest.TestCase):
             with mock.patch.object(compress_mod, "call_claude", return_value=""):
                 ok = compress_mod.compress_file(path)
             self.assertFalse(ok)
-            self.assertEqual(path.read_text(), original)
+            self.assertEqual(path.read_text(encoding="utf-8"), original)
             self.assertFalse((Path(tmp) / "task.original.md").exists())
 
     def test_whitespace_only_compressed_output_does_not_touch_disk(self):
@@ -54,7 +54,7 @@ class CompressSafetyTests(unittest.TestCase):
             with mock.patch.object(compress_mod, "call_claude", return_value="   \n  "):
                 ok = compress_mod.compress_file(path)
             self.assertFalse(ok)
-            self.assertEqual(path.read_text(), original)
+            self.assertEqual(path.read_text(encoding="utf-8"), original)
             self.assertFalse((Path(tmp) / "task.original.md").exists())
 
     def test_identical_compressed_output_does_not_touch_disk(self):
@@ -64,7 +64,7 @@ class CompressSafetyTests(unittest.TestCase):
             with mock.patch.object(compress_mod, "call_claude", return_value=original):
                 ok = compress_mod.compress_file(path)
             self.assertFalse(ok)
-            self.assertEqual(path.read_text(), original)
+            self.assertEqual(path.read_text(encoding="utf-8"), original)
             self.assertFalse((Path(tmp) / "task.original.md").exists())
 
     def test_real_compression_writes_backup_and_target(self):
@@ -81,12 +81,35 @@ class CompressSafetyTests(unittest.TestCase):
                 v.return_value = mock.Mock(is_valid=True, errors=[], warnings=[])
                 ok = compress_mod.compress_file(path)
             self.assertTrue(ok)
-            self.assertEqual(path.read_text(), compressed)
+            self.assertEqual(path.read_text(encoding="utf-8"), compressed)
             # Backups now live OUTSIDE the source dir (issue #420), under a
             # platform-aware data dir mirroring the source parent name.
             backup = compress_mod.backup_dir_for(path.resolve()) / "task.original.md"
-            self.assertEqual(backup.read_text(), original)
+            self.assertEqual(backup.read_text(encoding="utf-8"), original)
             self.assertFalse((Path(tmp) / "task.original.md").exists())
+
+    def test_unicode_content_round_trips_safely(self):
+        """Non-ASCII chars (→ — ≥ €) must survive read/compress/write without charmap crash."""
+        with tempfile.TemporaryDirectory() as tmp, \
+             tempfile.TemporaryDirectory() as data_home, \
+             mock.patch.dict(os.environ, {"XDG_DATA_HOME": data_home, "LOCALAPPDATA": data_home}):
+            original = (
+                "# Unicode Test\n\n"
+                "Arrow → right. Em-dash — pause. Greater-or-equal ≥ ten. Euro € cost.\n"
+            )
+            compressed = (
+                "# Unicode Test\n\n"
+                "Arrow →. Em-dash —. ≥ ten. € cost.\n"
+            )
+            path = self._file_with(Path(tmp), original)
+            with mock.patch.object(compress_mod, "call_claude", return_value=compressed), \
+                 mock.patch.object(compress_mod, "validate") as v:
+                v.return_value = mock.Mock(is_valid=True, errors=[], warnings=[])
+                ok = compress_mod.compress_file(path)
+            self.assertTrue(ok)
+            self.assertEqual(path.read_text(encoding="utf-8"), compressed)
+            backup = compress_mod.backup_dir_for(path.resolve()) / "task.original.md"
+            self.assertEqual(backup.read_text(encoding="utf-8"), original)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Windows defaults to cp1252, crashing on non-ASCII chars (→ —) with "charmap" codec error and truncating the target file to 0 bytes.

- Add encoding='utf-8' to all read_text/write_text calls in compress.py, validate.py, and detect.py
- Add _atomic_write() (temp file + rename) to prevent truncation if a write fails mid-way
- Update test helpers and add unicode round-trip safety test

Closes #533