### PR TITLE
fix(hooks): resolve SKILL.md path from src/hooks correctly

### DIFF
--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -48,12 +48,12 @@ if (INDEPENDENT_MODES.has(mode)) {
 const modeLabel = mode === 'wenyan' ? 'wenyan-full' : mode;
 
 // Read SKILL.md — the single source of truth for caveman behavior.
-// Plugin installs: __dirname = <plugin_root>/hooks/, SKILL.md at <plugin_root>/skills/caveman/SKILL.md
+// Plugin installs: __dirname = <plugin_root>/src/hooks/, SKILL.md at <plugin_root>/skills/caveman/SKILL.md
 // Standalone installs: __dirname = $CLAUDE_CONFIG_DIR/hooks/, SKILL.md won't exist — falls back to hardcoded rules.
 let skillContent = '';
 try {
   skillContent = fs.readFileSync(
-    path.join(__dirname, '..', 'skills', 'caveman', 'SKILL.md'), 'utf8'
+    path.join(__dirname, '..', '..', 'skills', 'caveman', 'SKILL.md'), 'utf8'
   );
 } catch (e) { /* standalone install — will use fallback below */ }
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -156,6 +156,19 @@ class HookScriptTests(unittest.TestCase):
             self.assertNotIn("STATUSLINE SETUP NEEDED", result.stdout)
             self.assertEqual((claude_dir / ".caveman-active").read_text(), "full")
 
+    def test_activate_reads_real_skill_md_not_fallback(self):
+        # Regression test: caveman-activate.js resolves SKILL.md relative to
+        # __dirname (src/hooks/), which sits two levels below the plugin
+        # root, not one. A wrong path silently fails (empty catch) and falls
+        # back to a hardcoded ruleset missing rules SKILL.md carries, e.g.
+        # "Preserve user's dominant language".
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-skillmd-") as tmp:
+            home = Path(tmp)
+
+            result = self.run_cmd(["node", "src/hooks/caveman-activate.js"], home)
+
+            self.assertIn("Preserve user's dominant language", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `caveman-activate.js` reads `SKILL.md` via `path.join(__dirname, '..', 'skills', 'caveman', 'SKILL.md')`. The hook lives at `<plugin_root>/src/hooks/`, so this resolved to `<plugin_root>/src/skills/...`, which doesn't exist — the real file is `<plugin_root>/skills/caveman/SKILL.md`.
- `readFileSync` failed, caught silently, and the hook fell back to the hardcoded ruleset — which is missing rules added to `SKILL.md` since (e.g. "Preserve user's dominant language"), so every plugin install replied in English regardless of the user's language.
- Fixed the path (added one more `..`) and corrected the stale comment above it.
- Added a regression test in `tests/test_hooks.py` asserting the activate hook's stdout contains "Preserve user's dominant language" — proves it's reading the real `SKILL.md`, not the fallback.

Fixes #589.

## Test plan
- [x] `npm test` — 73/73 pass
- [x] `python3 -m unittest tests.test_hooks` — 5/5 pass, including new regression test