### PR TITLE
caveman: extend switch syntax to cover all six declared intensity levels

### DIFF
--- a/plugins/caveman/skills/caveman/SKILL.md
+++ b/plugins/caveman/skills/caveman/SKILL.md
@@ -14,7 +14,7 @@ Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
 ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
 
-Default: **full**. Switch: `/caveman lite|full|ultra`.
+Default: **full**. Switch: `/caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra`.
 
 ## Rules
 


### PR DESCRIPTION
Fixes https://github.com/JuliusBrussee/caveman/issues/548.

The description and the Intensity table both declared six levels —
`lite`, `full`, `ultra`, `wenyan-lite`, `wenyan-full`,
`wenyan-ultra` — but the switch syntax `/caveman lite|full|ultra`
only accepted three. Extend the alternation so the wenyan-* trio is
reachable via `/caveman wenyan-lite|wenyan-full|wenyan-ultra`.