### PR TITLE
Fix for #585

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -413,6 +413,21 @@ function runSpawn(cmd, args, opts, dry) {
   return spawnXplat(cmd, args, Object.assign({ stdio: 'inherit' }, opts || {}));
 }
 
+// Create env with TMPDIR pointing to a temp dir inside configDir.
+// Workaround for Claude Code plugin install EXDEV bug: it tries to rename
+// from ~/.claude/plugins/cache/ to /tmp/ which fails when /tmp is on a
+// different filesystem (common on Linux). Setting TMPDIR to a directory
+// on the same filesystem as ~/.claude/ avoids the cross-device link error.
+function sameFilesystemTmpEnv(configDir) {
+  const tmpDir = path.join(configDir, 'tmp');
+  try { fs.mkdirSync(tmpDir, { recursive: true }); } catch (_) {}
+  return Object.assign({}, process.env, {
+    TMPDIR: tmpDir,  // Unix
+    TEMP: tmpDir,    // Windows
+    TMP: tmpDir,     // Windows alternate
+  });
+}
+
 function captureSpawn(cmd, args) {
   try { return spawnXplat(cmd, args, { encoding: 'utf8' }); }
   catch (_) { return { status: 1, stdout: '', stderr: '' }; }
@@ -440,8 +455,11 @@ async function installClaude(ctx) {
     results.skipped.push(['claude', 'plugin already installed']);
     pluginInstallSucceeded = true;
   } else {
-    const r1 = runSpawn('claude', ['plugin', 'marketplace', 'add', REPO], null, opts.dryRun);
-    const r2 = runSpawn('claude', ['plugin', 'install', 'caveman@caveman'], null, opts.dryRun);
+    // Use a temp dir on the same filesystem as configDir to avoid EXDEV errors
+    // when Claude Code's plugin installer tries to rename across filesystems.
+    const pluginEnv = sameFilesystemTmpEnv(configDir);
+    const r1 = runSpawn('claude', ['plugin', 'marketplace', 'add', REPO], { env: pluginEnv }, opts.dryRun);
+    const r2 = runSpawn('claude', ['plugin', 'install', 'caveman@caveman'], { env: pluginEnv }, opts.dryRun);
     if ((r1.status || 0) === 0 && (r2.status || 0) === 0) {
       results.installed.push('claude');
       pluginInstallSucceeded = true;


### PR DESCRIPTION
This fixes the edge case for the following error by instantiating the paths differently.

✘ Failed to install plugin "caveman@caveman": EXDEV: cross-device link not permitted

https://github.com/JuliusBrussee/caveman/issues/585