### PR TITLE
feat(cursor): SessionStart/UserPromptSubmit hook parity for CLI + IDE

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -24,6 +24,7 @@ const crypto = require('crypto');
 
 const SETTINGS = require('./lib/settings');
 const OPENCLAW = require('./lib/openclaw');
+const CURSOR = require('./lib/cursor');
 const { stripOpencodeAgentTools } = require('./lib/opencode-agent');
 
 const REPO = 'JuliusBrussee/caveman';
@@ -540,7 +541,7 @@ function installGemini(ctx) {
 }
 
 function installViaSkills(ctx, prov) {
-  const { say, opts, results } = ctx;
+  const { say, note, opts, results, repoRoot } = ctx;
   results.detected++;
   say(`→ ${prov.label} detected`);
   // --skill '*' --yes: skip the upstream skill-selection TUI and confirmation
@@ -555,8 +556,20 @@ function installViaSkills(ctx, prov) {
   // documented form for "install every skill into a specific agent".
   const args = ['-y', 'skills', 'add', REPO, '--skill', '*', '-a', prov.profile, '--yes'];
   const r = runSpawn('npx', args, null, opts.dryRun);
-  if ((r.status || 0) === 0) results.installed.push(prov.id);
-  else results.failed.push([prov.id, `npx skills add (${prov.profile}) failed`]);
+  if ((r.status || 0) === 0) {
+    results.installed.push(prov.id);
+    if (prov.id === 'cursor' && opts.withHooks !== false) {
+      say('  → installing Cursor hooks (~/.cursor/hooks.json)');
+      const hookResult = CURSOR.installCursorHooks({
+        repoRoot,
+        dryRun: opts.dryRun,
+        log: { note: (s) => note(s) },
+      });
+      if (hookResult.kind === 'ok') results.installed.push('cursor-hooks');
+      else if (hookResult.kind === 'skip') results.skipped.push(['cursor-hooks', hookResult.why || 'already wired']);
+      else results.failed.push(['cursor-hooks', hookResult.why || 'install failed']);
+    }
+  } else results.failed.push([prov.id, `npx skills add (${prov.profile}) failed`]);
   process.stdout.write('\n');
 }
 
@@ -1188,6 +1201,9 @@ function uninstall(ctx) {
     if (r.touched) ok('  pruned caveman entries from OpenClaw workspace');
   }
 
+  // Cursor user hooks (~/.cursor/hooks.json + adapters).
+  CURSOR.uninstallCursorHooks({ dryRun: opts.dryRun, log: { note: (s) => note(s) } });
+
   // Flag file
   const flag = path.join(configDir, '.caveman-active');
   if (fs.existsSync(flag) && !opts.dryRun) { try { fs.unlinkSync(flag); } catch (_) {} }
@@ -1253,8 +1269,9 @@ FLAGS
   --all                 Turn on hooks + init. (mcp-shrink needs an upstream;
                         pass --with-mcp-shrink="<cmd>" to add it.)
   --minimal             Just the plugin/extension install.
-  --with-hooks          Claude Code: install SessionStart/UserPromptSubmit hooks
-                        + statusline badge. (Default ON.)
+  --with-hooks          Claude Code: SessionStart/UserPromptSubmit hooks +
+                        statusline badge. Cursor: ~/.cursor/hooks.json +
+                        CLI statusLine when absent. (Default ON.)
   --no-hooks            Skip the hooks installer.
   --with-init           Write per-repo IDE rule files into \$PWD.
   --with-mcp-shrink="<upstream cmd>"

--- a/bin/lib/cursor.js
+++ b/bin/lib/cursor.js
@@ -1,0 +1,180 @@
+// caveman — Cursor CLI/IDE hook installer.
+//
+// Wires SessionStart + UserPromptSubmit parity via ~/.cursor/hooks.json and
+// optional statusLine in ~/.cursor/cli-config.json.
+//
+// Pure stdlib, CommonJS.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const HOOK_SCRIPT_NAMES = [
+  'caveman-config.js',
+  'caveman-activate.js',
+  'caveman-mode-tracker.js',
+  'caveman-stats.js',
+  'caveman-statusline.sh',
+];
+
+const ADAPTER_NAMES = [
+  'caveman-session-start.js',
+  'caveman-prompt-submit.js',
+];
+
+const CAVEMAN_MARKER = 'caveman-session-start.js';
+
+function cursorConfigDir() {
+  return path.join(os.homedir(), '.cursor');
+}
+
+function cursorHooksDir() {
+  return path.join(cursorConfigDir(), 'hooks');
+}
+
+function cursorHooksJsonPath() {
+  return path.join(cursorConfigDir(), 'hooks.json');
+}
+
+function cursorCliConfigPath() {
+  return path.join(cursorConfigDir(), 'cli-config.json');
+}
+
+function repoHooksDir(repoRoot) {
+  return path.join(repoRoot, 'src', 'hooks');
+}
+
+function repoCursorDir(repoRoot) {
+  return path.join(repoRoot, 'src', 'hooks', 'cursor');
+}
+
+function readJsonFile(p) {
+  if (!fs.existsSync(p)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch (_) {
+    return null;
+  }
+}
+
+function writeJsonFile(p, obj) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(obj, null, 2) + '\n', { mode: 0o644 });
+}
+
+function mergeCursorHooks(existing) {
+  const base = existing && typeof existing === 'object' ? existing : { version: 1, hooks: {} };
+  if (!base.hooks || typeof base.hooks !== 'object') base.hooks = {};
+  base.version = 1;
+  base.hooks.sessionStart = [{ command: './hooks/caveman-session-start.js' }];
+  base.hooks.beforeSubmitPrompt = [{ command: './hooks/caveman-prompt-submit.js' }];
+  return base;
+}
+
+function hooksJsonHasCaveman(obj) {
+  if (!obj || !obj.hooks) return false;
+  const events = ['sessionStart', 'beforeSubmitPrompt'];
+  return events.some((ev) => {
+    const arr = obj.hooks[ev];
+    if (!Array.isArray(arr)) return false;
+    return arr.some((entry) => typeof entry.command === 'string' && entry.command.includes(CAVEMAN_MARKER));
+  });
+}
+
+function installCursorHooks({ repoRoot, dryRun, log }) {
+  const hooksSrc = repoHooksDir(repoRoot);
+  const cursorSrc = repoCursorDir(repoRoot);
+  const hooksDir = cursorHooksDir();
+  const hooksJson = cursorHooksJsonPath();
+  const cliConfig = cursorCliConfigPath();
+
+  if (!fs.existsSync(hooksSrc) || !fs.existsSync(cursorSrc)) {
+    return { kind: 'fail', why: 'repo hook sources missing (src/hooks or src/hooks/cursor)' };
+  }
+
+  if (dryRun) {
+    log.note(`  would mkdir -p ${hooksDir}`);
+    for (const f of [...HOOK_SCRIPT_NAMES, ...ADAPTER_NAMES]) log.note(`  would install ${path.join(hooksDir, f)}`);
+    log.note(`  would merge caveman entries into ${hooksJson}`);
+    log.note(`  would merge statusLine into ${cliConfig} (if absent)`);
+    return { kind: 'ok' };
+  }
+
+  fs.mkdirSync(hooksDir, { recursive: true });
+
+  for (const f of HOOK_SCRIPT_NAMES) {
+    fs.copyFileSync(path.join(hooksSrc, f), path.join(hooksDir, f));
+  }
+  for (const f of ADAPTER_NAMES) {
+    fs.copyFileSync(path.join(cursorSrc, f), path.join(hooksDir, f));
+  }
+  try { fs.chmodSync(path.join(hooksDir, 'caveman-statusline.sh'), 0o755); } catch (_) {}
+  for (const f of ADAPTER_NAMES) {
+    try { fs.chmodSync(path.join(hooksDir, f), 0o755); } catch (_) {}
+  }
+
+  const existingHooks = readJsonFile(hooksJson);
+  if (existingHooks === null) {
+    return { kind: 'fail', why: `${hooksJson} is not valid JSON` };
+  }
+  writeJsonFile(hooksJson, mergeCursorHooks(existingHooks));
+
+  const cli = readJsonFile(cliConfig);
+  if (cli === null) {
+    return { kind: 'fail', why: `${cliConfig} is not valid JSON` };
+  }
+  if (!cli.statusLine) {
+    cli.statusLine = {
+      type: 'command',
+      command: `bash ${path.join(hooksDir, 'caveman-statusline.sh')}`,
+    };
+    writeJsonFile(cliConfig, cli);
+  }
+
+  return { kind: 'ok' };
+}
+
+function uninstallCursorHooks({ dryRun, log }) {
+  const hooksDir = cursorHooksDir();
+  const hooksJson = cursorHooksJsonPath();
+
+  if (dryRun) {
+    log.note(`  would remove caveman hook scripts from ${hooksDir}`);
+    log.note(`  would prune caveman entries from ${hooksJson}`);
+    return { kind: 'ok' };
+  }
+
+  for (const f of [...HOOK_SCRIPT_NAMES, ...ADAPTER_NAMES]) {
+    try { fs.unlinkSync(path.join(hooksDir, f)); } catch (_) {}
+  }
+
+  const existing = readJsonFile(hooksJson);
+  if (existing && existing.hooks) {
+    for (const ev of ['sessionStart', 'beforeSubmitPrompt']) {
+      if (!Array.isArray(existing.hooks[ev])) continue;
+      existing.hooks[ev] = existing.hooks[ev].filter(
+        (entry) => !(typeof entry.command === 'string' && entry.command.includes('caveman'))
+      );
+      if (existing.hooks[ev].length === 0) delete existing.hooks[ev];
+    }
+    writeJsonFile(hooksJson, existing);
+  }
+
+  return { kind: 'ok' };
+}
+
+module.exports = {
+  HOOK_SCRIPT_NAMES,
+  ADAPTER_NAMES,
+  CAVEMAN_MARKER,
+  cursorConfigDir,
+  cursorHooksDir,
+  cursorHooksJsonPath,
+  cursorCliConfigPath,
+  mergeCursorHooks,
+  hooksJsonHasCaveman,
+  installCursorHooks,
+  uninstallCursorHooks,
+};

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -105,6 +105,14 @@ npx -y github:JuliusBrussee/caveman -- --uninstall
 node bin/install.js --uninstall
 ```
 
+## Cursor (CLI + IDE)
+
+Cursor uses a separate user hook surface at `~/.cursor/hooks.json`. See [`cursor/README.md`](cursor/README.md) for the adapter layout and install/uninstall notes. The unified installer wires these when you run:
+
+```bash
+node bin/install.js --only cursor
+```
+
 Or manually:
 1. Remove the caveman hook files from `$CLAUDE_CONFIG_DIR/hooks/` (default `~/.claude/hooks/`): `caveman-activate.js`, `caveman-mode-tracker.js`, `caveman-stats.js`, `caveman-config.js`, and `caveman-statusline.{sh,ps1}`.
 2. Remove the SessionStart, UserPromptSubmit, and statusLine entries from `$CLAUDE_CONFIG_DIR/settings.json`.

--- a/src/hooks/cursor/README.md
+++ b/src/hooks/cursor/README.md
@@ -1,0 +1,63 @@
+# Caveman hooks for Cursor (CLI + IDE)
+
+Cursor runs hooks from `~/.cursor/hooks.json` with a JSON contract that differs slightly from Claude Code's hook stdout format. These adapters bridge the existing caveman hook scripts to Cursor.
+
+## Installed layout
+
+The unified installer (`bin/install.js --only cursor`, or auto-detect when Cursor is present) writes:
+
+```
+~/.cursor/
+├── hooks.json
+└── hooks/
+    ├── caveman-activate.js          # from src/hooks/
+    ├── caveman-mode-tracker.js
+    ├── caveman-config.js
+    ├── caveman-stats.js
+    ├── caveman-statusline.sh
+    ├── caveman-session-start.js     # Cursor adapter (this directory)
+    └── caveman-prompt-submit.js
+```
+
+Optional CLI badge (when `~/.cursor/cli-config.json` has no custom statusLine):
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.cursor/hooks/caveman-statusline.sh"
+  }
+}
+```
+
+## Event mapping
+
+| Caveman (Claude Code) | Cursor hook | Adapter output |
+| --- | --- | --- |
+| `SessionStart` | `sessionStart` | `{ "additional_context": "..." }` |
+| `UserPromptSubmit` | `beforeSubmitPrompt` | passthrough JSON (`hookSpecificOutput`, stats block, etc.) |
+
+Shared state uses the same flag file as Claude Code: `$CLAUDE_CONFIG_DIR/.caveman-active` (default `~/.claude/.caveman-active`).
+
+## Manual install
+
+From a repo clone:
+
+```bash
+node bin/install.js --only cursor
+```
+
+Or copy this directory's adapters plus `src/hooks/caveman-*.js` into `~/.cursor/hooks/` and merge `hooks.json` into `~/.cursor/hooks.json`.
+
+## Uninstall
+
+```bash
+npx -y github:JuliusBrussee/caveman -- --uninstall
+```
+
+Removes Cursor hook entries when the unified uninstall runs. Or delete the caveman files under `~/.cursor/hooks/` and the `sessionStart` / `beforeSubmitPrompt` entries from `~/.cursor/hooks.json`.
+
+## References
+
+- [Cursor hooks](https://cursor.com/docs/hooks)
+- [Third-party / Claude Code hook compatibility](https://cursor.com/docs/reference/third-party-hooks)

--- a/src/hooks/cursor/caveman-prompt-submit.js
+++ b/src/hooks/cursor/caveman-prompt-submit.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// Cursor beforeSubmitPrompt adapter — wraps caveman-mode-tracker.js.
+// Maps Claude Code UserPromptSubmit behavior to Cursor's beforeSubmitPrompt hook.
+// Docs: https://cursor.com/docs/reference/third-party-hooks
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+  });
+}
+
+async function main() {
+  const input = await readStdin();
+  let payload = { prompt: input.trim() };
+  try {
+    const parsed = JSON.parse(input);
+    if (parsed && typeof parsed.prompt === 'string') payload = parsed;
+  } catch (_) { /* plain string fallback */ }
+
+  const script = path.join(__dirname, 'caveman-mode-tracker.js');
+  const result = spawnSync(process.execPath, [script], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    env: process.env,
+  });
+
+  const out = (result.stdout || '').trim();
+  if (!out) {
+    process.stdout.write(JSON.stringify({ continue: true }));
+    return;
+  }
+
+  try {
+    JSON.parse(out);
+    process.stdout.write(out);
+  } catch (_) {
+    process.stdout.write(JSON.stringify({ continue: true, additional_context: out }));
+  }
+}
+
+main().catch(() => {
+  process.stdout.write(JSON.stringify({ continue: true }));
+});

--- a/src/hooks/cursor/caveman-session-start.js
+++ b/src/hooks/cursor/caveman-session-start.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Cursor sessionStart adapter — wraps caveman-activate.js for Cursor's JSON hook contract.
+// Docs: https://cursor.com/docs/hooks#sessionstart
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const script = path.join(__dirname, 'caveman-activate.js');
+const result = spawnSync(process.execPath, [script], {
+  encoding: 'utf8',
+  env: process.env,
+});
+
+const context = (result.stdout || '').trim();
+if (!context) process.exit(0);
+
+process.stdout.write(JSON.stringify({ additional_context: context }));

--- a/src/hooks/cursor/hooks.json
+++ b/src/hooks/cursor/hooks.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "./hooks/caveman-session-start.js"
+      }
+    ],
+    "beforeSubmitPrompt": [
+      {
+        "command": "./hooks/caveman-prompt-submit.js"
+      }
+    ]
+  }
+}

--- a/tests/test_caveman_cursor.js
+++ b/tests/test_caveman_cursor.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Tests for bin/lib/cursor.js — Cursor hook installer helpers.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+const {
+  mergeCursorHooks,
+  hooksJsonHasCaveman,
+  installCursorHooks,
+  uninstallCursorHooks,
+} = require('../bin/lib/cursor.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`  ✗ ${name}\n    ${e.message}`);
+  }
+}
+
+console.log('cursor hook installer tests\n');
+
+test('mergeCursorHooks adds sessionStart + beforeSubmitPrompt entries', () => {
+  const merged = mergeCursorHooks({ version: 1, hooks: { stop: [{ command: './hooks/other.js' }] } });
+  assert.strictEqual(merged.hooks.sessionStart[0].command, './hooks/caveman-session-start.js');
+  assert.strictEqual(merged.hooks.beforeSubmitPrompt[0].command, './hooks/caveman-prompt-submit.js');
+  assert.strictEqual(merged.hooks.stop[0].command, './hooks/other.js');
+});
+
+test('hooksJsonHasCaveman detects adapter command', () => {
+  assert.strictEqual(hooksJsonHasCaveman(mergeCursorHooks({})), true);
+  assert.strictEqual(hooksJsonHasCaveman({ version: 1, hooks: {} }), false);
+});
+
+test('install + uninstall round-trip in temp HOME', () => {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-cursor-test-'));
+  const prevHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  try {
+    const repoRoot = path.resolve(__dirname, '..');
+    const log = { note: () => {} };
+    const r = installCursorHooks({ repoRoot, dryRun: false, log });
+    assert.strictEqual(r.kind, 'ok');
+    assert.ok(fs.existsSync(path.join(tmpHome, '.cursor/hooks/caveman-activate.js')));
+    assert.ok(fs.existsSync(path.join(tmpHome, '.cursor/hooks/caveman-session-start.js')));
+    const hooksJson = JSON.parse(fs.readFileSync(path.join(tmpHome, '.cursor/hooks.json'), 'utf8'));
+    assert.ok(hooksJsonHasCaveman(hooksJson));
+    const cli = JSON.parse(fs.readFileSync(path.join(tmpHome, '.cursor/cli-config.json'), 'utf8'));
+    assert.ok(cli.statusLine && cli.statusLine.command.includes('caveman-statusline.sh'));
+    uninstallCursorHooks({ dryRun: false, log });
+    assert.ok(!fs.existsSync(path.join(tmpHome, '.cursor/hooks/caveman-activate.js')));
+  } finally {
+    process.env.HOME = prevHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Summary

Adds first-class Cursor hook support so `agent` (CLI) and the IDE get the same SessionStart + UserPromptSubmit behavior Claude Code users already get from the caveman plugin.

- **`src/hooks/cursor/`** — thin adapters mapping Cursor's JSON hook contract to existing `caveman-activate.js` / `caveman-mode-tracker.js`
- **`bin/lib/cursor.js`** — installs into `~/.cursor/hooks/` + merges `~/.cursor/hooks.json`
- **`bin/install.js --only cursor`** — wires hooks after `npx skills add … -a cursor`
- **CLI statusLine** — merges `caveman-statusline.sh` into `~/.cursor/cli-config.json` when no custom statusLine exists
- **`tests/test_caveman_cursor.js`** — install/uninstall round-trip

## Layout after install

```
~/.cursor/
├── hooks.json
└── hooks/
    ├── caveman-activate.js
    ├── caveman-mode-tracker.js
    ├── caveman-config.js
    ├── caveman-stats.js
    ├── caveman-statusline.sh
    ├── caveman-session-start.js      # adapter
    └── caveman-prompt-submit.js      # adapter
```

Shared flag file unchanged: `~/.claude/.caveman-active`.

## Event mapping

| Claude Code | Cursor | Adapter output |
|-------------|--------|----------------|
| `SessionStart` | `sessionStart` | `{ "additional_context": "…" }` |
| `UserPromptSubmit` | `beforeSubmitPrompt` | passthrough (`hookSpecificOutput`, `/caveman-stats`, etc.) |

## Test plan

- [x] `node tests/test_caveman_cursor.js`
- [x] `node bin/install.js --only cursor --dry-run`
- [ ] Manual: new `agent` session → `/caveman ultra` toggles flag + statusline badge
- [ ] Manual: `/caveman-stats` prints stats (may block prompt like CC)

## Notes

- Respects `--no-hooks` / `--minimal` (skips Cursor hook wiring)
- Uninstall path calls `uninstallCursorHooks()` to prune caveman entries
- Verified on Fujitora (Ubuntu 24.04, Cursor CLI 2026.06.19, IDE 3.8.11)


Made with [Cursor](https://cursor.com)