### PR TITLE
fix(commands): /caveman-init works for installed users

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -55,7 +55,7 @@ const HOOK_FILES = [
 function parseArgs(argv) {
   const opts = {
     dryRun: false, force: false, skipSkills: false,
-    withHooks: 'auto', withInit: false, withMcpShrink: false,
+    withHooks: 'auto', withInit: false, initOnly: false, withMcpShrink: false,
     all: false, minimal: false, listOnly: false, noColor: false,
     only: [], uninstall: false, nonInteractive: false,
     configDir: null, help: false,
@@ -83,6 +83,11 @@ function parseArgs(argv) {
       case '--with-hooks': opts.withHooks = true; break;
       case '--no-hooks': opts.withHooks = false; break;
       case '--with-init': opts.withInit = true; break;
+      // Init-only mode: write per-repo rule files, skip every agent install.
+      // This is what the /caveman-init slash command shipped to Codex/Gemini
+      // users runs — a slash command must not kick off the full provider
+      // matrix as a side effect (issue #603).
+      case '--init-only': opts.initOnly = true; opts.withInit = true; break;
       case '--with-mcp-shrink': {
         const v = argv[i + 1];
         if (v && !v.startsWith('--')) {
@@ -1257,6 +1262,8 @@ FLAGS
                         + statusline badge. (Default ON.)
   --no-hooks            Skip the hooks installer.
   --with-init           Write per-repo IDE rule files into \$PWD.
+  --init-only           Only write per-repo IDE rule files; skip all agent
+                        installs. (What the /caveman-init command runs.)
   --with-mcp-shrink="<upstream cmd>"
                         Claude Code (and opencode): register caveman-shrink MCP
                         proxy wrapping the given upstream. Default OFF.
@@ -1318,7 +1325,7 @@ async function main() {
   const detected = PROVIDERS.filter(p => detectMatch(p.detect));
 
   // TTY-only multi-select prompt when no --only and no --non-interactive.
-  if (opts.only.length === 0 && !opts.nonInteractive) {
+  if (!opts.initOnly && opts.only.length === 0 && !opts.nonInteractive) {
     const picks = await promptForOnly(detected);
     if (picks) opts.only = picks;
   }
@@ -1330,7 +1337,7 @@ async function main() {
   // are auto-skipped — user must opt in via `--only <id>`. Stops the installer
   // from firing `npx skills add ...` against agents the user never installed
   // just because some other tool created `~/.foo` along the way.
-  for (const prov of PROVIDERS) {
+  for (const prov of (opts.initOnly ? [] : PROVIDERS)) {
     if (!want(prov.id)) continue;
     if (prov.soft && !explicit(prov.id)) continue;
     // Auto-detect mode: skip providers we can't see. With --only <id> the user
@@ -1347,7 +1354,7 @@ async function main() {
   }
 
   // Auto-detect fallback if nothing matched
-  if (!opts.skipSkills && opts.only.length === 0 && ctx.results.detected === 0) {
+  if (!opts.initOnly && !opts.skipSkills && opts.only.length === 0 && ctx.results.detected === 0) {
     ctx.say('→ no known agents detected — running npx-skills auto-detect fallback');
     // --yes --all for the same reason as installViaSkills above (issue #370):
     // skip the interactive skill picker so curl|bash actually installs.

--- a/commands/caveman-init.toml
+++ b/commands/caveman-init.toml
@@ -1,2 +1,2 @@
 description = "Drop the always-on caveman activation rule into the current repo for every IDE agent"
-prompt = "Run `node src/tools/caveman-init.js {{args}}` in the current repo and report the result. Use --dry-run first if the user did not pass --force, so we never silently overwrite an existing rule file."
+prompt = "Run `npx -y github:JuliusBrussee/caveman -- --init-only {{args}}` in the current repo and report the result. Use --dry-run first if the user did not pass --force, so we never silently overwrite an existing rule file."

--- a/tests/installer/e2e.dryrun.test.mjs
+++ b/tests/installer/e2e.dryrun.test.mjs
@@ -57,3 +57,26 @@ test('dry-run --uninstall does not delete files', () => {
   assert.equal(fs.existsSync(fake), true);
   assert.equal(fs.readFileSync(path.join(cfg, 'settings.json'), 'utf8'), before);
 });
+
+// ── Test: --init-only skips every agent install (issue #603) ───────────────
+// The /caveman-init slash command shipped to Codex/Gemini users runs
+// `npx ... -- --init-only`. It must write per-repo rule files and NOTHING
+// else — no plugin installs, no npx-skills fallback, no interactive prompt.
+test('--init-only dry-run plans rule files only, no agent installs', () => {
+  const cfg = freshTmpDir();
+  const cwd = freshTmpDir();
+  const r = spawnSync('node', [INSTALLER,
+    '--init-only', '--dry-run', '--no-mcp-shrink',
+    '--config-dir', cfg,
+  ], { encoding: 'utf8', cwd, env: { ...process.env, CLAUDE_CONFIG_DIR: cfg } });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /writing per-repo IDE rule files/);
+  // No provider may run — not even ones detected on this machine.
+  assert.doesNotMatch(r.stdout, /Claude Code detected/);
+  assert.doesNotMatch(r.stdout, /Gemini CLI detected/);
+  assert.doesNotMatch(r.stdout, /would run: claude plugin/);
+  assert.doesNotMatch(r.stdout, /skills add/);
+  // Dry run — nothing written anywhere.
+  assert.equal(fs.existsSync(path.join(cfg, 'settings.json')), false);
+  assert.equal(fs.readdirSync(cwd).length, 0);
+});


### PR DESCRIPTION
## What happen

`commands/caveman-init.toml` tells the agent to run `node src/tools/caveman-init.js {{args}}` "in the current repo". For every installed Codex / Gemini-extension user, cwd is **their** project — that path only exists inside a caveman clone, so `/caveman-init` fails with `Cannot find module` for everyone except caveman developers.

Fixes #603.

## Fix

Two parts:

1. **New `--init-only` flag in `bin/install.js`** — writes the per-repo IDE rule files and skips everything else: the provider install matrix, the interactive TTY picker, and the npx-skills auto-detect fallback. Rationale: the TOML can't just use `--with-init`, because that runs the full agent-install matrix as a side effect — a slash command named *init* must not silently install plugins.
2. **TOML now runs the installer that works from anywhere:** `npx -y github:JuliusBrussee/caveman -- --init-only {{args}}`. `--dry-run` / `--force` pass straight through, so the existing prompt guidance ("dry-run first unless the user passed --force") keeps working.

The other three TOML stubs are prompt-only (no paths) — unaffected.

## Tests

New dry-run e2e test: `--init-only --dry-run` plans rule files, and asserts **no** provider output appears (no `Claude Code detected`, no `would run: claude plugin`, no `skills add`), and nothing is written. Also verified live in a scratch git repo (with `OPENCLAW_WORKSPACE` isolated): `.cursor/`, `.windsurf/`, `.clinerules/`, `.github/`, `.opencode/`, `AGENTS.md` written; zero agent installs triggered. Dry-run suite 3/3, `node --check` clean.