### PR TITLE
feat(install): add pi-coding-agent native target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 .env.local
 **/.DS_Store
 .claude/worktrees/
+.worktrees/
 evals/snapshots/*.html
 evals/snapshots/*.png
 context/refs/research-brief-caveman-code-efficiency.md

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,6 +43,7 @@ If you want to install for one agent (or want to know exactly what command runs 
 | **Gemini CLI** | `gemini extensions install https://github.com/JuliusBrussee/caveman` | Yes |
 | **opencode** | `node bin/install.js --only opencode` *(or `npx -y github:JuliusBrussee/caveman -- --only opencode`)* | Yes (plugin + AGENTS.md) |
 | **OpenClaw** | `npx -y github:JuliusBrussee/caveman -- --only openclaw` | Yes (workspace skill + SOUL.md) |
+| **pi-coding-agent** | `node bin/install.js --only pi` *(or `npx -y github:JuliusBrussee/caveman -- --only pi`)* | Yes (skills pack + AGENTS.md) |
 | **Codex CLI** | `npx skills add JuliusBrussee/caveman -a codex` | Per-session: `/caveman` |
 | **Cursor** | `npx skills add JuliusBrussee/caveman -a cursor` | Per-session by default; `--with-init` for an always-on rule file |
 | **Windsurf** | `npx skills add JuliusBrussee/caveman -a windsurf` | Per-session by default; `--with-init` for an always-on rule file |

--- a/bin/install.js
+++ b/bin/install.js
@@ -207,6 +207,13 @@ const PROVIDERS = [
   { id: 'gemini',     label: 'Gemini CLI',          mech: 'gemini extensions install',     detect: 'command:gemini' },
   { id: 'opencode',   label: 'opencode',            mech: 'native opencode plugin',        detect: 'command:opencode' },
   { id: 'openclaw',   label: 'OpenClaw',            mech: 'workspace skill + SOUL.md',     detect: 'command:openclaw||dir:$HOME/.openclaw/workspace' },
+  // pi-coding-agent (earendil-works) — discovers skills from
+  // ~/.pi/agent/skills/<pack>/SKILL.md and reads ~/.pi/agent/AGENTS.md as
+  // always-on rules. No `npx skills add` integration; install path is a
+  // single symlink to the repo's `skills/` folder plus a fenced ruleset
+  // block in AGENTS.md. Detection probes the binary OR the config dir —
+  // either is enough signal that the user has pi installed.
+  { id: 'pi',         label: 'pi-coding-agent',     mech: 'skills pack in ~/.pi/agent/skills + AGENTS.md', detect: 'command:pi||dir:$HOME/.pi/agent' },
   { id: 'codex',      label: 'Codex CLI',           mech: 'npx skills add (codex)',        detect: 'command:codex',           profile: 'codex' },
 
   // IDE / VS Code-family — extension probes are precise. Cursor/Windsurf also
@@ -594,6 +601,24 @@ function copyDirRecursive(src, dest) {
   }
 }
 
+function piPackLooksManaged(dir) {
+  return OPENCODE_SKILL_DIRS.every(name => fs.existsSync(path.join(dir, name, 'SKILL.md')));
+}
+
+function symlinkPointsTo(linkPath, expectedTarget) {
+  const raw = fs.readlinkSync(linkPath);
+  const resolved = path.resolve(path.dirname(linkPath), raw);
+  return path.resolve(resolved) === path.resolve(expectedTarget);
+}
+
+function installPiSkillsPayload(mode, sourceDir, destPath) {
+  if (mode === 'symlink') {
+    fs.symlinkSync(sourceDir, destPath, 'dir');
+  } else {
+    copyDirRecursive(sourceDir, destPath);
+  }
+}
+
 function installOpencode(ctx) {
   const { say, note, warn, opts, repoRoot, results } = ctx;
   results.detected++;
@@ -795,6 +820,151 @@ function installOpenclaw(ctx) {
   if (r.ok) results.installed.push('openclaw');
   else results.failed.push(['openclaw', r.reason || 'install failed']);
 
+  process.stdout.write('\n');
+}
+
+// pi-coding-agent (earendil-works) — native install.
+// Pi discovers skills from `~/.pi/agent/skills/<pack>/SKILL.md` and reads
+// `~/.pi/agent/AGENTS.md` as always-on rules. No `npx skills add` integration
+// exists upstream — install is a symlink for git checkouts, a copy for
+// package/npx installs, plus a fenced ruleset block. Re-runs are idempotent:
+// the skills pack is recreated only if missing or
+// dangling, and the AGENTS.md block is detected via the same marker fence
+// the opencode installer uses (re-using OPENCODE_AGENTS_MD_BEGIN/END so a
+// later --uninstall can strip our block cleanly).
+function installPi(ctx) {
+  const { say, note, warn, opts, repoRoot, results } = ctx;
+  results.detected++;
+  say('→ pi-coding-agent detected');
+
+  if (!repoRoot) {
+    warn('  pi install requires a local clone or package copy of the caveman repo.');
+    note('  Re-run from a clone: git clone https://github.com/' + REPO + ' && cd caveman && node bin/install.js --only pi');
+    results.failed.push(['pi', 'native install requires local repo/package root']);
+    process.stdout.write('\n');
+    return;
+  }
+
+  const home = os.homedir();
+  const piAgentDir = path.join(home, '.pi', 'agent');
+  const piSkillsDir = path.join(piAgentDir, 'skills');
+  const packName = 'caveman';
+  const linkPath = path.join(piSkillsDir, packName);
+  const linkTarget = path.join(repoRoot, 'skills');
+  // Local git checkouts get a symlink so `git pull` updates installed skills.
+  // Package/npx installs have no durable checkout, so copy the skills pack
+  // instead of leaving ~/.pi pointing at a cache/temp directory.
+  const installMode = fs.existsSync(path.join(repoRoot, '.git')) ? 'symlink' : 'copy';
+
+  const agentsMd = path.join(piAgentDir, 'AGENTS.md');
+
+  if (opts.dryRun) {
+    note(`  would mkdir -p ${piSkillsDir}`);
+    note(installMode === 'symlink'
+      ? `  would symlink ${linkPath} -> ${linkTarget}`
+      : `  would copy ${linkTarget}/ -> ${linkPath}/`);
+    note(`  would append caveman ruleset (fenced) to ${agentsMd} (creating if absent)`);
+    results.installed.push('pi');
+    process.stdout.write('\n');
+    return;
+  }
+
+  try {
+    // 1. Skills payload: symlink for git checkouts, copy for package/npx.
+    fs.mkdirSync(piSkillsDir, { recursive: true });
+    const installPayload = (verb) => {
+      installPiSkillsPayload(installMode, linkTarget, linkPath);
+      process.stdout.write(installMode === 'symlink'
+        ? `  ${verb}: ${linkPath} -> ${linkTarget}\n`
+        : `  ${verb}: ${linkPath}/\n`);
+    };
+
+    let existing = null;
+    try { existing = fs.lstatSync(linkPath); } catch (_) { existing = null; }
+    if (existing) {
+      if (existing.isSymbolicLink()) {
+        if (installMode === 'symlink' && symlinkPointsTo(linkPath, linkTarget)) {
+          if (opts.force) {
+            fs.unlinkSync(linkPath);
+            installPayload('re-symlinked');
+          } else {
+            note(`  ${linkPath} already points at ${linkTarget} (use --force to replace)`);
+          }
+        } else if (opts.force) {
+          fs.unlinkSync(linkPath);
+          installPayload(installMode === 'symlink' ? 're-symlinked' : 'replaced symlink with copied pack');
+        } else {
+          let raw = '<unknown>';
+          try { raw = fs.readlinkSync(linkPath); } catch (_) {}
+          warn(`  ${linkPath} points elsewhere (${raw}) — refusing to overwrite (use --force to replace)`);
+          results.failed.push(['pi', `${linkPath} points elsewhere; use --force`]);
+          process.stdout.write('\n');
+          return;
+        }
+      } else if (existing.isDirectory()) {
+        if (piPackLooksManaged(linkPath)) {
+          if (opts.force) {
+            fs.rmSync(linkPath, { recursive: true, force: true });
+            installPayload(installMode === 'symlink' ? 'replaced copied pack with symlink' : 're-copied');
+          } else {
+            note(`  ${linkPath} already contains a caveman skills pack (use --force to replace)`);
+          }
+        } else if (opts.force) {
+          fs.rmSync(linkPath, { recursive: true, force: true });
+          installPayload(installMode === 'symlink' ? 'replaced directory with symlink' : 'replaced directory with copied pack');
+        } else {
+          warn(`  ${linkPath} exists as a real directory — refusing to overwrite (use --force to replace)`);
+          results.failed.push(['pi', `${linkPath} is a real directory; use --force`]);
+          process.stdout.write('\n');
+          return;
+        }
+      } else {
+        warn(`  ${linkPath} exists and is not a directory/symlink — refusing to touch`);
+        results.failed.push(['pi', `${linkPath} is not a directory/symlink`]);
+        process.stdout.write('\n');
+        return;
+      }
+    } else {
+      installPayload(installMode === 'symlink' ? 'symlinked' : 'copied');
+    }
+
+    // 2. AGENTS.md — append a fenced caveman block. Idempotency mirrors the
+    //    opencode path exactly: BEGIN + END markers allow --uninstall to
+    //    strip just our block even when the user has authored content
+    //    above and below it.
+    const ruleBody = fs.readFileSync(path.join(repoRoot, 'src', 'rules', 'caveman-activate.md'), 'utf8').trimEnd() + '\n';
+    const fencedBlock = `${OPENCODE_AGENTS_MD_BEGIN}\n${ruleBody}${OPENCODE_AGENTS_MD_END}\n`;
+    fs.mkdirSync(piAgentDir, { recursive: true });
+    if (fs.existsSync(agentsMd)) {
+      const existingBody = fs.readFileSync(agentsMd, 'utf8');
+      const alreadyFenced = existingBody.includes(OPENCODE_AGENTS_MD_BEGIN)
+        && existingBody.includes(OPENCODE_AGENTS_MD_END);
+      if (alreadyFenced) {
+        note(`  ${agentsMd} already contains the caveman ruleset`);
+      } else if (existingBody.includes(OPENCODE_AGENTS_MD_SENTINEL)) {
+        note(`  ${agentsMd} contains a legacy (un-fenced) caveman block — leaving as-is`);
+        note('  re-run with --force to replace it with a fenced block');
+        if (opts.force) {
+          // Legacy path didn't fence, so we can't isolate the block — full
+          // rewrite is the only safe option under --force.
+          fs.writeFileSync(agentsMd, fencedBlock, { mode: 0o644 });
+          process.stdout.write(`  rewrote ${agentsMd} with fenced caveman block\n`);
+        }
+      } else {
+        const sep = existingBody.endsWith('\n\n') ? '' : (existingBody.endsWith('\n') ? '\n' : '\n\n');
+        fs.writeFileSync(agentsMd, existingBody + sep + fencedBlock, { mode: 0o644 });
+        process.stdout.write(`  appended caveman ruleset to ${agentsMd}\n`);
+      }
+    } else {
+      fs.writeFileSync(agentsMd, fencedBlock, { mode: 0o644 });
+      process.stdout.write(`  installed: ${agentsMd}\n`);
+    }
+
+    results.installed.push('pi');
+  } catch (e) {
+    warn('  pi install failed: ' + (e && e.message || e));
+    results.failed.push(['pi', (e && e.message) || 'unknown error']);
+  }
   process.stdout.write('\n');
 }
 
@@ -1188,6 +1358,60 @@ function uninstall(ctx) {
     if (r.touched) ok('  pruned caveman entries from OpenClaw workspace');
   }
 
+  // pi-coding-agent native install — remove the skills payload and strip
+  // the fenced caveman block from ~/.pi/agent/AGENTS.md. Only remove the
+  // payload when the AGENTS marker proves caveman installed it; this avoids
+  // deleting a user-authored ~/.pi/agent/skills/caveman symlink/dir that just
+  // happens to share the same name.
+  const piHome = os.homedir();
+  const piPack = path.join(piHome, '.pi', 'agent', 'skills', 'caveman');
+  const piAgentsMd = path.join(piHome, '.pi', 'agent', 'AGENTS.md');
+  const piMdPresent = (() => {
+    if (!fs.existsSync(piAgentsMd)) return false;
+    const body = fs.readFileSync(piAgentsMd, 'utf8');
+    return body.includes(OPENCODE_AGENTS_MD_BEGIN) && body.includes(OPENCODE_AGENTS_MD_END);
+  })();
+  const piPackKind = (() => {
+    try {
+      const st = fs.lstatSync(piPack);
+      if (st.isSymbolicLink()) return 'symlink';
+      if (st.isDirectory() && piPackLooksManaged(piPack)) return 'copied-pack';
+    } catch (_) {}
+    return null;
+  })();
+
+  if (piMdPresent && piPackKind) {
+    if (!opts.dryRun) {
+      try {
+        if (piPackKind === 'symlink') fs.unlinkSync(piPack);
+        else fs.rmSync(piPack, { recursive: true, force: true });
+      } catch (_) {}
+    }
+    note(`  removed ${piPack}`);
+  } else if (piPackKind && !piMdPresent) {
+    note(`  left ${piPack} in place (no caveman AGENTS.md marker found)`);
+  }
+
+  if (piMdPresent) {
+    const body = fs.readFileSync(piAgentsMd, 'utf8');
+    const begin = body.indexOf(OPENCODE_AGENTS_MD_BEGIN);
+    const end = body.indexOf(OPENCODE_AGENTS_MD_END);
+    if (begin !== -1 && end !== -1 && end > begin) {
+      const before = body.slice(0, begin).replace(/\n+$/, '\n');
+      const after = body.slice(end + OPENCODE_AGENTS_MD_END.length).replace(/^\n+/, '\n');
+      let next = (before + after).trimEnd();
+      next = next ? next + '\n' : '';
+      if (!opts.dryRun) {
+        if (next === '') {
+          try { fs.unlinkSync(piAgentsMd); } catch (_) {}
+        } else {
+          fs.writeFileSync(piAgentsMd, next, { mode: 0o644 });
+        }
+      }
+      note(next === '' ? `  removed ${piAgentsMd}` : `  stripped caveman block from ${piAgentsMd}`);
+    }
+  }
+
   // Flag file
   const flag = path.join(configDir, '.caveman-active');
   if (fs.existsSync(flag) && !opts.dryRun) { try { fs.unlinkSync(flag); } catch (_) {} }
@@ -1343,6 +1567,7 @@ async function main() {
     if (prov.id === 'gemini')   { installGemini(ctx); continue; }
     if (prov.id === 'opencode') { installOpencode(ctx); continue; }
     if (prov.id === 'openclaw') { installOpenclaw(ctx); continue; }
+    if (prov.id === 'pi')       { installPi(ctx); continue; }
     if (prov.profile)           { installViaSkills(ctx, prov); continue; }
   }
 

--- a/tests/installer/pi.test.mjs
+++ b/tests/installer/pi.test.mjs
@@ -1,0 +1,297 @@
+// pi-coding-agent (earendil-works) native install — fresh install, idempotency,
+// uninstall.
+//
+// Detection of pi is gated behind `command -v pi` (or `~/.pi/agent` dir), so
+// to run on a CI box without pi installed we shim a `pi` binary onto PATH.
+// The installer's per-provider dispatch only checks PATH presence for
+// `command:` probes; the binary itself is never invoked by the installer.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const INSTALLER = path.join(REPO_ROOT, 'bin', 'install.js');
+
+const IS_WIN = process.platform === 'win32';
+
+function freshTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-pi-'));
+}
+
+function shimPi() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cm-pi-shim-'));
+  if (IS_WIN) {
+    fs.writeFileSync(path.join(dir, 'pi.cmd'), '@echo off\r\n');
+  } else {
+    const f = path.join(dir, 'pi');
+    fs.writeFileSync(f, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(f, 0o755);
+  }
+  return dir;
+}
+
+function runInstallerAt(installer, args, env) {
+  return spawnSync('node', [installer, ...args, '--non-interactive', '--no-mcp-shrink'], {
+    env, encoding: 'utf8',
+  });
+}
+
+function runInstaller(args, env) {
+  return runInstallerAt(INSTALLER, args, env);
+}
+
+function copyNpxLikePackage() {
+  const pkg = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-pi-pkg-'));
+  for (const name of ['bin', 'src', 'agents', 'skills']) {
+    fs.cpSync(path.join(REPO_ROOT, name), path.join(pkg, name), { recursive: true });
+  }
+  return pkg;
+}
+
+function pathWith(prependDir) {
+  const sep = IS_WIN ? ';' : ':';
+  return prependDir + sep + (process.env.PATH || '');
+}
+
+// ── 1. Fresh install: symlink + fenced AGENTS.md ─────────────────────────
+test('pi fresh install creates skills symlink and fenced AGENTS.md block', () => {
+  const fakeHome = freshTmpDir();
+  const shimDir = shimPi();
+  try {
+    const r = runInstaller(['--only', 'pi'], {
+      ...process.env,
+      HOME: fakeHome,
+      USERPROFILE: fakeHome,
+      PATH: pathWith(shimDir),
+      NO_COLOR: '1',
+    });
+    assert.notEqual(r.status, 2, `argv error: ${r.stderr}`);
+
+    const piAgentDir = path.join(fakeHome, '.pi', 'agent');
+    const linkPath = path.join(piAgentDir, 'skills', 'caveman');
+    const agentsMd = path.join(piAgentDir, 'AGENTS.md');
+
+    // Symlink exists, points to repo skills, resolves to SKILL.md files.
+    assert.ok(fs.lstatSync(linkPath).isSymbolicLink(), 'skills/caveman should be a symlink');
+    const target = fs.readlinkSync(linkPath);
+    assert.equal(target, path.join(REPO_ROOT, 'skills'), 'symlink target should be repo skills/');
+    for (const name of ['caveman', 'caveman-commit', 'caveman-compress', 'caveman-help', 'caveman-review', 'caveman-stats', 'cavecrew']) {
+      assert.ok(
+        fs.existsSync(path.join(linkPath, name, 'SKILL.md')),
+        `resolved skill ${name}/SKILL.md should exist via the symlink`,
+      );
+    }
+
+    // AGENTS.md exists, contains the fenced caveman block.
+    assert.ok(fs.existsSync(agentsMd), 'AGENTS.md should be created');
+    const body = fs.readFileSync(agentsMd, 'utf8');
+    assert.ok(body.includes('<!-- caveman-begin -->'), 'AGENTS.md should include BEGIN marker');
+    assert.ok(body.includes('<!-- caveman-end -->'), 'AGENTS.md should include END marker');
+    assert.ok(body.includes('Respond terse like smart caveman'), 'AGENTS.md should include the rule body');
+  } finally {
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+// ── 2. Idempotency: re-run does not duplicate the fence ─────────────────
+test('pi re-install is idempotent — re-run keeps a single fenced block', () => {
+  const fakeHome = freshTmpDir();
+  const shimDir = shimPi();
+  try {
+    const env = {
+      ...process.env, HOME: fakeHome, USERPROFILE: fakeHome,
+      PATH: pathWith(shimDir), NO_COLOR: '1',
+    };
+    const r1 = runInstaller(['--only', 'pi'], env);
+    assert.equal(r1.status, 0, `first install failed: ${r1.stderr}`);
+
+    const agentsMd = path.join(fakeHome, '.pi', 'agent', 'AGENTS.md');
+    const before = fs.readFileSync(agentsMd, 'utf8');
+    const beginCount = (before.match(/<!-- caveman-begin -->/g) || []).length;
+
+    const r2 = runInstaller(['--only', 'pi'], env);
+    assert.equal(r2.status, 0, `re-install failed: ${r2.stderr}`);
+
+    const after = fs.readFileSync(agentsMd, 'utf8');
+    const beginAfter = (after.match(/<!-- caveman-begin -->/g) || []).length;
+    assert.equal(beginAfter, beginCount, 're-install must not append a second fence');
+  } finally {
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+// ── 3. Uninstall: removes symlink and strips the fenced block ────────────
+test('pi uninstall removes the skills symlink and strips the AGENTS.md block', () => {
+  const fakeHome = freshTmpDir();
+  const shimDir = shimPi();
+  try {
+    const env = {
+      ...process.env, HOME: fakeHome, USERPROFILE: fakeHome,
+      PATH: pathWith(shimDir), NO_COLOR: '1',
+    };
+    runInstaller(['--only', 'pi'], env);
+    const linkPath = path.join(fakeHome, '.pi', 'agent', 'skills', 'caveman');
+    const agentsMd = path.join(fakeHome, '.pi', 'agent', 'AGENTS.md');
+    assert.ok(fs.lstatSync(linkPath).isSymbolicLink(), 'precondition: symlink should exist');
+    assert.ok(fs.existsSync(agentsMd), 'precondition: AGENTS.md should exist');
+
+    const r = runInstaller(['--uninstall', '--only', 'pi'], env);
+    assert.equal(r.status, 0, `uninstall failed: ${r.stderr}`);
+
+    assert.equal(fs.existsSync(linkPath), false, 'symlink should be removed');
+    assert.equal(fs.existsSync(agentsMd), false, 'AGENTS.md should be removed (was 100% our block)');
+  } finally {
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+// ── 4. Uninstall with user-authored content above the fence: preserved ──
+test('pi uninstall preserves user-authored content above the fenced block', () => {
+  const fakeHome = freshTmpDir();
+  const shimDir = shimPi();
+  try {
+    const piAgentDir = path.join(fakeHome, '.pi', 'agent');
+    fs.mkdirSync(piAgentDir, { recursive: true });
+    const userHeader = '# My agent notes\n\ndo not delete me.\n';
+    fs.writeFileSync(path.join(piAgentDir, 'AGENTS.md'), userHeader, { mode: 0o644 });
+
+    const env = {
+      ...process.env, HOME: fakeHome, USERPROFILE: fakeHome,
+      PATH: pathWith(shimDir), NO_COLOR: '1',
+    };
+    runInstaller(['--only', 'pi'], env);
+
+    const agentsMd = path.join(piAgentDir, 'AGENTS.md');
+    const afterInstall = fs.readFileSync(agentsMd, 'utf8');
+    assert.ok(afterInstall.startsWith(userHeader), 'install must preserve user header above the fence');
+
+    runInstaller(['--uninstall', '--only', 'pi'], env);
+
+    const afterUninstall = fs.readFileSync(agentsMd, 'utf8');
+    assert.equal(afterUninstall, userHeader, 'uninstall must leave only the user-authored header');
+  } finally {
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+// ── 5. Refuses to overwrite a real (non-symlink) directory ───────────────
+test('pi install refuses to overwrite a real directory at the symlink path', () => {
+  const fakeHome = freshTmpDir();
+  const shimDir = shimPi();
+  try {
+    const realDir = path.join(fakeHome, '.pi', 'agent', 'skills', 'caveman');
+    fs.mkdirSync(realDir, { recursive: true });
+    fs.writeFileSync(path.join(realDir, 'user-skill.md'), '# mine');
+
+    const r = runInstaller(['--only', 'pi'], {
+      ...process.env,
+      HOME: fakeHome,
+      USERPROFILE: fakeHome,
+      PATH: pathWith(shimDir),
+      NO_COLOR: '1',
+    });
+
+    // The installer should refuse without --force and leave the real dir intact.
+    assert.match(r.stdout + r.stderr, /refusing to overwrite/, 'installer should report refusal');
+    assert.ok(fs.existsSync(path.join(realDir, 'user-skill.md')), 'user content must not be deleted');
+    assert.equal(fs.lstatSync(realDir).isSymbolicLink(), false, 'real dir must not be replaced by symlink');
+  } finally {
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+// ── 6. npx/package install: copy, do not symlink to temp cache ───────────
+test('pi install from a package without .git copies skills instead of creating a fragile symlink', () => {
+  const fakeHome = freshTmpDir();
+  const shimDir = shimPi();
+  const pkg = copyNpxLikePackage();
+  try {
+    const r = runInstallerAt(path.join(pkg, 'bin', 'install.js'), ['--only', 'pi'], {
+      ...process.env,
+      HOME: fakeHome,
+      USERPROFILE: fakeHome,
+      PATH: pathWith(shimDir),
+      NO_COLOR: '1',
+    });
+    assert.equal(r.status, 0, `package install failed: ${r.stderr}\n${r.stdout}`);
+
+    const packPath = path.join(fakeHome, '.pi', 'agent', 'skills', 'caveman');
+    assert.equal(fs.lstatSync(packPath).isSymbolicLink(), false, 'package install should copy, not symlink');
+    for (const name of ['caveman', 'caveman-commit', 'caveman-compress', 'caveman-help', 'caveman-review', 'caveman-stats', 'cavecrew']) {
+      assert.ok(
+        fs.existsSync(path.join(packPath, name, 'SKILL.md')),
+        `copied skill ${name}/SKILL.md should exist`,
+      );
+    }
+  } finally {
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+    fs.rmSync(pkg, { recursive: true, force: true });
+  }
+});
+
+// ── 7. Existing wrong symlink: refuse without --force ────────────────────
+test('pi install refuses to accept an existing symlink that points elsewhere', () => {
+  const fakeHome = freshTmpDir();
+  const shimDir = shimPi();
+  try {
+    const linkPath = path.join(fakeHome, '.pi', 'agent', 'skills', 'caveman');
+    const wrongTarget = path.join(fakeHome, 'other-skills');
+    fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+    fs.mkdirSync(wrongTarget, { recursive: true });
+    fs.symlinkSync(wrongTarget, linkPath, 'dir');
+
+    const r = runInstaller(['--only', 'pi'], {
+      ...process.env,
+      HOME: fakeHome,
+      USERPROFILE: fakeHome,
+      PATH: pathWith(shimDir),
+      NO_COLOR: '1',
+    });
+
+    assert.match(r.stdout + r.stderr, /points elsewhere|use --force/, 'installer should report wrong symlink');
+    assert.equal(fs.readlinkSync(linkPath), wrongTarget, 'wrong symlink should be left untouched');
+    assert.equal(fs.existsSync(path.join(fakeHome, '.pi', 'agent', 'AGENTS.md')), false, 'AGENTS.md should not be written after symlink refusal');
+  } finally {
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+// ── 8. Uninstall removes copied package install ──────────────────────────
+test('pi uninstall removes copied package skills and strips AGENTS.md', () => {
+  const fakeHome = freshTmpDir();
+  const shimDir = shimPi();
+  const pkg = copyNpxLikePackage();
+  try {
+    const installer = path.join(pkg, 'bin', 'install.js');
+    const env = {
+      ...process.env,
+      HOME: fakeHome,
+      USERPROFILE: fakeHome,
+      PATH: pathWith(shimDir),
+      NO_COLOR: '1',
+    };
+    const install = runInstallerAt(installer, ['--only', 'pi'], env);
+    assert.equal(install.status, 0, `package install failed: ${install.stderr}\n${install.stdout}`);
+
+    const packPath = path.join(fakeHome, '.pi', 'agent', 'skills', 'caveman');
+    const agentsMd = path.join(fakeHome, '.pi', 'agent', 'AGENTS.md');
+    assert.equal(fs.lstatSync(packPath).isSymbolicLink(), false, 'precondition: copied pack should be a real dir');
+    assert.ok(fs.existsSync(path.join(packPath, 'caveman', 'SKILL.md')), 'precondition: copied skill exists');
+    assert.ok(fs.existsSync(agentsMd), 'precondition: AGENTS.md exists');
+
+    const uninstall = runInstallerAt(installer, ['--uninstall', '--only', 'pi'], env);
+    assert.equal(uninstall.status, 0, `uninstall failed: ${uninstall.stderr}\n${uninstall.stdout}`);
+
+    assert.equal(fs.existsSync(packPath), false, 'copied pack should be removed');
+    assert.equal(fs.existsSync(agentsMd), false, 'AGENTS.md should be removed (was 100% our block)');
+  } finally {
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+    fs.rmSync(pkg, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add pi-coding-agent (earendil-works) to the provider matrix
- install Pi skills via symlink for local git checkouts, copy for package/npx installs
- append/remove fenced caveman AGENTS.md block safely
- add Pi installer tests for symlink, package copy, idempotency, uninstall, and refusal cases

## Tests
- node --check bin/install.js
- node --test tests/installer/pi.test.mjs (8/8 pass)
- npm test (79/81 pass; 2 pre-existing env-dependent failures in baseline)