### PR TITLE
feat: add Hermes Agent support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,6 +43,7 @@ If you want to install for one agent (or want to know exactly what command runs 
 | **Gemini CLI** | `gemini extensions install https://github.com/JuliusBrussee/caveman` | Yes |
 | **opencode** | `node bin/install.js --only opencode` *(or `npx -y github:JuliusBrussee/caveman -- --only opencode`)* | Yes (plugin + AGENTS.md) |
 | **OpenClaw** | `npx -y github:JuliusBrussee/caveman -- --only openclaw` | Yes (workspace skill + SOUL.md) |
+| **Hermes Agent** | `npx -y github:JuliusBrussee/caveman -- --only hermes` | Yes (skill + memory bootstrap) |
 | **Codex CLI** | `npx skills add JuliusBrussee/caveman -a codex` | Per-session: `/caveman` |
 | **Cursor** | `npx skills add JuliusBrussee/caveman -a cursor` | Per-session by default; `--with-init` for an always-on rule file |
 | **Windsurf** | `npx skills add JuliusBrussee/caveman -a windsurf` | Per-session by default; `--with-init` for an always-on rule file |

--- a/README.md
+++ b/README.md
@@ -207,6 +207,36 @@ Two thing happen, no more:
 
 Custom workspace path? `OPENCLAW_WORKSPACE=/your/path` before the command. Uninstall: same one-liner with `--uninstall` — skill folder gone, SOUL.md block ripped out cleanly, your other workspace content stay untouched. Idempotent re-runs (frontmatter not double-prepended, marker block not duplicated).
 
+---
+
+[**Hermes Agent**](https://github.com/nousresearch/hermes-agent) the personal AI agent. Run across CLI, Telegram, Discord, Slack, and 20+ platforms. Skill-based system, persistent memory, subagent delegation. Tagline: *"The messenger way."* Hermes versatile. Hermes everywhere.
+
+Caveman teach messenger brevity — same canonical installer, scoped to one agent:
+
+```bash
+# macOS / Linux / WSL
+curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.sh | bash -s -- --only hermes
+
+# Windows (PowerShell): no Node? install Node >=18 first, then
+npx -y github:JuliusBrussee/caveman -- --only hermes
+```
+
+Two thing happen, no more:
+
+1. **Skill drop** at `~/.hermes/skills/productivity/caveman/SKILL.md` — full ruleset, discoverable by Hermes skill loader. Skill load on-demand when user mention caveman.
+2. **Memory nudge.** Tiny marker-fenced block written to `~/.hermes/memories/caveman`. Hermes auto-inject memory entries into *every* turn. Agent terse from message one. No `/caveman` per session. No nag.
+
+```
+~/.hermes/
+├── skills/productivity/caveman/SKILL.md  ← full ruleset, on-demand load
+└── memories/caveman                       ← <!-- caveman-begin --> ... <!-- caveman-end -->
+                                              ↑ auto-inject every turn
+```
+
+Custom home path? `HERMES_HOME=/your/path` before the command. Uninstall: same one-liner with `--uninstall` — skill folder gone, memory block ripped out cleanly, your other content stay untouched. Idempotent re-runs (marker block not duplicated).
+
+---
+
 Lobster claw still sharp. Lobster mouth now small. Brain still big.
 
 ## Caveman Ecosystem

--- a/bin/install.js
+++ b/bin/install.js
@@ -24,6 +24,7 @@ const crypto = require('crypto');
 
 const SETTINGS = require('./lib/settings');
 const OPENCLAW = require('./lib/openclaw');
+const HERMES = require('./lib/hermes');
 const { stripOpencodeAgentTools } = require('./lib/opencode-agent');
 
 const REPO = 'JuliusBrussee/caveman';
@@ -207,6 +208,7 @@ const PROVIDERS = [
   { id: 'gemini',     label: 'Gemini CLI',          mech: 'gemini extensions install',     detect: 'command:gemini' },
   { id: 'opencode',   label: 'opencode',            mech: 'native opencode plugin',        detect: 'command:opencode' },
   { id: 'openclaw',   label: 'OpenClaw',            mech: 'workspace skill + SOUL.md',     detect: 'command:openclaw||dir:$HOME/.openclaw/workspace' },
+  { id: 'hermes',     label: 'Hermes Agent',        mech: 'skill + memory bootstrap',      detect: 'command:hermes||dir:$HOME/.hermes' },
   { id: 'codex',      label: 'Codex CLI',           mech: 'npx skills add (codex)',        detect: 'command:codex',           profile: 'codex' },
 
   // IDE / VS Code-family — extension probes are precise. Cursor/Windsurf also
@@ -798,6 +800,37 @@ function installOpenclaw(ctx) {
   process.stdout.write('\n');
 }
 
+// ── Hermes Agent native install ──────────────────────────────────────────
+// Drops skills/caveman/SKILL.md into the Hermes skills directory and writes
+// a small always-on bootstrap to ~/.hermes/memories/caveman. Hermes auto-
+// injects memory entries every turn, so this drives always-on behavior —
+// similar to OpenClaw's SOUL.md approach. See bin/lib/hermes.js for the
+// actual file writes.
+function installHermes(ctx) {
+  const { say, note, warn, opts, repoRoot, results } = ctx;
+  results.detected++;
+  say('→ Hermes Agent detected');
+
+  const log = {
+    write: (s) => process.stdout.write(s),
+    note: (s) => note(s),
+    warn: (s) => warn(s),
+  };
+
+  const r = HERMES.installHermes({
+    hermesHome: process.env.HERMES_HOME || undefined,
+    repoRoot,
+    dryRun: opts.dryRun,
+    force: opts.force,
+    log,
+  });
+
+  if (r.ok) results.installed.push('hermes');
+  else results.failed.push(['hermes', r.reason || 'install failed']);
+
+  process.stdout.write('\n');
+}
+
 // ── Hooks installer ────────────────────────────────────────────────────────
 // Replaces src/hooks/install.sh + src/hooks/install.ps1.
 async function installHooks(ctx) {
@@ -1188,6 +1221,18 @@ function uninstall(ctx) {
     if (r.touched) ok('  pruned caveman entries from OpenClaw workspace');
   }
 
+  // Hermes Agent
+  const hermesHome = process.env.HERMES_HOME || path.join(os.homedir(), '.hermes');
+  if (fs.existsSync(hermesHome)) {
+    const log = {
+      write: (s) => process.stdout.write(s),
+      note: (s) => note(s),
+      warn: (s) => warn(s),
+    };
+    const r = HERMES.uninstallHermes({ hermesHome, dryRun: opts.dryRun, log });
+    if (r.touched) ok('  pruned caveman entries from Hermes Agent');
+  }
+
   // Flag file
   const flag = path.join(configDir, '.caveman-active');
   if (fs.existsSync(flag) && !opts.dryRun) { try { fs.unlinkSync(flag); } catch (_) {} }
@@ -1343,6 +1388,7 @@ async function main() {
     if (prov.id === 'gemini')   { installGemini(ctx); continue; }
     if (prov.id === 'opencode') { installOpencode(ctx); continue; }
     if (prov.id === 'openclaw') { installOpenclaw(ctx); continue; }
+    if (prov.id === 'hermes')   { installHermes(ctx);   continue; }
     if (prov.profile)           { installViaSkills(ctx, prov); continue; }
   }
 

--- a/bin/lib/hermes.js
+++ b/bin/lib/hermes.js
@@ -1,0 +1,191 @@
+// caveman → Hermes Agent install / uninstall helper.
+//
+// Hermes Agent is a personal AI agent that runs across CLI, Telegram,
+// Discord, Slack, and 20+ platforms. It uses a skill-based system at
+// ~/.hermes/skills/<category>/<name>/SKILL.md. Skills are loaded on-demand
+// by keyword matching in the agent's system prompt.
+//
+// For always-on caveman behavior, we do two writes:
+//   1. Drop skills/caveman/SKILL.md into ~/.hermes/skills/productivity/caveman/
+//      with Hermes-required frontmatter merged in. Makes the skill discoverable
+//      via the agent's skill loader.
+//   2. Write a tiny marker-fenced bootstrap snippet to ~/.hermes/memories/caveman.
+//      Hermes auto-injects memory entries every turn (subject to a char cap),
+//      so this drives always-on behavior — similar to OpenClaw's SOUL.md approach.
+//
+// Idempotent on both writes. Uninstall removes the skill folder and strips
+// the marker block from the memory file while preserving any user-authored content.
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SKILL_NAME = 'caveman';
+const SKILL_CATEGORY = 'productivity';
+const MARK_BEGIN = '<!-- caveman-begin -->';
+const MARK_END = '<!-- caveman-end -->';
+
+function resolveHermesHome(env = process.env) {
+  if (env.HERMES_HOME) return path.resolve(env.HERMES_HOME);
+  return path.join(os.homedir(), '.hermes');
+}
+
+function readIfExists(p) {
+  try { return fs.readFileSync(p, 'utf8'); } catch (_) { return null; }
+}
+
+// ── Bootstrap snippet load ────────────────────────────────────────────────
+function loadBootstrapSnippet(repoRoot) {
+  if (repoRoot) {
+    const p = path.join(repoRoot, 'src', 'rules', 'caveman-hermes-bootstrap.md');
+    const body = readIfExists(p);
+    if (body) return body.endsWith('\n') ? body : body + '\n';
+  }
+  // Standalone fallback (curl|node case where there's no repo on disk).
+  // Keep this in sync with src/rules/caveman-hermes-bootstrap.md.
+  return [
+    MARK_BEGIN,
+    'Caveman mode active. Respond terse like smart caveman. All technical substance stay. Only fluff die.',
+    '',
+    'Rules: Drop filler/hedging/articles. Fragments OK. Short synonyms. Technical terms exact. Code unchanged.',
+    'Pattern: [thing] [action] [reason]. [next step].',
+    'Stop: "stop caveman" / "normal mode".',
+    '',
+    'Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.',
+    'Boundaries: code, commits, PRs written normal.',
+    MARK_END,
+    '',
+  ].join('\n');
+}
+
+function loadSkillBody(repoRoot) {
+  if (!repoRoot) return null;
+  return readIfExists(path.join(repoRoot, 'skills', 'caveman', 'SKILL.md'));
+}
+
+// ── Memory file marker-block append/strip ─────────────────────────────────
+function appendBootstrapToMemory(memPath, snippet) {
+  const existing = readIfExists(memPath);
+  if (existing && existing.includes(MARK_BEGIN) && existing.includes(MARK_END)) {
+    return { changed: false, reason: 'already present' };
+  }
+  let next;
+  if (existing && existing.length) {
+    const sep = existing.endsWith('\n\n') ? '' : (existing.endsWith('\n') ? '\n' : '\n\n');
+    next = existing + sep + snippet;
+  } else {
+    next = snippet;
+  }
+  fs.writeFileSync(memPath, next, { mode: 0o644 });
+  return { changed: true };
+}
+
+function stripBootstrapFromMemory(memPath) {
+  const existing = readIfExists(memPath);
+  if (!existing) return { changed: false, reason: 'no memory file' };
+  const begin = existing.indexOf(MARK_BEGIN);
+  const end = existing.indexOf(MARK_END);
+  if (begin === -1 || end === -1 || end <= begin) return { changed: false, reason: 'no marker block' };
+  const before = existing.slice(0, begin);
+  const after = existing.slice(end + MARK_END.length);
+  let next = (before.replace(/\n+$/, '\n') + after.replace(/^\n+/, '\n')).trimEnd();
+  next = next ? next + '\n' : '';
+  if (next === '') {
+    // Memory file only contained our block — remove the file.
+    try { fs.unlinkSync(memPath); } catch (_) {}
+    return { changed: true, removed: true };
+  }
+  fs.writeFileSync(memPath, next, { mode: 0o644 });
+  return { changed: true };
+}
+
+// ── Public API ────────────────────────────────────────────────────────────
+function installHermes({ hermesHome, repoRoot, dryRun = false, force = false, log = noopLog() } = {}) {
+  const home = hermesHome || resolveHermesHome();
+  const skillBody = loadSkillBody(repoRoot);
+  if (!skillBody) {
+    log.warn('  hermes install requires the caveman repo on disk (skills/caveman/SKILL.md missing).');
+    log.note('  Re-run from a clone or via `npx -y github:JuliusBrussee/caveman -- --only hermes`.');
+    return { ok: false, reason: 'repo not available' };
+  }
+
+  const snippet = loadBootstrapSnippet(repoRoot);
+  const skillDir = path.join(home, 'skills', SKILL_CATEGORY, SKILL_NAME);
+  const skillFile = path.join(skillDir, 'SKILL.md');
+  const memFile = path.join(home, 'memories', SKILL_NAME);
+
+  if (dryRun) {
+    log.note(`  would write ${skillFile}`);
+    log.note(`  would ${fs.existsSync(memFile) ? 'update' : 'create'} ${memFile} (always-on bootstrap)`);
+    return { ok: true, dryRun: true };
+  }
+
+  // Write skill file
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(skillFile, skillBody, { mode: 0o644 });
+  log.write(`  installed: ${skillFile}\n`);
+
+  // Write memory entry for always-on behavior
+  fs.mkdirSync(path.dirname(memFile), { recursive: true });
+  const mem = appendBootstrapToMemory(memFile, snippet);
+  if (mem.changed) log.write(`  wrote bootstrap to ${memFile}\n`);
+  else log.note(`  ${memFile} already contains caveman bootstrap`);
+
+  return { ok: true };
+}
+
+function uninstallHermes({ hermesHome, dryRun = false, log = noopLog() } = {}) {
+  const home = hermesHome || resolveHermesHome();
+  const skillDir = path.join(home, 'skills', SKILL_CATEGORY, SKILL_NAME);
+  const memFile = path.join(home, 'memories', SKILL_NAME);
+
+  let touched = false;
+
+  if (fs.existsSync(skillDir)) {
+    if (dryRun) {
+      log.note(`  would remove ${skillDir}/`);
+    } else {
+      try { fs.rmSync(skillDir, { recursive: true, force: true }); } catch (_) {}
+      log.note(`  removed ${skillDir}`);
+    }
+    touched = true;
+  }
+
+  if (fs.existsSync(memFile)) {
+    if (dryRun) {
+      log.note(`  would strip caveman block from ${memFile}`);
+      touched = true;
+    } else {
+      const r = stripBootstrapFromMemory(memFile);
+      if (r.changed) {
+        log.note(r.removed ? `  removed ${memFile}` : `  stripped caveman block from ${memFile}`);
+        touched = true;
+      }
+    }
+  }
+
+  return { ok: true, touched };
+}
+
+function noopLog() {
+  return {
+    write: (_) => {},
+    note: (_) => {},
+    warn: (_) => {},
+  };
+}
+
+module.exports = {
+  installHermes,
+  uninstallHermes,
+  resolveHermesHome,
+  appendBootstrapToMemory,
+  stripBootstrapFromMemory,
+  loadBootstrapSnippet,
+  MARK_BEGIN,
+  MARK_END,
+  SKILL_NAME,
+  SKILL_CATEGORY,
+};

--- a/src/rules/caveman-hermes-bootstrap.md
+++ b/src/rules/caveman-hermes-bootstrap.md
@@ -1,0 +1,10 @@
+<!-- caveman-begin -->
+Caveman mode active. Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+Rules: Drop filler/hedging/articles. Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
+Pattern: [thing] [action] [reason]. [next step].
+Stop: "stop caveman" / "normal mode".
+
+Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
+Boundaries: code, commits, PRs written normal.
+<!-- caveman-end -->

--- a/tests/test_hermes_install.js
+++ b/tests/test_hermes_install.js
@@ -1,0 +1,158 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { installHermes, uninstallHermes, appendBootstrapToMemory, stripBootstrapFromMemory } = require('../bin/lib/hermes');
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-hermes-'));
+}
+
+test('install writes skill file and memory bootstrap', () => {
+  const home = tmpDir();
+  const repoRoot = path.resolve(__dirname, '..');
+  const log = { write() {}, note() {}, warn() {} };
+
+  const r = installHermes({ hermesHome: home, repoRoot, log });
+  assert.ok(r.ok);
+  assert.strictEqual(r.dryRun, undefined);
+
+  // Skill file exists
+  const skillPath = path.join(home, 'skills', 'productivity', 'caveman', 'SKILL.md');
+  assert.ok(fs.existsSync(skillPath));
+  const skillContent = fs.readFileSync(skillPath, 'utf8');
+  assert.ok(skillContent.includes('caveman'));
+  assert.ok(skillContent.includes('Respond terse'));
+
+  // Memory bootstrap exists
+  const memPath = path.join(home, 'memories', 'caveman');
+  assert.ok(fs.existsSync(memPath));
+  const memContent = fs.readFileSync(memPath, 'utf8');
+  assert.ok(memContent.includes('<!-- caveman-begin -->'));
+  assert.ok(memContent.includes('<!-- caveman-end -->'));
+
+  // Cleanup
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test('install is idempotent', () => {
+  const home = tmpDir();
+  const repoRoot = path.resolve(__dirname, '..');
+  const log = { write() {}, note() {}, warn() {} };
+
+  const r1 = installHermes({ hermesHome: home, repoRoot, log });
+  assert.ok(r1.ok);
+
+  // Read memory content after first install
+  const memPath = path.join(home, 'memories', 'caveman');
+  const after1 = fs.readFileSync(memPath, 'utf8');
+
+  // Second install should not duplicate the block
+  const r2 = installHermes({ hermesHome: home, repoRoot, log });
+  assert.ok(r2.ok);
+
+  const after2 = fs.readFileSync(memPath, 'utf8');
+  assert.strictEqual(after1, after2, 'memory should not change on re-install');
+
+  // Skill file should still be there
+  const skillPath = path.join(home, 'skills', 'productivity', 'caveman', 'SKILL.md');
+  assert.ok(fs.existsSync(skillPath));
+
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test('dry run does not write files', () => {
+  const home = tmpDir();
+  const repoRoot = path.resolve(__dirname, '..');
+  const log = { write() {}, note() {}, warn() {} };
+
+  const r = installHermes({ hermesHome: home, repoRoot, dryRun: true, log });
+  assert.ok(r.ok);
+  assert.strictEqual(r.dryRun, true);
+
+  // No files should exist
+  const skillPath = path.join(home, 'skills', 'productivity', 'caveman', 'SKILL.md');
+  const memPath = path.join(home, 'memories', 'caveman');
+  assert.ok(!fs.existsSync(skillPath));
+  assert.ok(!fs.existsSync(memPath));
+
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test('uninstall removes skill and strips bootstrap', () => {
+  const home = tmpDir();
+  const repoRoot = path.resolve(__dirname, '..');
+  const log = { write() {}, note() {}, warn() {} };
+
+  installHermes({ hermesHome: home, repoRoot, log });
+
+  const r = uninstallHermes({ hermesHome: home, log });
+  assert.ok(r.ok);
+  assert.strictEqual(r.touched, true);
+
+  // Skill directory should be gone
+  const skillDir = path.join(home, 'skills', 'productivity', 'caveman');
+  assert.ok(!fs.existsSync(skillDir));
+
+  // Memory file should be removed (only contained our block)
+  const memPath = path.join(home, 'memories', 'caveman');
+  assert.ok(!fs.existsSync(memPath));
+
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test('uninstall preserves other memory content', () => {
+  const home = tmpDir();
+  const repoRoot = path.resolve(__dirname, '..');
+  const log = { write() {}, note() {}, warn() {} };
+
+  // Pre-populate memory with user content
+  const memDir = path.join(home, 'memories');
+  fs.mkdirSync(memDir, { recursive: true });
+  fs.writeFileSync(path.join(memDir, 'caveman'), 'User memory entry here.\n', 'utf8');
+
+  installHermes({ hermesHome: home, repoRoot, log });
+
+  // Memory should have both user content and caveman block
+  const memPath = path.join(memDir, 'caveman');
+  const content = fs.readFileSync(memPath, 'utf8');
+  assert.ok(content.includes('User memory entry'));
+  assert.ok(content.includes('<!-- caveman-begin -->'));
+
+  // Uninstall should preserve user content
+  uninstallHermes({ hermesHome: home, log });
+
+  const after = fs.readFileSync(memPath, 'utf8');
+  assert.ok(after.includes('User memory entry'));
+  assert.ok(!after.includes('<!-- caveman-begin -->'));
+
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test('appendBootstrapToMemory works on empty directory', () => {
+  const home = tmpDir();
+  const memPath = path.join(home, 'memories', 'caveman');
+  fs.mkdirSync(path.dirname(memPath), { recursive: true });
+
+  const snippet = '<!-- caveman-begin -->\ntest\n<!-- caveman-end -->\n';
+  const r = appendBootstrapToMemory(memPath, snippet);
+  assert.ok(r.changed);
+  assert.ok(fs.existsSync(memPath));
+  assert.ok(fs.readFileSync(memPath, 'utf8').includes('test'));
+
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test('stripBootstrapFromMemory returns no change when no markers', () => {
+  const home = tmpDir();
+  const memPath = path.join(home, 'memories', 'caveman');
+
+  fs.mkdirSync(path.dirname(memPath), { recursive: true });
+  fs.writeFileSync(memPath, 'just some user content\n', 'utf8');
+
+  const r = stripBootstrapFromMemory(memPath);
+  assert.strictEqual(r.changed, false);
+
+  fs.rmSync(home, { recursive: true, force: true });
+});


### PR DESCRIPTION
- Add hermes installer module (bin/lib/hermes.js)
  - Skill drop to ~/.hermes/skills/productivity/caveman/
  - Memory bootstrap to ~/.hermes/memories/caveman (always-on)
  - Idempotent install/uninstall
- Add bootstrap rule (src/rules/caveman-hermes-bootstrap.md)
- Wire up detection: command:hermes || dir:$HOME/.hermes
- Update README with Hermes section
- Update INSTALL.md with Hermes in supported agents table
- Include 7 unit tests (install, idempotent, dry-run, uninstall, preserve content, append, strip)

Hermes Agent is a personal AI agent running across CLI, Telegram, Discord, Slack, and 20+ platforms. Uses skill-based system similar to OpenClaw's workspace skills. Always-on behavior via memory auto-injection (mirrors OpenClaw's SOUL.md approach).