### PR TITLE
fix(agents): move cavecrew investigator/reviewer off haiku

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,9 +91,9 @@ caveman/
 | `skills/caveman-help/SKILL.md` | Quick-reference card. One-shot display, not a persistent mode. |
 | `skills/caveman-compress/SKILL.md` | Compress sub-skill behavior. |
 | `skills/cavecrew/SKILL.md` | Cavecrew decision guide — when to delegate to caveman subagents vs vanilla. Edit only here. |
-| `agents/cavecrew-investigator.md` | Read-only locator subagent (haiku). Output contract: `path:line — symbol — note`. |
+| `agents/cavecrew-investigator.md` | Read-only locator subagent (sonnet, low effort). Output contract: `path:line — symbol — note`. |
 | `agents/cavecrew-builder.md` | Surgical 1-2 file editor subagent. Refuses 3+ file scope. |
-| `agents/cavecrew-reviewer.md` | Diff/file reviewer subagent (haiku). One-line findings with severity emoji. |
+| `agents/cavecrew-reviewer.md` | Diff/file reviewer subagent (sonnet, medium effort). One-line findings with severity emoji. |
 | `src/plugins/opencode/plugin.js` | opencode native plugin. ESM Bun module — `session.created` writes flag, `tui.prompt.append` parses slash/natural-language activation and appends per-prompt reinforcement. Reuses `caveman-config.js` via `createRequire`. |
 | `src/plugins/opencode/commands/*.md` | Six opencode slash-command prompt templates (`/caveman`, `/caveman-{commit,review,compress,stats,help}`). |
 

--- a/agents/cavecrew-investigator.md
+++ b/agents/cavecrew-investigator.md
@@ -6,7 +6,8 @@ description: >
   caveman-compressed so the main thread eats ~60% fewer tokens than
   vanilla Explore. Refuses to suggest fixes.
 tools: [Read, Grep, Glob, Bash]
-model: haiku
+model: sonnet
+effort: low
 ---
 
 Caveman-ultra. Drop articles/filler/hedging. Code/symbols/paths exact, backticked. Lead with answer.

--- a/agents/cavecrew-reviewer.md
+++ b/agents/cavecrew-reviewer.md
@@ -6,7 +6,8 @@ description: >
   Use for "review this PR", "review my diff", "audit this file". Skips
   formatting nits unless they change meaning.
 tools: [Read, Grep, Bash]
-model: haiku
+model: sonnet
+effort: medium
 ---
 
 Caveman-ultra. Findings only. No "looks good", no "I'd suggest", no preamble.


### PR DESCRIPTION
## What

Re-tiers two cavecrew subagents away from `model: haiku`:

- `cavecrew-investigator` → `model: sonnet` + `effort: low`
- `cavecrew-reviewer` → `model: sonnet` + `effort: medium`

Also updates the corresponding rows in `CLAUDE.md`. CI sync will mirror the agent files into `plugins/caveman/agents/`.

## Why

Haiku 4.5 has become a poor fit for multi-step agentic subagents:

1. **Confirmed tool-loop failure mode** — Haiku 4.5 re-calls already-completed tools and stalls multi-step plans in agentic chains: anthropics/claude-code#10029. Both of these agents run tool chains (Grep/Glob/Read/Bash iterations), so a single looped run erases the price advantage and returns unreliable findings.
2. **No effort support** — Haiku 4.5 rejects the `effort` parameter (400 error; it is absent from the supported-models list at https://platform.claude.com/docs/en/build-with-claude/effort), so the cheap-tier slot can't be tuned down. Sonnet at `low` effort fills that slot: official docs describe low as "significant token savings, some capability reduction", which matches the locate/report workload.
3. **Staleness** — Haiku 4.5 (Oct 2025) is now two generations behind Sonnet 5 with no newer Haiku announced.

Cost impact is modest and bounded: Sonnet 5 is $2/$10 per MTok (intro through Aug 31, 2026; $3/$15 after) vs Haiku's $1/$5, and the reviewer especially benefits — one-line severity-tagged findings are judgment work that haiku frequently fumbles.

The reviewer was arguably mis-tiered even before this: diff review is judgment work, which the model-routing literature consistently puts at least one tier above the mechanical bucket.