### PR TITLE
fix(install): make Hermes skill install safe

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -228,8 +228,8 @@ const PROVIDERS = [
   // CLI agents — require the binary. The `||dir:~/.foo` fallbacks were the
   // main source of false positives (warp, kiro, junie etc. leave config dirs
   // behind on uninstall).
-    { id: 'hermes',     label: 'Hermes Agent',        mech: 'npx skills add (hermes)',       detect: 'command:hermes',        profile: 'hermes' },
-    { id: 'aider-desk', label: 'Aider Desk',          mech: 'npx skills add (aider-desk)',   detect: 'command:aider', profile: 'aider-desk' },
+  { id: 'hermes',     label: 'Hermes Agent',        mech: 'native Hermes skills copy',   detect: 'command:hermes',        profile: 'hermes' },
+  { id: 'aider-desk', label: 'Aider Desk',          mech: 'npx skills add (aider-desk)',   detect: 'command:aider', profile: 'aider-desk' },
   { id: 'amp',        label: 'Sourcegraph Amp',     mech: 'npx skills add (amp)',          detect: 'command:amp',             profile: 'amp' },
   { id: 'bob',        label: 'IBM Bob',             mech: 'npx skills add (bob)',          detect: 'command:bob', profile: 'bob' },
   { id: 'crush',      label: 'Crush',               mech: 'npx skills add (crush)',        detect: 'command:crush', profile: 'crush' },
@@ -597,17 +597,26 @@ function installHermes(ctx) {
   try {
     fs.mkdirSync(skillsRoot, { recursive: true });
 
+    const missing = HERMES_SKILL_DIRS
+      .map(skillDir => path.join(repoRoot, 'skills', skillDir))
+      .filter(srcDir => !fs.existsSync(srcDir));
+    if (missing.length) {
+      for (const srcDir of missing) warn(`  skill dir not found: ${srcDir}`);
+      results.failed.push(['hermes', `missing ${missing.length} source skill dir${missing.length === 1 ? '' : 's'}`]);
+      process.stdout.write('\n');
+      return;
+    }
+
     for (const skillDir of HERMES_SKILL_DIRS) {
       const srcDir = path.join(repoRoot, 'skills', skillDir);
       const destDir = path.join(skillsRoot, skillDir);
-      if (fs.existsSync(srcDir)) {
-        // Remove existing to ensure clean copy
-        if (fs.existsSync(destDir)) fs.rmSync(destDir, { recursive: true, force: true });
-        copyDirRecursive(srcDir, destDir);
-        note(`  copied ${skillDir} → ${destDir}`);
-      } else {
-        warn(`  skill dir not found: ${srcDir}`);
+      if (fs.existsSync(destDir) && !opts.force) {
+        note(`  skipped ${destDir}/ (exists; --force to overwrite)`);
+        continue;
       }
+      if (fs.existsSync(destDir)) fs.rmSync(destDir, { recursive: true, force: true });
+      copyDirRecursive(srcDir, destDir);
+      note(`  copied ${skillDir} → ${destDir}`);
     }
 
     results.installed.push('hermes');
@@ -1233,6 +1242,17 @@ function uninstall(ctx) {
     if (fs.existsSync(ocFlag) && !opts.dryRun) { try { fs.unlinkSync(ocFlag); } catch (_) {} }
   }
 
+  // Hermes native install — remove only the skill directories this installer owns.
+  const hermesSkillsRoot = path.join(hermesConfigDir(), 'productivity');
+  if (HERMES_SKILL_DIRS.some(name => fs.existsSync(path.join(hermesSkillsRoot, name)))) {
+    for (const name of HERMES_SKILL_DIRS) {
+      const p = path.join(hermesSkillsRoot, name);
+      if (!fs.existsSync(p)) continue;
+      if (!opts.dryRun) { try { fs.rmSync(p, { recursive: true, force: true }); } catch (_) {} }
+      note(`  removed ${p}`);
+    }
+  }
+
   // OpenClaw native install — strip skill folder + SOUL.md marker block.
   // Probed by the skill folder we own; if absent, skip silently.
   const ocwWs = process.env.OPENCLAW_WORKSPACE || path.join(os.homedir(), '.openclaw', 'workspace');
@@ -1398,11 +1418,11 @@ async function main() {
     // missing without --force).
     if (!explicit(prov.id) && !detectMatch(prov.detect)) continue;
     if (prov.id === 'claude')   { await installClaude(ctx); continue; }
-      if (prov.id === 'gemini')   { installGemini(ctx); continue; }
-      if (prov.id === 'opencode') { installOpencode(ctx); continue; }
-      if (prov.id === 'openclaw') { installOpenclaw(ctx); continue; }
-      if (prov.id === 'hermes')   { installHermes(ctx); continue; }
-      if (prov.profile)           { installViaSkills(ctx, prov); continue; }
+    if (prov.id === 'gemini')   { installGemini(ctx); continue; }
+    if (prov.id === 'opencode') { installOpencode(ctx); continue; }
+    if (prov.id === 'openclaw') { installOpenclaw(ctx); continue; }
+    if (prov.id === 'hermes')   { installHermes(ctx); continue; }
+    if (prov.profile)           { installViaSkills(ctx, prov); continue; }
   }
 
   // Auto-detect fallback if nothing matched

--- a/bin/install.js
+++ b/bin/install.js
@@ -228,7 +228,8 @@ const PROVIDERS = [
   // CLI agents — require the binary. The `||dir:~/.foo` fallbacks were the
   // main source of false positives (warp, kiro, junie etc. leave config dirs
   // behind on uninstall).
-  { id: 'aider-desk', label: 'Aider Desk',          mech: 'npx skills add (aider-desk)',   detect: 'command:aider', profile: 'aider-desk' },
+    { id: 'hermes',     label: 'Hermes Agent',        mech: 'npx skills add (hermes)',       detect: 'command:hermes',        profile: 'hermes' },
+    { id: 'aider-desk', label: 'Aider Desk',          mech: 'npx skills add (aider-desk)',   detect: 'command:aider', profile: 'aider-desk' },
   { id: 'amp',        label: 'Sourcegraph Amp',     mech: 'npx skills add (amp)',          detect: 'command:amp',             profile: 'amp' },
   { id: 'bob',        label: 'IBM Bob',             mech: 'npx skills add (bob)',          detect: 'command:bob', profile: 'bob' },
   { id: 'crush',      label: 'Crush',               mech: 'npx skills add (crush)',        detect: 'command:crush', profile: 'crush' },
@@ -557,6 +558,63 @@ function installViaSkills(ctx, prov) {
   const r = runSpawn('npx', args, null, opts.dryRun);
   if ((r.status || 0) === 0) results.installed.push(prov.id);
   else results.failed.push([prov.id, `npx skills add (${prov.profile}) failed`]);
+  process.stdout.write('\n');
+}
+
+// ── hermes native install ──────────────────────────────────────────────────
+// Drops the caveman skills into ~/.hermes/skills/productivity/ (or HERMES_HOME if set).
+const HERMES_SKILL_DIRS = ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'cavecrew'];
+
+function hermesConfigDir() {
+  // Hermes uses ~/.hermes by default, or HERMES_HOME env var.
+  if (process.env.HERMES_HOME) return path.join(process.env.HERMES_HOME, 'skills');
+  return path.join(os.homedir(), '.hermes', 'skills');
+}
+
+function installHermes(ctx) {
+  const { say, note, warn, opts, repoRoot, results } = ctx;
+  results.detected++;
+  say('→ Hermes Agent detected');
+
+  if (!repoRoot) {
+    warn('  Hermes native install requires a local clone of the caveman repo.');
+    note('  Re-run from a clone: git clone https://github.com/' + REPO + ' && cd caveman && node bin/install.js --only hermes');
+    results.failed.push(['hermes', 'native install requires local repo clone']);
+    process.stdout.write('\n');
+    return;
+  }
+
+  const skillsRoot = path.join(hermesConfigDir(), 'productivity');
+
+  if (opts.dryRun) {
+    note(`  would mkdir ${skillsRoot}/`);
+    note(`  would copy ${HERMES_SKILL_DIRS.length} skill dirs into ${skillsRoot}/`);
+    results.installed.push('hermes');
+    process.stdout.write('\n');
+    return;
+  }
+
+  try {
+    fs.mkdirSync(skillsRoot, { recursive: true });
+
+    for (const skillDir of HERMES_SKILL_DIRS) {
+      const srcDir = path.join(repoRoot, 'skills', skillDir);
+      const destDir = path.join(skillsRoot, skillDir);
+      if (fs.existsSync(srcDir)) {
+        // Remove existing to ensure clean copy
+        if (fs.existsSync(destDir)) fs.rmSync(destDir, { recursive: true, force: true });
+        copyDirRecursive(srcDir, destDir);
+        note(`  copied ${skillDir} → ${destDir}`);
+      } else {
+        warn(`  skill dir not found: ${srcDir}`);
+      }
+    }
+
+    results.installed.push('hermes');
+  } catch (err) {
+    results.failed.push(['hermes', 'copy failed: ' + err.message]);
+  }
+
   process.stdout.write('\n');
 }
 
@@ -1340,10 +1398,11 @@ async function main() {
     // missing without --force).
     if (!explicit(prov.id) && !detectMatch(prov.detect)) continue;
     if (prov.id === 'claude')   { await installClaude(ctx); continue; }
-    if (prov.id === 'gemini')   { installGemini(ctx); continue; }
-    if (prov.id === 'opencode') { installOpencode(ctx); continue; }
-    if (prov.id === 'openclaw') { installOpenclaw(ctx); continue; }
-    if (prov.profile)           { installViaSkills(ctx, prov); continue; }
+      if (prov.id === 'gemini')   { installGemini(ctx); continue; }
+      if (prov.id === 'opencode') { installOpencode(ctx); continue; }
+      if (prov.id === 'openclaw') { installOpenclaw(ctx); continue; }
+      if (prov.id === 'hermes')   { installHermes(ctx); continue; }
+      if (prov.profile)           { installViaSkills(ctx, prov); continue; }
   }
 
   // Auto-detect fallback if nothing matched

--- a/tests/installer/hermes.test.mjs
+++ b/tests/installer/hermes.test.mjs
@@ -1,0 +1,95 @@
+// End-to-end coverage for Hermes Agent native skill installation.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const INSTALLER = path.join(REPO_ROOT, 'bin', 'install.js');
+const SKILL_NAMES = ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'cavecrew'];
+
+function freshTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-hermes-'));
+}
+
+function runInstaller(args, hermesHome) {
+  return spawnSync('node', [INSTALLER, ...args, '--non-interactive', '--no-color'], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, HERMES_HOME: hermesHome },
+    encoding: 'utf8',
+  });
+}
+
+function skillPath(hermesHome, name) {
+  return path.join(hermesHome, 'skills', 'productivity', name);
+}
+
+test('hermes install copies all shipped skill directories under HERMES_HOME', () => {
+  const dir = freshTmpDir();
+  try {
+    const hermesHome = path.join(dir, 'hermes-home');
+    const r = runInstaller(['--only', 'hermes'], hermesHome);
+    assert.equal(r.status, 0, r.stderr || r.stdout);
+    for (const name of SKILL_NAMES) {
+      assert.ok(fs.existsSync(path.join(skillPath(hermesHome, name), 'SKILL.md')), `${name} SKILL.md missing`);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('hermes reinstall preserves existing local skill edits unless --force is passed', () => {
+  const dir = freshTmpDir();
+  try {
+    const hermesHome = path.join(dir, 'hermes-home');
+    const first = runInstaller(['--only', 'hermes'], hermesHome);
+    assert.equal(first.status, 0, first.stderr || first.stdout);
+
+    const editedSkill = path.join(skillPath(hermesHome, 'caveman'), 'SKILL.md');
+    fs.appendFileSync(editedSkill, '\nLOCAL USER EDIT\n');
+
+    const second = runInstaller(['--only', 'hermes'], hermesHome);
+    assert.equal(second.status, 0, second.stderr || second.stdout);
+    assert.match(fs.readFileSync(editedSkill, 'utf8'), /LOCAL USER EDIT/, 'reinstall without --force wiped local edit');
+
+    const forced = runInstaller(['--only', 'hermes', '--force'], hermesHome);
+    assert.equal(forced.status, 0, forced.stderr || forced.stdout);
+    assert.doesNotMatch(fs.readFileSync(editedSkill, 'utf8'), /LOCAL USER EDIT/, '--force should refresh the skill from repo contents');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('hermes uninstall removes native skill directories and dry-run preserves them', () => {
+  const dir = freshTmpDir();
+  try {
+    const hermesHome = path.join(dir, 'hermes-home');
+    const installed = runInstaller(['--only', 'hermes'], hermesHome);
+    assert.equal(installed.status, 0, installed.stderr || installed.stdout);
+
+    const dry = runInstaller(['--uninstall', '--dry-run'], hermesHome);
+    assert.equal(dry.status, 0, dry.stderr || dry.stdout);
+    for (const name of SKILL_NAMES) {
+      assert.ok(fs.existsSync(skillPath(hermesHome, name)), `${name} removed during dry-run`);
+    }
+
+    const removed = runInstaller(['--uninstall'], hermesHome);
+    assert.equal(removed.status, 0, removed.stderr || removed.stdout);
+    for (const name of SKILL_NAMES) {
+      assert.equal(fs.existsSync(skillPath(hermesHome, name)), false, `${name} survived uninstall`);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('provider matrix labels Hermes as a native install', () => {
+  const r = spawnSync('node', [INSTALLER, '--list', '--no-color'], { encoding: 'utf8' });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /hermes\s+Hermes Agent\s+native Hermes skills copy/);
+});


### PR DESCRIPTION
## Summary
- Adds Hermes Agent as a native caveman skill target.
- Installs the seven caveman skills into `$HERMES_HOME/skills/productivity` or `~/.hermes/skills/productivity`.
- Makes Hermes reinstall safe: existing local/self-edited skills are preserved unless `--force` is passed.
- Adds Hermes cleanup to `--uninstall`.
- Adds Hermes-specific installer regression tests.

## Fixes from review
- Avoids deleting Hermes skill directories on normal reinstall.
- Removes Hermes-installed skills during uninstall.
- Labels Hermes as a native copy provider in `--list`.
- Fails the Hermes install path if shipped source skill directories are missing.

## Test plan
- [x] `node --test tests/installer/hermes.test.mjs`
- [x] `npm test`
- [x] `node -c bin/install.js`
- [x] `git diff --check origin/main...HEAD`
- [x] `python3 -m pytest tests -q`
- [x] Manual isolated install with `HERMES_HOME=$(mktemp -d)/hermes-home node bin/install.js --only hermes` and `hermes skills list`
