### PR TITLE
Fix: CJK text immediately before a tool call can truncate the turn

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -24,6 +24,8 @@ Preserve user's dominant language. User write Portuguese → reply Portuguese ca
 
 No self-reference. Never name or announce the style. No "caveman mode on", "me caveman think", no third-person caveman tags. Output caveman-only — never normal answer plus "Caveman:" recap. Exception: user explicitly ask what the mode is.
 
+CJK + tool calls: never place CJK (Chinese/Japanese/Korean) text **immediately before a tool call** or structured XML/code block. CJK characters abutting tool-call markup can corrupt or truncate the emitted call, cutting the turn off at the tool boundary. When a turn uses tool calls, keep surrounding narration in English (or omit it); write the CJK summary only **after** all tool calls finish.
+
 Pattern: `[thing] [action] [reason]. [next step].`
 
 Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -126,7 +126,9 @@ process.stdin.on('end', () => {
           hookEventName: "UserPromptSubmit",
           additionalContext: "CAVEMAN MODE ACTIVE (" + activeMode + "). " +
             "Drop articles/filler/pleasantries/hedging. Fragments OK. " +
-            "Code/commits/security: write normal."
+            "Code/commits/security: write normal. " +
+            "CJK (Chinese/JP/KR) + tool calls: never put CJK text right before a tool call " +
+            "(can truncate the turn) — narrate in English around tools, summarize in CJK after."
         }
       }));
     }


### PR DESCRIPTION
## Problem

When caveman is active and the user works in a **CJK language** (Chinese/Japanese/Korean), turns that include **tool calls** are frequently cut off at the tool-call boundary. The visible truncation always spans from a garbled fragment of the tool-call wrapper through `</invoke>` — i.e. the structured tool-call markup itself is corrupted/truncated, not the prose.

Key signals from a user report:

- Pure **English** workflows never truncate.
- Only **CJK + caveman + tool calls** truncates, with high frequency.
- A user-confirmed workaround — *work/narrate in English, write the CJK summary only after tools finish* — eliminated the truncation entirely.

## Root cause (best current understanding)

CJK characters placed immediately before a tool call abut the structured tool-call markup; the model's tool-call emission destabilizes at that boundary and the turn is cut. This is fundamentally a model/client tool-call-emission interaction with multibyte text — but **caveman is the trigger**, because it pushes the model to interleave terse CJK prose tightly against tool calls.

## Fix

Encode the confirmed workaround as a rule, so users do not have to discover/repeat it:

- `skills/caveman/SKILL.md` — never place CJK text immediately before a tool call; narrate around tools in English (or omit), write the CJK summary only after all tool calls finish.
- `src/hooks/caveman-mode-tracker.js` — same rule appended to the per-turn reinforcement, so it survives context compaction in long sessions.

Mitigation is from the skill side (steering prose/tool-call layout); it does not require any client change.

## Repro

1. Enable caveman (`full`), converse in Chinese.
2. Ask for a task needing several tool calls (write a file, run a command).
3. Observe the turn cut off at the tool-call boundary: CJK prose immediately followed by a truncated tool call.
4. Apply this patch (or the English-narration workaround) → no more truncation.
