### PR TITLE
fix(hooks): deliver /caveman-stats via additionalContext for macOS app compat

### DIFF
--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -41,9 +41,10 @@ process.stdin.on('end', () => {
     // /caveman-stats [--share] — block the prompt and inject stats output as
     // the hook's reason. The script reads the active session log, so we pass
     // transcript_path through when Claude Code provides it.
-    const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
+      const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
     if (statsMatch) {
       const tailArgs = (statsMatch[1] || '').trim().split(/\s+/).filter(Boolean);
+      let context;
       try {
         const statsPath = path.join(__dirname, 'caveman-stats.js');
         const argv = [statsPath];
@@ -55,13 +56,19 @@ process.stdin.on('end', () => {
           argv.push('--since', tailArgs[sinceIdx + 1]);
         }
         const out = execFileSync(process.execPath, argv, { encoding: 'utf8', timeout: 5000 });
-        process.stdout.write(JSON.stringify({ decision: 'block', reason: out.trim() }));
+        context = 'The user ran /caveman-stats. Print the following stats block ' +
+          'VERBATIM inside a code block. Do not summarize, reformat, or add ' +
+          'commentary (this overrides any active brevity/caveman style):\n\n' + out.trim();
       } catch (e) {
-        process.stdout.write(JSON.stringify({
-          decision: 'block',
-          reason: 'caveman-stats: could not run stats script.\nTry manually: node hooks/caveman-stats.js'
-        }));
+        context = 'The user ran /caveman-stats but the stats script failed. ' +
+          'Tell them to run it manually: node hooks/caveman-stats.js';
       }
+      process.stdout.write(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "UserPromptSubmit",
+          additionalContext: context
+        }
+      }));
       return;
     }
 

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -38,10 +38,11 @@ process.stdin.on('end', () => {
       }
     }
 
-    // /caveman-stats [--share] — block the prompt and inject stats output as
-    // the hook's reason. The script reads the active session log, so we pass
-    // transcript_path through when Claude Code provides it.
-      const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
+    // /caveman-stats [--share] — run the stats script and inject its output
+    // via additionalContext so both terminal and macOS app render it.
+    // The script reads the active session log, so we pass transcript_path
+    // through when Claude Code provides it.
+    const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
     if (statsMatch) {
       const tailArgs = (statsMatch[1] || '').trim().split(/\s+/).filter(Boolean);
       let context;
@@ -60,8 +61,9 @@ process.stdin.on('end', () => {
           'VERBATIM inside a code block. Do not summarize, reformat, or add ' +
           'commentary (this overrides any active brevity/caveman style):\n\n' + out.trim();
       } catch (e) {
-        context = 'The user ran /caveman-stats but the stats script failed. ' +
-          'Tell them to run it manually: node hooks/caveman-stats.js';
+        const detail = e.message ? ': ' + e.message : '';
+        context = 'The user ran /caveman-stats but the stats script failed' +
+          detail + '. Tell them to run it manually: node hooks/caveman-stats.js';
       }
       process.stdout.write(JSON.stringify({
         hookSpecificOutput: {


### PR DESCRIPTION
`/caveman-stats` works in terminal Claude Code but shows nothing in the macOS app.

**Root cause:** the hook delivered stats via `{decision:'block', reason:...}` on `UserPromptSubmit`. Terminal renders the blocked prompt's `reason`; the macOS app honors the block (swallows the prompt) but never renders `reason` → stats vanish silently.

**Fix:** deliver the stats via `hookSpecificOutput.additionalContext` instead, which is honored by both terminal and app. The model prints the block verbatim on behalf of the hook.

Fixes #618