### PR TITLE
fix(hooks): preserve user language in per-turn reminder and fallback ruleset

### DIFF
--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -101,6 +101,7 @@ if (skillContent) {
     '## Rules\n\n' +
     'Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. ' +
     'Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.\n\n' +
+    'Reply in user\'s dominant language — compress the style, not the language. No forced English openings. Keep technical terms, code, API names, CLI commands, error strings verbatim.\n\n' +
     'Pattern: `[thing] [action] [reason]. [next step].`\n\n' +
     'Not: "Sure! I\'d be happy to help you with that. The issue you\'re experiencing is likely caused by..."\n' +
     'Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"\n\n' +

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -126,6 +126,7 @@ process.stdin.on('end', () => {
           hookEventName: "UserPromptSubmit",
           additionalContext: "CAVEMAN MODE ACTIVE (" + activeMode + "). " +
             "Drop articles/filler/pleasantries/hedging. Fragments OK. " +
+            "Reply in user's language — compress the style, not the language. " +
             "Code/commits/security: write normal."
         }
       }));


### PR DESCRIPTION
## What

  Caveman already says "preserve the user's language — compress the style, not the language." But that line lives only in the SessionStart ruleset. Two places
  that run every turn never got the memo:

  - **`caveman-mode-tracker.js`** re-injects a short English reminder on *every* prompt. It's the freshest instruction the model sees, and it's English-only — so
  in long sessions (especially after a `/compact` drops the SessionStart block) replies quietly drift back to English.
  - **`caveman-activate.js`** fallback ruleset (the one used when SKILL.md isn't found) skips the language rule too.

  ## Fix

  One line added to each. Caveman keeps crushing tokens; it just stops switching the language while doing it.

  ## Impact

  Nothing changes for English users. For the rest of us, caveman finally stays in our language. I'm Russian — `/caveman` kept flipping me to English mid-task,
  and this was the leak.

  Two-line diff, hook tests green (`tests/test_hooks.py`).