### PR TITLE
fix(hooks): isolate flag files per session

### DIFF
--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -1,143 +1,172 @@
 #!/usr/bin/env node
 // caveman — Claude Code SessionStart activation hook
 //
-// Runs on every session start:
-//   1. Writes flag file at $CLAUDE_CONFIG_DIR/.caveman-active (statusline reads this)
-//   2. Emits caveman ruleset as hidden SessionStart context
-//   3. Detects missing statusline config and emits setup nudge
+// Runs on every session start (startup, resume, compact, clear):
+//   1. Reads stdin JSON for session_id and source
+//   2. Writes per-session flag file (conditional on source)
+//   3. Writes global flag file (best-effort for external tools)
+//   4. Emits caveman ruleset as hidden SessionStart context
+//   5. Detects missing statusline config and emits setup nudge
+//   6. Cleans up stale per-session flag files on fresh startup
 
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { getDefaultMode, safeWriteFlag } = require('./caveman-config');
+const { getDefaultMode, safeWriteFlag, readFlag, getFlagPath, getGlobalFlagPath, safeUnlinkFlag, cleanupStaleFlagFiles } = require('./caveman-config');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-const flagPath = path.join(claudeDir, '.caveman-active');
 const settingsPath = path.join(claudeDir, 'settings.json');
 
-const mode = getDefaultMode();
+let input = '';
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', () => {
+  let sessionId = null;
+  let source = 'startup';
+  try {
+    const data = JSON.parse(input);
+    sessionId = data.session_id || null;
+    source = data.source || 'startup';
+  } catch (e) {
+    // No stdin or invalid JSON — proceed with defaults
+  }
 
-// "off" mode — skip activation entirely, don't write flag or emit rules
-if (mode === 'off') {
-  try { fs.unlinkSync(flagPath); } catch (e) {}
-  process.stdout.write('OK');
-  process.exit(0);
-}
+  const mode = getDefaultMode();
+  const perSessionFlagPath = getFlagPath(claudeDir, sessionId);
+  const globalFlagPath = getGlobalFlagPath(claudeDir);
 
-// 1. Write flag file (symlink-safe)
-safeWriteFlag(flagPath, mode);
+  // "off" mode — skip activation entirely
+  if (mode === 'off') {
+    safeUnlinkFlag(perSessionFlagPath);
+    safeUnlinkFlag(globalFlagPath);
+    process.stdout.write('OK');
+    return;
+  }
 
-// 2. Emit full caveman ruleset, filtered to the active intensity level.
-//    The old 2-sentence summary was too weak — models drifted back to verbose
-//    mid-conversation, especially after context compression pruned it away.
-//    Full rules with examples anchor behavior much more reliably.
-//
-//    Reads SKILL.md at runtime so edits to the source of truth propagate
-//    automatically — no hardcoded duplication to go stale.
-
-// Modes that have their own independent skill files — not caveman intensity levels.
-// For these, emit a short activation line; the skill itself handles behavior.
-const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
-
-if (INDEPENDENT_MODES.has(mode)) {
-  process.stdout.write('CAVEMAN MODE ACTIVE — level: ' + mode + '. Behavior defined by /caveman-' + mode + ' skill.');
-  process.exit(0);
-}
-
-// Resolve the canonical label for wenyan alias
-const modeLabel = mode === 'wenyan' ? 'wenyan-full' : mode;
-
-// Read SKILL.md — the single source of truth for caveman behavior.
-// Plugin installs: __dirname = <plugin_root>/hooks/, SKILL.md at <plugin_root>/skills/caveman/SKILL.md
-// Standalone installs: __dirname = $CLAUDE_CONFIG_DIR/hooks/, SKILL.md won't exist — falls back to hardcoded rules.
-let skillContent = '';
-try {
-  skillContent = fs.readFileSync(
-    path.join(__dirname, '..', 'skills', 'caveman', 'SKILL.md'), 'utf8'
-  );
-} catch (e) { /* standalone install — will use fallback below */ }
-
-let output;
-
-if (skillContent) {
-  // Strip YAML frontmatter
-  const body = skillContent.replace(/^---[\s\S]*?---\s*/, '');
-
-  // Filter intensity table: keep header rows + only the active level's row
-  const filtered = body.split('\n').reduce((acc, line) => {
-    // Intensity table rows start with | **level** |
-    const tableRowMatch = line.match(/^\|\s*\*\*(\S+?)\*\*\s*\|/);
-    if (tableRowMatch) {
-      // Keep only the active level's row (and always keep header/separator)
-      if (tableRowMatch[1] === modeLabel) {
-        acc.push(line);
-      }
-      return acc;
-    }
-
-    // Example lines start with "- level:" — keep only lines matching active level
-    const exampleMatch = line.match(/^- (\S+?):\s/);
-    if (exampleMatch) {
-      if (exampleMatch[1] === modeLabel) {
-        acc.push(line);
-      }
-      return acc;
-    }
-
-    acc.push(line);
-    return acc;
-  }, []);
-
-  output = 'CAVEMAN MODE ACTIVE — level: ' + modeLabel + '\n\n' + filtered.join('\n');
-} else {
-  // Fallback when SKILL.md is not found (standalone hook install without skills dir).
-  // This is the minimum viable ruleset — better than nothing.
-  output =
-    'CAVEMAN MODE ACTIVE — level: ' + modeLabel + '\n\n' +
-    'Respond terse like smart caveman. All technical substance stay. Only fluff die.\n\n' +
-    '## Persistence\n\n' +
-    'ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".\n\n' +
-    'Current level: **' + modeLabel + '**. Switch: `/caveman lite|full|ultra`.\n\n' +
-    '## Rules\n\n' +
-    'Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. ' +
-    'Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.\n\n' +
-    'Pattern: `[thing] [action] [reason]. [next step].`\n\n' +
-    'Not: "Sure! I\'d be happy to help you with that. The issue you\'re experiencing is likely caused by..."\n' +
-    'Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"\n\n' +
-    '## Auto-Clarity\n\n' +
-    'Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.\n\n' +
-    '## Boundaries\n\n' +
-    'Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.';
-}
-
-// 3. Detect missing statusline config — nudge Claude to help set it up
-try {
-  let hasStatusline = false;
-  if (fs.existsSync(settingsPath)) {
-    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-    if (settings.statusLine) {
-      hasStatusline = true;
+  // Per-session flag: conditional on source.
+  // On compact/resume, preserve existing per-session mode (the core fix for #184/#334).
+  // On startup/clear, write (or overwrite) with configured default.
+  if (source === 'startup' || source === 'clear') {
+    safeWriteFlag(perSessionFlagPath, mode);
+  } else {
+    // compact or resume — only write if per-session flag doesn't exist yet
+    const existing = readFlag(perSessionFlagPath);
+    if (!existing) {
+      safeWriteFlag(perSessionFlagPath, mode);
     }
   }
 
-  if (!hasStatusline) {
-    const isWindows = process.platform === 'win32';
-    const scriptName = isWindows ? 'caveman-statusline.ps1' : 'caveman-statusline.sh';
-    const scriptPath = path.join(__dirname, scriptName);
-    const command = isWindows
-      ? `powershell -ExecutionPolicy Bypass -File "${scriptPath}"`
-      : `bash "${scriptPath}"`;
-    const statusLineSnippet =
-      '"statusLine": { "type": "command", "command": ' + JSON.stringify(command) + ' }';
-    output += "\n\n" +
-      "STATUSLINE SETUP NEEDED: The caveman plugin includes a statusline badge showing active mode " +
-      "(e.g. [CAVEMAN], [CAVEMAN:ULTRA]). It is not configured yet. " +
-      "To enable, add this to " + path.join(claudeDir, 'settings.json') + ": " +
-      statusLineSnippet + " " +
-      "Proactively offer to set this up for the user on first interaction.";
-  }
-} catch (e) {
-  // Silent fail — don't block session start over statusline detection
-}
+  // Global flag: always written (best-effort for external tools, last-writer-wins)
+  safeWriteFlag(globalFlagPath, mode);
 
-process.stdout.write(output);
+  // Stale file cleanup — only on fresh startup
+  if (source === 'startup') {
+    cleanupStaleFlagFiles(claudeDir, 24 * 60 * 60 * 1000);
+  }
+
+  // Modes that have their own independent skill files — not caveman intensity levels.
+  // For these, emit a short activation line; the skill itself handles behavior.
+  const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
+
+  if (INDEPENDENT_MODES.has(mode)) {
+    process.stdout.write('CAVEMAN MODE ACTIVE — level: ' + mode + '. Behavior defined by /caveman-' + mode + ' skill.');
+    return;
+  }
+
+  // Resolve the canonical label for wenyan alias
+  const modeLabel = mode === 'wenyan' ? 'wenyan-full' : mode;
+
+  // Read SKILL.md — the single source of truth for caveman behavior.
+  // Plugin installs: __dirname = <plugin_root>/hooks/, SKILL.md at <plugin_root>/skills/caveman/SKILL.md
+  // Standalone installs: __dirname = $CLAUDE_CONFIG_DIR/hooks/, SKILL.md won't exist — falls back to hardcoded rules.
+  let skillContent = '';
+  try {
+    skillContent = fs.readFileSync(
+      path.join(__dirname, '..', 'skills', 'caveman', 'SKILL.md'), 'utf8'
+    );
+  } catch (e) { /* standalone install — will use fallback below */ }
+
+  let output;
+
+  if (skillContent) {
+    // Strip YAML frontmatter
+    const body = skillContent.replace(/^---[\s\S]*?---\s*/, '');
+
+    // Filter intensity table: keep header rows + only the active level's row
+    const filtered = body.split('\n').reduce((acc, line) => {
+      // Intensity table rows start with | **level** |
+      const tableRowMatch = line.match(/^\|\s*\*\*(\S+?)\*\*\s*\|/);
+      if (tableRowMatch) {
+        // Keep only the active level's row (and always keep header/separator)
+        if (tableRowMatch[1] === modeLabel) {
+          acc.push(line);
+        }
+        return acc;
+      }
+
+      // Example lines start with "- level:" — keep only lines matching active level
+      const exampleMatch = line.match(/^- (\S+?):\s/);
+      if (exampleMatch) {
+        if (exampleMatch[1] === modeLabel) {
+          acc.push(line);
+        }
+        return acc;
+      }
+
+      acc.push(line);
+      return acc;
+    }, []);
+
+    output = 'CAVEMAN MODE ACTIVE — level: ' + modeLabel + '\n\n' + filtered.join('\n');
+  } else {
+    // Fallback when SKILL.md is not found (standalone hook install without skills dir).
+    // This is the minimum viable ruleset — better than nothing.
+    output =
+      'CAVEMAN MODE ACTIVE — level: ' + modeLabel + '\n\n' +
+      'Respond terse like smart caveman. All technical substance stay. Only fluff die.\n\n' +
+      '## Persistence\n\n' +
+      'ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".\n\n' +
+      'Current level: **' + modeLabel + '**. Switch: `/caveman lite|full|ultra`.\n\n' +
+      '## Rules\n\n' +
+      'Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. ' +
+      'Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.\n\n' +
+      'Pattern: `[thing] [action] [reason]. [next step].`\n\n' +
+      'Not: "Sure! I\'d be happy to help you with that. The issue you\'re experiencing is likely caused by..."\n' +
+      'Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"\n\n' +
+      '## Auto-Clarity\n\n' +
+      'Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.\n\n' +
+      '## Boundaries\n\n' +
+      'Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.';
+  }
+
+  // Detect missing statusline config — nudge Claude to help set it up
+  try {
+    let hasStatusline = false;
+    if (fs.existsSync(settingsPath)) {
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      if (settings.statusLine) {
+        hasStatusline = true;
+      }
+    }
+
+    if (!hasStatusline) {
+      const isWindows = process.platform === 'win32';
+      const scriptName = isWindows ? 'caveman-statusline.ps1' : 'caveman-statusline.sh';
+      const scriptPath = path.join(__dirname, scriptName);
+      const command = isWindows
+        ? `powershell -ExecutionPolicy Bypass -File "${scriptPath}"`
+        : `bash "${scriptPath}"`;
+      const statusLineSnippet =
+        '"statusLine": { "type": "command", "command": ' + JSON.stringify(command) + ' }';
+      output += "\n\n" +
+        "STATUSLINE SETUP NEEDED: The caveman plugin includes a statusline badge showing active mode " +
+        "(e.g. [CAVEMAN], [CAVEMAN:ULTRA]). It is not configured yet. " +
+        "To enable, add this to " + path.join(claudeDir, 'settings.json') + ": " +
+        statusLineSnippet + " " +
+        "Proactively offer to set this up for the user on first interaction.";
+    }
+  } catch (e) {
+    // Silent fail — don't block session start over statusline detection
+  }
+
+  process.stdout.write(output);
+});

--- a/src/hooks/caveman-config.js
+++ b/src/hooks/caveman-config.js
@@ -322,4 +322,69 @@ function readHistory(filePath) {
   }
 }
 
-module.exports = { getDefaultMode, getConfigDir, getConfigPath, findRepoConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory };
+// Validate session ID as UUID format. Returns lowercase UUID or null.
+// Claude Code session IDs are UUIDs (hex + hyphens). Non-UUID input
+// returns null, causing callers to fall back to the global flag path.
+function sanitizeSessionId(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(raw)) {
+    return null;
+  }
+  return raw.toLowerCase();
+}
+
+// Returns the flag file path for a given session. Per-session when a valid
+// session ID is provided, global otherwise.
+function getFlagPath(claudeDir, sessionId) {
+  const sanitized = sanitizeSessionId(sessionId);
+  if (sanitized) {
+    return path.join(claudeDir, `.caveman-active-${sanitized}`);
+  }
+  return path.join(claudeDir, '.caveman-active');
+}
+
+// Returns the global (non-session-specific) flag path.
+function getGlobalFlagPath(claudeDir) {
+  return path.join(claudeDir, '.caveman-active');
+}
+
+// Symlink-safe flag file removal. Refuses to unlink symlinks.
+function safeUnlinkFlag(flagPath) {
+  try {
+    const st = fs.lstatSync(flagPath);
+    if (st.isSymbolicLink()) return;
+    fs.unlinkSync(flagPath);
+  } catch (e) {
+    // Silent fail — ENOENT or permission errors are fine
+  }
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+// Best-effort cleanup of stale per-session flag files older than maxAge ms.
+// Uses withFileTypes + symlink refusal. Only deletes UUID-suffixed files.
+function cleanupStaleFlagFiles(claudeDir, maxAgeMs) {
+  try {
+    const entries = fs.readdirSync(claudeDir, { withFileTypes: true });
+    const prefix = '.caveman-active-';
+    const now = Date.now();
+    for (const entry of entries) {
+      if (!entry.name.startsWith(prefix)) continue;
+      if (entry.isSymbolicLink()) continue;
+      if (!entry.isFile()) continue;
+      const suffix = entry.name.slice(prefix.length);
+      if (!UUID_RE.test(suffix)) continue;
+      const fullPath = path.join(claudeDir, entry.name);
+      try {
+        const st = fs.statSync(fullPath);
+        if (now - st.mtimeMs > maxAgeMs) {
+          fs.unlinkSync(fullPath);
+        }
+      } catch (e) { /* best-effort */ }
+    }
+  } catch (e) {
+    // Silent fail
+  }
+}
+
+module.exports = { getDefaultMode, getConfigDir, getConfigPath, findRepoConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory, sanitizeSessionId, getFlagPath, getGlobalFlagPath, safeUnlinkFlag, cleanupStaleFlagFiles };

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -6,14 +6,13 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { execFileSync } = require('child_process');
-const { getDefaultMode, safeWriteFlag, readFlag, VALID_MODES } = require('./caveman-config');
+const { getDefaultMode, safeWriteFlag, readFlag, getFlagPath, getGlobalFlagPath, safeUnlinkFlag, VALID_MODES } = require('./caveman-config');
 
 // Modes handled by their own slash commands (/caveman-commit, etc.) — not
 // selectable via /caveman <arg>.
 const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-const flagPath = path.join(claudeDir, '.caveman-active');
 
 let input = '';
 process.stdin.on('data', chunk => { input += chunk; });
@@ -21,6 +20,9 @@ process.stdin.on('end', () => {
   try {
     const data = JSON.parse(input);
     const prompt = (data.prompt || '').trim().toLowerCase();
+    const sessionId = data.session_id || null;
+    const flagPath = getFlagPath(claudeDir, sessionId);
+    const globalFlagPath = getGlobalFlagPath(claudeDir);
 
     // Natural language activation (e.g. "activate caveman", "turn on caveman mode",
     // "talk like caveman"). README tells users they can say these, but the hook
@@ -97,7 +99,8 @@ process.stdin.on('end', () => {
       if (mode && mode !== 'off') {
         safeWriteFlag(flagPath, mode);
       } else if (mode === 'off') {
-        try { fs.unlinkSync(flagPath); } catch (e) {}
+        safeUnlinkFlag(flagPath);
+        safeUnlinkFlag(globalFlagPath);
       }
     }
 
@@ -105,20 +108,12 @@ process.stdin.on('end', () => {
     if (/\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/i.test(prompt) ||
         /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/i.test(prompt) ||
         /\bnormal mode\b/i.test(prompt)) {
-      try { fs.unlinkSync(flagPath); } catch (e) {}
+      safeUnlinkFlag(flagPath);
+      safeUnlinkFlag(globalFlagPath);
     }
 
     // Per-turn reinforcement: emit a structured reminder when caveman is active.
-    // The SessionStart hook injects the full ruleset once, but models lose it
-    // when other plugins inject competing style instructions every turn.
-    // This keeps caveman visible in the model's attention on every user message.
-    //
-    // Skip independent modes (commit, review, compress) — they have their own
-    // skill behavior and the base caveman rules would conflict.
     // readFlag enforces symlink-safe read + size cap + VALID_MODES whitelist.
-    // If the flag is missing, corrupted, oversized, or a symlink pointing at
-    // something like ~/.ssh/id_rsa, readFlag returns null and we emit nothing
-    // — never inject untrusted bytes into model context.
     const activeMode = readFlag(flagPath);
     if (activeMode && !INDEPENDENT_MODES.has(activeMode)) {
       process.stdout.write(JSON.stringify({

--- a/src/hooks/caveman-stats.js
+++ b/src/hooks/caveman-stats.js
@@ -10,7 +10,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { readFlag, appendFlag, readHistory, safeWriteFlag } = require('./caveman-config');
+const { readFlag, appendFlag, readHistory, safeWriteFlag, getFlagPath } = require('./caveman-config');
 
 // Mean per-task savings from benchmarks/results/*.json (avg_savings: 65 across
 // 10 tasks, sonnet-4-20250514). Only 'full' has measured data; lite / ultra /
@@ -308,7 +308,10 @@ function main() {
   }
 
   const parsed = parseSession(sessionFile);
-  const mode = readFlag(path.join(claudeDir, '.caveman-active'));
+  // Read per-session flag — prefer env var (reliable UUID), fall back to filename
+  const sessionIdForFlag = process.env.CLAUDE_CODE_SESSION_ID
+    || path.basename(sessionFile, '.jsonl');
+  const mode = readFlag(getFlagPath(claudeDir, sessionIdForFlag));
 
   // Append a snapshot of this session's totals to the lifetime log. Multiple
   // /caveman-stats calls in one session emit multiple lines for the same

--- a/src/hooks/caveman-statusline.ps1
+++ b/src/hooks/caveman-statusline.ps1
@@ -1,6 +1,18 @@
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
-$Flag = Join-Path $ClaudeDir ".caveman-active"
+
+# Per-session flag via CLAUDE_CODE_SESSION_ID env var (set by Claude Code).
+# Falls back to global flag if env var absent or per-session file doesn't exist.
+$Flag = $null
+if ($env:CLAUDE_CODE_SESSION_ID -match '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$') {
+    $SessionFlag = Join-Path $ClaudeDir ".caveman-active-$($env:CLAUDE_CODE_SESSION_ID)"
+    if ((Test-Path $SessionFlag) -and -not ((Get-Item -LiteralPath $SessionFlag -Force).Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+        $Flag = $SessionFlag
+    }
+}
+if (-not $Flag) {
+    $Flag = Join-Path $ClaudeDir ".caveman-active"
+}
 if (-not (Test-Path $Flag)) { exit 0 }
 
 # Refuse reparse points (symlinks / junctions) and oversized files. Without

--- a/src/hooks/caveman-statusline.sh
+++ b/src/hooks/caveman-statusline.sh
@@ -8,7 +8,20 @@
 # Plugin users: Claude will offer to set this up on first session.
 # Standalone users: install.sh wires this automatically.
 
-FLAG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.caveman-active"
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+
+# Per-session flag via CLAUDE_CODE_SESSION_ID env var (set by Claude Code).
+# Falls back to global flag if env var absent or per-session file doesn't exist.
+FLAG=""
+if [[ "$CLAUDE_CODE_SESSION_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+  SESSION_FLAG="$CLAUDE_DIR/.caveman-active-$CLAUDE_CODE_SESSION_ID"
+  if [ -f "$SESSION_FLAG" ] && [ ! -L "$SESSION_FLAG" ]; then
+    FLAG="$SESSION_FLAG"
+  fi
+fi
+if [ -z "$FLAG" ]; then
+  FLAG="$CLAUDE_DIR/.caveman-active"
+fi
 
 # Refuse symlinks — a local attacker could point the flag at ~/.ssh/id_rsa and
 # have the statusline render its bytes (including ANSI escape sequences) to
@@ -42,7 +55,7 @@ fi
 # the suffix file is absent and nothing is rendered — so the default is safe
 # for fresh installs (no fake number, no crash).
 if [ "${CAVEMAN_STATUSLINE_SAVINGS:-1}" != "0" ]; then
-  SAVINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.caveman-statusline-suffix"
+  SAVINGS_FILE="$CLAUDE_DIR/.caveman-statusline-suffix"
   if [ -f "$SAVINGS_FILE" ] && [ ! -L "$SAVINGS_FILE" ]; then
     SAVINGS=$(head -c 64 "$SAVINGS_FILE" 2>/dev/null | tr -d '\000-\037')
     [ -n "$SAVINGS" ] && printf ' \033[38;5;172m%s\033[0m' "$SAVINGS"

--- a/src/hooks/uninstall.ps1
+++ b/src/hooks/uninstall.ps1
@@ -118,10 +118,16 @@ console.log('  Removed ' + removed + ' caveman hook entries from settings.json')
     }
 }
 
-# 3. Remove flag file
+# 3. Remove flag files (global + per-session)
 if (Test-Path $FlagFile) {
     Remove-Item $FlagFile -Force
     Write-Host "  Removed: $FlagFile"
+}
+Get-ChildItem -Path $ClaudeDir -Filter ".caveman-active-*" -File -ErrorAction SilentlyContinue | Where-Object {
+    -not ($_.Attributes -band [System.IO.FileAttributes]::ReparsePoint)
+} | ForEach-Object {
+    Remove-Item $_.FullName -Force
+    Write-Host "  Removed: $($_.FullName)"
 }
 
 Write-Host ""

--- a/src/hooks/uninstall.sh
+++ b/src/hooks/uninstall.sh
@@ -113,11 +113,14 @@ if [ -f "$SETTINGS.bak" ]; then
   echo "  Removed: $SETTINGS.bak"
 fi
 
-# 4. Remove flag file
+# 4. Remove flag files (global + per-session)
 if [ -f "$FLAG_FILE" ]; then
   rm "$FLAG_FILE"
   echo "  Removed: $FLAG_FILE"
 fi
+for f in "$CLAUDE_DIR"/.caveman-active-*; do
+  [ -f "$f" ] && [ ! -L "$f" ] && rm "$f" && echo "  Removed: $f"
+done
 
 echo ""
 echo "Done! Restart Claude Code to complete the uninstall."


### PR DESCRIPTION
Single global `.caveman-active` caused two bugs:
- Concurrent sessions clobbered each other's mode
- Context compression (compact/resume) reset mid-session changes

Per-session flag keyed by `session_id` from hook stdin. SessionStart skips write on compact/resume if per-session file exists. Global file kept as best-effort fallback for external tools.

UUID validation on all session ID inputs. `safeUnlinkFlag` helper for symlink-safe deletion. Stale per-session files cleaned after 24h.

BREAKING CHANGE: mid-session mode changes (`/caveman ultra`, etc.) no longer update the global `.caveman-active` file. External tools reading that file see the session's startup default, not mid-session changes. Migrate to per-session files via `CLAUDE_CODE_SESSION_ID`.

Fixes #184. Fixes #334.