### PR TITLE
Clarify documentation boundary in caveman skill

### DIFF
--- a/plugins/caveman/skills/caveman/SKILL.md
+++ b/plugins/caveman/skills/caveman/SKILL.md
@@ -75,4 +75,4 @@ Example — destructive op:
 
 ## Boundaries
 
-Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+Code/documentation/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -75,4 +75,4 @@ Example — destructive op:
 
 ## Boundaries
 
-Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+Code/documentation/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.


### PR DESCRIPTION
## Summary

Adds `documentation` to the caveman skill boundary text so documentation is clearly treated like code, commits, and PRs and should be written normally.

## Changes

* Updated `skills/caveman/SKILL.md`
* Updated `plugins/caveman/skills/caveman/SKILL.md`

## Related issue

Closes #558
