### PR TITLE
fix(opencode): --force migrates legacy AGENTS.md, never wipes it

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -705,14 +705,36 @@ function installOpencode(ctx) {
       if (alreadyFenced) {
         note(`  ${agentsMd} already contains caveman ruleset`);
       } else if (alreadyByLegacySentinel) {
-        note(`  ${agentsMd} contains a legacy (un-fenced) caveman block — leaving as-is`);
-        note('  re-run with --force to replace it with a fenced block');
+        if (!opts.force) {
+          note(`  ${agentsMd} contains a legacy (un-fenced) caveman block — leaving as-is`);
+          note('  re-run with --force to migrate it to a fenced block');
+        }
         if (opts.force) {
-          // Replace the entire file with a clean fenced version. The legacy
-          // path didn't fence, so we can't isolate the block — full rewrite is
-          // the only safe option under --force.
-          fs.writeFileSync(agentsMd, fencedBlock, { mode: 0o644 });
-          process.stdout.write(`  rewrote ${agentsMd} with fenced caveman block\n`);
+          // Migrate, don't wipe (issue #594): the old code replaced the whole
+          // file, destroying any user-authored content around the legacy
+          // block. Back up once, then remove only the legacy block: exact
+          // match of the current rule body when possible, otherwise cut from
+          // the sentinel's paragraph start to EOF (the legacy path APPENDED
+          // the block, so user content precedes it; anything after lives on
+          // in the backup).
+          const agentsBak = agentsMd + '.bak';
+          if (!fs.existsSync(agentsBak)) {
+            try { fs.copyFileSync(agentsMd, agentsBak); } catch (_) {}
+          }
+          const bodyTrim = ruleBody.trimEnd();
+          let userPart;
+          const exact = existing.indexOf(bodyTrim);
+          if (exact !== -1) {
+            userPart = (existing.slice(0, exact) + existing.slice(exact + bodyTrim.length)).trim();
+          } else {
+            const sentinelAt = existing.indexOf(OPENCODE_AGENTS_MD_SENTINEL);
+            const cutAt = existing.lastIndexOf('\n\n', sentinelAt);
+            userPart = cutAt === -1 ? '' : existing.slice(0, cutAt).trim();
+            note(`  legacy block did not match the current ruleset — everything from the sentinel down was replaced; original kept at ${agentsBak}`);
+          }
+          const next = (userPart ? userPart + '\n\n' : '') + fencedBlock;
+          fs.writeFileSync(agentsMd, next, { mode: 0o644 });
+          process.stdout.write(`  migrated ${agentsMd} legacy block to fenced (backup: ${agentsBak})\n`);
         }
       } else {
         const sep = existing.endsWith('\n\n') ? '' : (existing.endsWith('\n') ? '\n' : '\n\n');

--- a/tests/installer/e2e.freshinstall.test.mjs
+++ b/tests/installer/e2e.freshinstall.test.mjs
@@ -400,3 +400,41 @@ test('lib settings.addCommandHook is idempotent across two synthetic install pas
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// ── Test: --force migrates a mixed legacy AGENTS.md instead of wiping it (#594)
+// The old code replaced the whole file with the fenced block whenever the
+// legacy un-fenced sentinel was present — and the installer's own hint told
+// users with mixed files to run exactly that. User content must survive.
+test('opencode: --force on legacy AGENTS.md preserves user content and takes a backup', () => {
+  const dir = freshTmpDir();
+  const xdg = path.join(dir, 'xdg');
+  const ocDir = path.join(xdg, 'opencode');
+  fs.mkdirSync(ocDir, { recursive: true });
+  const agentsMd = path.join(ocDir, 'AGENTS.md');
+  const legacyBody = fs.readFileSync(
+    path.join(REPO_ROOT, 'src', 'rules', 'caveman-activate.md'), 'utf8').trimEnd() + '\n';
+  const userRules = '# My precious user rules\n\nAlways use tabs.\n';
+  fs.writeFileSync(agentsMd, userRules + '\n' + legacyBody);
+  try {
+    const r = spawnSync('node', [INSTALLER, '--only', 'opencode', '--force', '--non-interactive', '--no-mcp-shrink', '--config-dir', path.join(dir, 'claude')], {
+      env: { ...process.env, XDG_CONFIG_HOME: xdg, NO_COLOR: '1' },
+      encoding: 'utf8',
+    });
+    assert.notEqual(r.status, 2, `installer argv error: ${r.stderr}`);
+
+    const after = fs.readFileSync(agentsMd, 'utf8');
+    assert.match(after, /My precious user rules/, 'user heading wiped by --force migration');
+    assert.match(after, /Always use tabs\./, 'user rule wiped by --force migration');
+    assert.match(after, /<!-- caveman-begin -->/, 'fenced block missing after migration');
+    assert.match(after, /<!-- caveman-end -->/, 'fence end missing after migration');
+    // Legacy un-fenced copy must be gone: sentinel appears only inside the fence.
+    const beforeFence = after.slice(0, after.indexOf('<!-- caveman-begin -->'));
+    assert.doesNotMatch(beforeFence, /Respond terse like smart caveman/,
+      'legacy un-fenced block still present above the fence');
+    assert.ok(fs.existsSync(agentsMd + '.bak'), 'backup missing after --force migration');
+    assert.match(fs.readFileSync(agentsMd + '.bak', 'utf8'), /My precious user rules/,
+      'backup does not contain the original content');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What happen

When `~/.config/opencode/AGENTS.md` contains the legacy un-fenced sentinel, the installer prints *"re-run with `--force` to replace it with a fenced block"* — and `--force` then executed a **full-file replace** (`fs.writeFileSync(agentsMd, fencedBlock)`). All user-authored content around the legacy block was destroyed, no backup taken. The installer's own hint steered users with mixed files into data loss, and `--help` describes `--force` as merely "Re-run even if a target reports already installed".

Fixes #594.

## Fix

Migrate instead of wipe:

1. One-time backup to `AGENTS.md.bak` before any rewrite (same once-only pattern as `opencode.json.bak`).
2. Remove **only the legacy block**: exact match of the current rule body when possible; otherwise cut from the sentinel's paragraph start to EOF — the legacy path *appended* the block, so user content precedes it, and the heuristic path says so explicitly and points at the backup.
3. Write the fenced block after the preserved user content.

## Tests

New e2e test drives the real installer against a mixed legacy AGENTS.md (user rules + legacy body): user content survives, the fence is present, the legacy un-fenced copy is gone, and the backup contains the original. The older-revision heuristic path verified manually (user notes above sentinel survive, `.bak` written). Full suites green locally **and in a clean node:20-bookworm container**, including a targeted container repro of the exact reported scenario.