### PR TITLE
fix(hooks): handle stdin 'error' in mode-tracker (#538)

### DIFF
--- a/tests/test_mode_tracker_stdin.js
+++ b/tests/test_mode_tracker_stdin.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Tests for the stdin 'error' handler in caveman-mode-tracker.js.
+// Covers issue #538: an abnormal stdin close (broken pipe, parent crash) emits
+// an 'error' event on process.stdin; without a listener Node throws it as an
+// uncaught exception and the hook exits non-zero — a spurious hook failure.
+//
+// Run: node tests/test_mode_tracker_stdin.js
+
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const HOOK_PATH = path.resolve(__dirname, '..', 'src', 'hooks', 'caveman-mode-tracker.js');
+const CLEAN_EXIT = 0;
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${e.message}`);
+  }
+}
+
+console.log('caveman-mode-tracker stdin error handling\n');
+
+// Load the REAL hook in a child, then emit an 'error' on process.stdin to
+// simulate an abnormal close. stdin is left open (never closed) so the only
+// event that fires is the injected 'error' — isolating the handler under test.
+function runWithStdinError() {
+  const harness =
+    `require(${JSON.stringify(HOOK_PATH)});` +
+    `setImmediate(() => process.stdin.emit('error', new Error('EPIPE (simulated)')));`;
+  return spawnSync(process.execPath, ['-e', harness], {
+    stdio: ['pipe', 'ignore', 'pipe'],
+    encoding: 'utf8',
+  });
+}
+
+test('stdin "error" event does not crash the hook (exit 0)', () => {
+  const res = runWithStdinError();
+  assert.strictEqual(
+    res.status,
+    CLEAN_EXIT,
+    `expected clean exit on stdin error, got status=${res.status} signal=${res.signal}\n` +
+      `stderr: ${(res.stderr || '').trim()}`
+  );
+  assert.ok(
+    !/Unhandled 'error' event/.test(res.stderr || ''),
+    `hook leaked an uncaught stdin error:\n${(res.stderr || '').trim()}`
+  );
+});
+
+// Regression guard: the new listener must not disturb the normal path — a valid
+// prompt piped on stdin, then a clean EOF, still exits 0.
+test('normal stdin (valid JSON + clean EOF) still exits 0', () => {
+  const tmpConfig = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-tracker-stdin-'));
+  try {
+    const res = spawnSync(process.execPath, [HOOK_PATH], {
+      input: JSON.stringify({ prompt: 'hello there' }),
+      env: { ...process.env, CLAUDE_CONFIG_DIR: tmpConfig },
+      stdio: ['pipe', 'ignore', 'pipe'],
+      encoding: 'utf8',
+    });
+    assert.strictEqual(
+      res.status,
+      CLEAN_EXIT,
+      `expected clean exit on normal input, got status=${res.status}\n` +
+        `stderr: ${(res.stderr || '').trim()}`
+    );
+  } finally {
+    fs.rmSync(tmpConfig, { recursive: true, force: true });
+  }
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Fixes #538

`src/hooks/caveman-mode-tracker.js` registered `process.stdin.on('data')` and
`on('end')` but had **no `on('error')` handler**. When stdin closes abnormally
(broken pipe, parent process crash, network interruption) Node emits an `error`
event on the stream; with no listener it becomes an **uncaught exception** and
the hook exits non-zero — a spurious hook failure under Claude Code's hook
system.

Fix: add a silent-fail `error` listener that exits `0`, consistent with the
hook contract (hooks must always exit 0 and never block the session). One line,
single concern, no behavior change on the normal path.

```js
process.stdin.on('error', () => process.exit(0));
```

## Test verification (RED → GREEN)

New standalone test `tests/test_mode_tracker_stdin.js` loads the **real** hook
(`spawnSync` of `src/hooks/caveman-mode-tracker.js`) and emits an `error` on
`process.stdin` to simulate the abnormal close. No GitHub Actions test job runs
on PRs here, so the proof is local:

**RED** — prod fix reverted, test kept:

```
  ✗ stdin "error" event does not crash the hook (exit 0)
    expected clean exit on stdin error, got status=1 signal=null
    stderr: throw er; // Unhandled 'error' event ... Error: EPIPE (simulated)
1 passed, 1 failed
```

**GREEN** — fix applied:

```
  ✓ stdin "error" event does not crash the hook (exit 0)
  ✓ normal stdin (valid JSON + clean EOF) still exits 0
2 passed, 0 failed
```

A second case asserts the new listener leaves the normal `data`/`end` path
untouched (valid JSON in → clean EOF → exit 0).

## No regression

| Suite | Result |
|-------|--------|
| `npm test` | 73 pass, 0 fail |
| `python3 -m unittest tests.test_hooks` | 4 pass |
| `node tests/test_symlink_flag.js` | 12 pass |
| `node tests/test_mode_tracker_stdin.js` | 2 pass (new) |

## Files changed

| File | Change |
|------|--------|
| `src/hooks/caveman-mode-tracker.js` | add `stdin.on('error')` silent-fail handler |
| `tests/test_mode_tracker_stdin.js` | new — RED→GREEN coverage for the handler |
