### PR TITLE
tiny update: add 'documentation' to caveman boundaries

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -75,4 +75,4 @@ Example — destructive op:
 
 ## Boundaries
 
-Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+Code/documentation/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.


### PR DESCRIPTION
That change makes the boundaries clearer: by explicitly adding “documentation” alongside code, commits, and PRs, you’re telling the AI that documentation should also always be written in normal English rather than caveman style.

So instead of the AI hesitating or misinterpreting whether documentation counts as a “commit/PR,” the rule now directly covers it. This prevents edge cases like the one you described, where you had to manually clarify.

In short:

Before: Documentation wasn’t explicitly mentioned, so the AI could get confused.

After: Documentation is explicitly included, so the AI will consistently write it in standard English.

This tiny one‑word addition removes ambiguity and ensures documentation is treated as professional output, not playful caveman text.