### PR TITLE
test(mcp-shrink): guard npm files[] against missing relative requires

### DIFF
--- a/tests/test_mcp_shrink.js
+++ b/tests/test_mcp_shrink.js
@@ -30,6 +30,28 @@ function test(name, fn) {
 
 console.log('mcp-shrink compress tests\n');
 
+// ── Packaging guard (issue #597) ──────────────────────────────────────────
+// Every relative require() reachable from the published entry points must be
+// listed in package.json "files", or `npm publish` ships a package that
+// crashes on launch (spawn-options.js was missing from the 0.1.0 file list).
+test('package.json files[] covers all relative requires of shipped js', () => {
+  const fs = require('fs');
+  const pkgDir = path.join(ROOT, 'src', 'mcp-servers', 'caveman-shrink');
+  const pkg = JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf8'));
+  const shipped = new Set(pkg.files);
+  for (const f of pkg.files.filter(f => f.endsWith('.js'))) {
+    const src = fs.readFileSync(path.join(pkgDir, f), 'utf8');
+    const re = /require\(\s*['"]\.\/([^'"]+)['"]\s*\)/g;
+    let m;
+    while ((m = re.exec(src)) !== null) {
+      const dep = m[1].endsWith('.js') ? m[1] : m[1] + '.js';
+      assert.ok(shipped.has(dep),
+        `${f} requires ./${dep} but package.json files[] does not ship it`);
+    }
+  }
+});
+
+
 test('drops articles', () => {
   const { compressed } = compress('The user is the owner of an account');
   assert.match(compressed, /User is owner of account/i);


### PR DESCRIPTION
## What this is now

Rescoped after a884696 landed — the maintainer's commit already ships `spawn-options.js` and bumps 0.1.1, so this PR no longer touches `package.json`. What remains is the **regression guard** so this bug class can't come back silently:

every relative `require()` reachable from the shipped js files must itself be listed in `files[]` — the test fails at CI time instead of at the next `npm publish` if a future refactor adds a helper module without shipping it (exactly how #597 happened: `spawn-options.js` was added for the Windows shell fix but `files[]` wasn't updated).

Refs #597.

## Verification

- 18/18 tests pass against current main (guard included)
- Removing `spawn-options.js` from `files[]` makes the guard fail with `index.js requires ./spawn-options.js but package.json files[] does not ship it` — verified both directions