### PR TITLE
fix: add version field to plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "caveman",
+  "version": "1.9.0",
   "description": "Ultra-compressed communication mode. Cuts ~75% of tokens while keeping full technical accuracy by speaking like a caveman.",
   "author": {
     "name": "Julius Brussee",


### PR DESCRIPTION
CLI tools and plugin managers use the `version` field to display installed versions. Without it, `plugin.json` shows `vundefined`. This adds `"version": "1.9.0"` to match the release tag.