### PR TITLE
Fix caveman-init command runner

### DIFF
--- a/commands/caveman-init.toml
+++ b/commands/caveman-init.toml
@@ -1,2 +1,2 @@
 description = "Drop the always-on caveman activation rule into the current repo for every IDE agent"
-prompt = "Run `node src/tools/caveman-init.js {{args}}` in the current repo and report the result. Use --dry-run first if the user did not pass --force, so we never silently overwrite an existing rule file."
+prompt = "Run `npx -y github:JuliusBrussee/caveman -- --with-init {{args}}` in the current repo and report the result. Use --dry-run first if the user did not pass --force, so we never silently overwrite an existing rule file."

--- a/tests/test_caveman_init.js
+++ b/tests/test_caveman_init.js
@@ -10,6 +10,7 @@ const { execFileSync } = require('child_process');
 
 const ROOT = path.resolve(__dirname, '..');
 const INIT = path.join(ROOT, 'src', 'tools', 'caveman-init.js');
+const COMMAND = path.join(ROOT, 'commands', 'caveman-init.toml');
 
 let passed = 0;
 let failed = 0;
@@ -39,6 +40,15 @@ function test(name, fn) {
 }
 
 console.log('caveman-init tests\n');
+
+test('slash command uses portable npx GitHub runner', () => {
+  const command = fs.readFileSync(COMMAND, 'utf8');
+  assert.match(command, /github:JuliusBrussee\/caveman/);
+  assert.match(command, /--with-init/);
+  assert.match(command, /\{\{args\}\}/);
+  assert.doesNotMatch(command, /src\/tools\/caveman-init\.js/);
+  assert.doesNotMatch(command, /node src\/tools\/caveman-init\.js/);
+});
 
 test('greenfield: creates all rule files with proper frontmatter', (tmp) => {
   runInit(tmp);


### PR DESCRIPTION
# Context

The `/caveman-init` command currently depends on the current working directory containing `src/tools/caveman-init.js`, limiting its portability and usability across different user projects.

# Solution

This pull request updates the `commands/caveman-init.toml` file to replace the repository-relative Node invocation with a portable `npx` command, preserving existing metadata and argument placeholders. The prompt now instructs users to run `npx -y github:JuliusBrussee/caveman -- --with-init {{args}}`, ensuring the command is user-project independent.

# Scope

- Update `commands/caveman-init.toml` to use the portable runner.
- Add tests to verify the updated command does not reference `src/tools/caveman-init.js`.

# Tests Run

Focused tests for the caveman-init command were added, which check the command's structure against the new requirements.

# Results

Checks passed, but no tests ran and no static analysis validated the change — review carefully. 

# Risks

Minimal risk due to the focused nature of the updates. However, there could be edge cases not considered in user environments.

# Related Issue

None