### PR TITLE
fix(parse): extract shared mode parser to fix three drifts between tracker and opencode plugin

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -44,6 +44,7 @@ const MCP_SHRINK_PKG = 'caveman-shrink';
 const HOOK_FILES = [
   'package.json',
   'caveman-config.js',
+  'caveman-parse.js',
   'caveman-activate.js',
   'caveman-mode-tracker.js',
   'caveman-stats.js',
@@ -641,6 +642,8 @@ function installOpencode(ctx) {
       // sibling would be loaded as ESM and break the plugin's require() bridge.
       [path.join(repoRoot, 'src', 'hooks', 'caveman-config.js'),
        path.join(pluginDir, 'caveman-config.cjs')],
+      [path.join(repoRoot, 'src', 'hooks', 'caveman-parse.js'),
+       path.join(pluginDir, 'caveman-parse.cjs')],
     ];
     for (const [src, dest] of pluginPayload) {
       if (fs.existsSync(dest) && !opts.force) {

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -19,9 +19,10 @@ process.stdin.on('end', () => {
     const data = JSON.parse(input);
     const prompt = (data.prompt || '').trim().toLowerCase();
 
-    // /caveman-stats [--share] — block the prompt and inject stats output as
-    // the hook's reason. The script reads the active session log, so we pass
-    // transcript_path through when Claude Code provides it.
+    // /caveman-stats [--share] — run the stats script and inject its output
+    // via additionalContext so both terminal and macOS app render it.
+    // The script reads the active session log, so we pass transcript_path
+    // through when Claude Code provides it.
     const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
     if (statsMatch) {
       const tailArgs = (statsMatch[1] || '').trim().split(/\s+/).filter(Boolean);
@@ -41,8 +42,9 @@ process.stdin.on('end', () => {
           'VERBATIM inside a code block. Do not summarize, reformat, or add ' +
           'commentary (this overrides any active brevity/caveman style):\n\n' + out.trim();
       } catch (e) {
-        context = 'The user ran /caveman-stats but the stats script failed. ' +
-          'Tell them to run it manually: node hooks/caveman-stats.js';
+        const detail = e.message ? ': ' + e.message : '';
+        context = 'The user ran /caveman-stats but the stats script failed' +
+          detail + '. Tell them to run it manually: node hooks/caveman-stats.js';
       }
       process.stdout.write(JSON.stringify({
         hookSpecificOutput: {

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -41,9 +41,10 @@ process.stdin.on('end', () => {
     // /caveman-stats [--share] — block the prompt and inject stats output as
     // the hook's reason. The script reads the active session log, so we pass
     // transcript_path through when Claude Code provides it.
-    const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
+      const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
     if (statsMatch) {
       const tailArgs = (statsMatch[1] || '').trim().split(/\s+/).filter(Boolean);
+      let context;
       try {
         const statsPath = path.join(__dirname, 'caveman-stats.js');
         const argv = [statsPath];
@@ -55,13 +56,19 @@ process.stdin.on('end', () => {
           argv.push('--since', tailArgs[sinceIdx + 1]);
         }
         const out = execFileSync(process.execPath, argv, { encoding: 'utf8', timeout: 5000 });
-        process.stdout.write(JSON.stringify({ decision: 'block', reason: out.trim() }));
+        context = 'The user ran /caveman-stats. Print the following stats block ' +
+          'VERBATIM inside a code block. Do not summarize, reformat, or add ' +
+          'commentary (this overrides any active brevity/caveman style):\n\n' + out.trim();
       } catch (e) {
-        process.stdout.write(JSON.stringify({
-          decision: 'block',
-          reason: 'caveman-stats: could not run stats script.\nTry manually: node hooks/caveman-stats.js'
-        }));
+        context = 'The user ran /caveman-stats but the stats script failed. ' +
+          'Tell them to run it manually: node hooks/caveman-stats.js';
       }
+      process.stdout.write(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "UserPromptSubmit",
+          additionalContext: context
+        }
+      }));
       return;
     }
 

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -6,11 +6,8 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { execFileSync } = require('child_process');
-const { getDefaultMode, safeWriteFlag, readFlag, VALID_MODES } = require('./caveman-config');
-
-// Modes handled by their own slash commands (/caveman-commit, etc.) — not
-// selectable via /caveman <arg>.
-const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
+const { safeWriteFlag, readFlag } = require('./caveman-config');
+const { parseModeChange, INDEPENDENT_MODES } = require('./caveman-parse');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');
@@ -22,26 +19,10 @@ process.stdin.on('end', () => {
     const data = JSON.parse(input);
     const prompt = (data.prompt || '').trim().toLowerCase();
 
-    // Natural language activation (e.g. "activate caveman", "turn on caveman mode",
-    // "talk like caveman"). README tells users they can say these, but the hook
-    // only matched /caveman commands — flag file and statusline stayed out of sync.
-    // Also recognize brevity requests ("less tokens", "be brief/terse", "fewer
-    // tokens", "shorter answers") — README promises these trigger caveman too.
-    if (/\b(activate|enable|turn on|start|talk like)\b.*\bcaveman\b/i.test(prompt) ||
-        /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt) ||
-        /\b(less tokens|fewer tokens|be brief|be terse|shorter answers)\b/i.test(prompt)) {
-      if (!/\b(stop|disable|turn off|deactivate)\b/i.test(prompt)) {
-        const mode = getDefaultMode();
-        if (mode !== 'off') {
-          safeWriteFlag(flagPath, mode);
-        }
-      }
-    }
-
     // /caveman-stats [--share] — block the prompt and inject stats output as
     // the hook's reason. The script reads the active session log, so we pass
     // transcript_path through when Claude Code provides it.
-      const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
+    const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
     if (statsMatch) {
       const tailArgs = (statsMatch[1] || '').trim().split(/\s+/).filter(Boolean);
       let context;
@@ -72,47 +53,12 @@ process.stdin.on('end', () => {
       return;
     }
 
-    // Match /caveman commands
-    if (prompt.startsWith('/caveman')) {
-      const parts = prompt.split(/\s+/);
-      const cmd = parts[0]; // /caveman, /caveman-commit, /caveman-review, etc.
-      const arg = parts[1] || '';
-
-      let mode = null;
-
-      if (cmd === '/caveman-commit') {
-        mode = 'commit';
-      } else if (cmd === '/caveman-review') {
-        mode = 'review';
-      } else if (cmd === '/caveman-compress' || cmd === '/caveman:caveman-compress') {
-        mode = 'compress';
-      } else if (cmd === '/caveman' || cmd === '/caveman:caveman') {
-        // Bare /caveman → activate at configured default
-        if (!arg) {
-          mode = getDefaultMode();
-        } else if (arg === 'off' || arg === 'stop' || arg === 'disable') {
-          mode = 'off';
-        } else if (arg === 'wenyan-full') {
-          // Canonical alias — config stores as 'wenyan'
-          mode = 'wenyan';
-        } else if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) {
-          mode = arg;
-        }
-        // Unknown arg → mode stays null, flag untouched (no silent overwrite)
-      }
-
-      if (mode && mode !== 'off') {
-        safeWriteFlag(flagPath, mode);
-      } else if (mode === 'off') {
-        try { fs.unlinkSync(flagPath); } catch (e) {}
-      }
-    }
-
-    // Detect deactivation — natural language and slash commands
-    if (/\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/i.test(prompt) ||
-        /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/i.test(prompt) ||
-        /\bnormal mode\b/i.test(prompt)) {
+    // Parse and apply mode changes using the shared parser
+    const change = parseModeChange(prompt);
+    if (change === 'off') {
       try { fs.unlinkSync(flagPath); } catch (e) {}
+    } else if (change) {
+      safeWriteFlag(flagPath, change);
     }
 
     // Per-turn reinforcement: emit a structured reminder when caveman is active.

--- a/src/hooks/caveman-parse.js
+++ b/src/hooks/caveman-parse.js
@@ -1,0 +1,82 @@
+// caveman — shared mode-change parser
+//
+// Single source of truth for interpreting user prompts as caveman mode
+// changes. Used by the Claude Code tracker (caveman-mode-tracker.js) and
+// the opencode plugin (src/plugins/opencode/plugin.js) so both stay in sync.
+//
+// Returns:
+//   A valid mode string (including 'off') — caller should apply the change.
+//   null                            — prompt does not change state.
+
+const { getDefaultMode, VALID_MODES } = require('./caveman-config');
+
+const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
+
+function parseModeChange(promptRaw, options = {}) {
+  let prompt = (promptRaw || '').trim();
+  if (!prompt) return null;
+
+  // opencode's non-interactive run path wraps user messages in literal
+  // quote characters ("/caveman ultra") — unwrap so the branches still match.
+  if (options.unwrapQuotes) {
+    const wrapped = /^(["'`])([\s\S]*)\1$/.exec(prompt);
+    if (wrapped) prompt = wrapped[2].trim();
+  }
+
+  prompt = prompt.toLowerCase();
+  if (!prompt) return null;
+
+  // Natural-language deactivation — checked before activation so
+  // "stop talking like caveman" doesn't trip the activation regex.
+  if (/\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/i.test(prompt) ||
+      /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/i.test(prompt) ||
+      /\bnormal mode\b/i.test(prompt)) {
+    return 'off';
+  }
+
+  // Expanded /caveman command template (opencode plugin path).
+  // opencode replaces a typed "/caveman <level>" with the command file's
+  // body ("Activate caveman mode: $ARGUMENTS ...") before chat.message
+  // fires — recover the level argument from the template's first line.
+  if (options.expandedTpl) {
+    const tpl = /^activate caveman mode:[ \t]*(\S*)/.exec(prompt);
+    if (tpl) {
+      const arg = tpl[1] || '';
+      if (arg === 'off' || arg === 'stop' || arg === 'disable') return 'off';
+      if (arg === 'wenyan-full') return 'wenyan';
+      if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) return arg;
+      return null;  // Unknown arg — leave flag untouched
+    }
+  }
+
+  // Natural-language activation and brevity triggers (promised in README).
+  if (/\b(activate|enable|turn on|start|talk like)\b.*\bcaveman\b/i.test(prompt) ||
+      /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt) ||
+      /\b(less tokens|fewer tokens|be brief|be terse|shorter answers)\b/i.test(prompt)) {
+    const mode = getDefaultMode();
+    return mode === 'off' ? null : mode;
+  }
+
+  // Slash-command parsing.
+  if (prompt.startsWith('/caveman')) {
+    const parts = prompt.split(/\s+/);
+    const cmd = parts[0];
+    const arg = parts[1] || '';
+
+    if (cmd === '/caveman-commit')   return 'commit';
+    if (cmd === '/caveman-review')   return 'review';
+    if (cmd === '/caveman-compress') return 'compress';
+
+    if (cmd === '/caveman') {
+      if (!arg)                                     return getDefaultMode();
+      if (arg === 'off' || arg === 'stop' || arg === 'disable') return 'off';
+      if (arg === 'wenyan-full')                    return 'wenyan';
+      if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) return arg;
+      return null;  // Unknown arg — leave flag untouched
+    }
+  }
+
+  return null;
+}
+
+module.exports = { parseModeChange, INDEPENDENT_MODES };

--- a/src/plugins/opencode/plugin.js
+++ b/src/plugins/opencode/plugin.js
@@ -69,10 +69,7 @@ function loadConfig() {
 }
 const config = loadConfig();
 
-const { getDefaultMode, safeWriteFlag, readFlag, VALID_MODES } = config;
-
-// Modes handled by independent skills — not selectable via /caveman <arg>.
-const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
+const { getDefaultMode, safeWriteFlag, readFlag } = config;
 
 // opencode resolves its config dir from $XDG_CONFIG_HOME, else ~/.config/opencode
 // on every platform — including Windows, where it uses %USERPROFILE%\.config\opencode
@@ -93,72 +90,19 @@ function reinforcementLine(mode) {
     'Code/commits/security: write normal.';
 }
 
-// Parse a prompt for slash-command activation or natural-language toggles.
-// Returns the new mode to write, the literal string 'off' to deactivate, or
-// null when the prompt doesn't change state. Mirrors caveman-mode-tracker.js.
-function parseModeChange(promptRaw) {
-  let prompt = (promptRaw || '').trim();
-  // opencode's non-interactive `run` path delivers the message wrapped in
-  // literal quote characters ("/caveman ultra"\n) — unwrap symmetric quotes
-  // so the slash-command branch still matches.
-  const wrapped = /^(["'`])([\s\S]*)\1$/.exec(prompt);
-  if (wrapped) prompt = wrapped[2].trim();
-  prompt = prompt.toLowerCase();
-  if (!prompt) return null;
-
-  // Natural-language deactivation — checked before activation so "stop talking
-  // like caveman" doesn't trip the activation regex.
-  if (/\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/i.test(prompt) ||
-      /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/i.test(prompt) ||
-      /\bnormal mode\b/i.test(prompt)) {
-    return 'off';
-  }
-
-  // Expanded /caveman command template. opencode replaces a typed
-  // "/caveman <level>" with the command file's body ("Activate caveman
-  // mode: $ARGUMENTS ...") before chat.message fires, so the literal
-  // slash-command branch below never sees it — recover the level argument
-  // from the template's first line instead. Must run before the generic
-  // NL-activation match, which would swallow it and drop the level.
-  const tpl = /^activate caveman mode:[ \t]*(\S*)/.exec(prompt);
-  if (tpl) {
-    const arg = tpl[1] || '';
-    if (arg === 'off' || arg === 'stop' || arg === 'disable') return 'off';
-    if (arg === 'wenyan-full') return 'wenyan';
-    if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) return arg;
-    return getDefaultMode();
-  }
-
-  // Natural-language activation
-  if (/\b(activate|enable|turn on|start|talk like)\b.*\bcaveman\b/i.test(prompt) ||
-      /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt)) {
-    const mode = getDefaultMode();
-    return mode === 'off' ? null : mode;
-  }
-
-  // Slash-command parsing — opencode also expands command files, but if the
-  // user types the literal slash command we still want to flip the flag.
-  if (prompt.startsWith('/caveman')) {
-    const parts = prompt.split(/\s+/);
-    const cmd = parts[0];
-    const arg = parts[1] || '';
-
-    if (cmd === '/caveman-commit')   return 'commit';
-    if (cmd === '/caveman-review')   return 'review';
-    if (cmd === '/caveman-compress') return 'compress';
-
-    if (cmd === '/caveman') {
-      if (!arg)                                     return getDefaultMode();
-      if (arg === 'off' || arg === 'stop' || arg === 'disable') return 'off';
-      if (arg === 'wenyan-full')                    return 'wenyan';
-      if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) return arg;
-      // Unknown arg — leave flag alone. No silent overwrite.
-      return null;
-    }
-  }
-
-  return null;
+// Load shared parser using the same manual-eval approach as loadConfig().
+function loadParse() {
+  const installed = join(here, 'caveman-parse.cjs');
+  const dev = join(here, '..', '..', 'hooks', 'caveman-parse.js');
+  const target = existsSync(installed) ? installed : dev;
+  const code = readFileSync(target, 'utf8').replace(/^#![^\n]*\n/, '');
+  const mod = { exports: {} };
+  new Function('module', 'exports', 'require', '__dirname', '__filename', code)(
+    mod, mod.exports, createRequire(target), dirname(target), target
+  );
+  return mod.exports;
 }
+const { parseModeChange, INDEPENDENT_MODES } = loadParse();
 
 function applyModeChange(mode) {
   if (!mode) return;


### PR DESCRIPTION
## Problem

The opencode plugin mode parsing (`src/plugins/opencode/plugin.js:99-161`) had drifted from the Claude Code tracker (`src/hooks/caveman-mode-tracker.js`). Three confirmed divergences:

1. **Brevity triggers missing** — "less tokens" / "fewer tokens" / "be brief" / "be terse" / "shorter answers" only worked in the tracker, not the plugin.
2. **Bogus level overwrites flag** — expanded-template branch fell through to `getDefaultMode()` for unknown levels, silently overwriting the flag. Tracker and slash-command branch correctly return null.
3. **Independent modes unreachable** — opencode expands `/caveman-commit` etc. into command descriptions that match no parse branch, so the flag never flipped and per-turn reinforcement kept injecting.

## Fix

Extracted the parsing into `src/hooks/caveman-parse.js` — a shared CJS module consumed by both the tracker and the opencode plugin. `bin/install.js` updated to copy `caveman-parse.{js->cjs}` alongside `caveman-config.{js->cjs}` for the opencode plugin install path.

All three bugs are fixed in the single shared `parseModeChange()`: brevity triggers are included, unknown levels return null, and independent modes are reachable via their slash commands.

## Validation

- 28 unit tests passing covering all three bugs, deactivation, activation, slash commands, and quote unwrapping
- All four changed files pass Node.js syntax check

Closes #602