### PR TITLE
fix(compress): UTF-8 I/O + atomic writes, no more wiped files

### DIFF
--- a/plugins/caveman/skills/caveman-compress/scripts/benchmark.py
+++ b/plugins/caveman/skills/caveman-compress/scripts/benchmark.py
@@ -23,8 +23,8 @@ def count_tokens(text):
 
 
 def benchmark_pair(orig_path: Path, comp_path: Path):
-    orig_text = orig_path.read_text()
-    comp_text = comp_path.read_text()
+    orig_text = orig_path.read_text(encoding="utf-8", errors="ignore")
+    comp_text = comp_path.read_text(encoding="utf-8", errors="ignore")
 
     orig_tokens = count_tokens(orig_text)
     comp_tokens = count_tokens(comp_text)

--- a/plugins/caveman/skills/caveman-compress/scripts/compress.py
+++ b/plugins/caveman/skills/caveman-compress/scripts/compress.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import List
 
@@ -114,6 +115,31 @@ from .detect import should_compress
 from .validate import validate
 
 MAX_RETRIES = 2
+
+
+def write_text_atomic(path: Path, text: str) -> None:
+    """UTF-8 write that can never truncate or half-write the destination.
+
+    Path.write_text opens-and-truncates the target BEFORE encoding the string,
+    so on Windows (cp1252 default) a UnicodeEncodeError on characters like →
+    left the live file 0 bytes (issue #533). Encode first, write a temp file
+    in the same directory, fsync, then os.replace — atomic on POSIX and
+    Windows, and a failure at any step leaves the destination untouched.
+    """
+    data = text.encode("utf-8")
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 # ---------- Claude Calls ----------
@@ -246,7 +272,7 @@ def compress_file(filepath: Path) -> bool:
         print("Skipping (not natural language)")
         return False
 
-    original_text = filepath.read_text(errors="ignore")
+    original_text = filepath.read_text(encoding="utf-8", errors="ignore")
     # Store backup outside the source directory so skill auto-loaders don't
     # re-ingest the `.original.md` copy as a live file. Mirror the source's
     # parent-dir name + stem under a platform-aware base to reduce collisions.
@@ -300,8 +326,8 @@ def compress_file(filepath: Path) -> bool:
     # touching the input file. If the filesystem dropped bytes (encoding,
     # antivirus, disk full), unlink the bad backup and abort instead of
     # leaving the user with a corrupt backup + compressed primary.
-    backup_path.write_text(original_text)
-    backup_readback = backup_path.read_text(errors="ignore")
+    write_text_atomic(backup_path, original_text)
+    backup_readback = backup_path.read_text(encoding="utf-8", errors="ignore")
     if backup_readback != original_text:
         print(f"❌ Backup write verification failed: {backup_path}")
         print("   In-memory original differs from on-disk backup. Aborting before touching the input file.")
@@ -310,7 +336,7 @@ def compress_file(filepath: Path) -> bool:
         except OSError:
             pass
         return False
-    filepath.write_text(compressed)
+    write_text_atomic(filepath, compressed)
 
     # Step 2: Validate + Retry
     for attempt in range(MAX_RETRIES):
@@ -328,15 +354,21 @@ def compress_file(filepath: Path) -> bool:
 
         if attempt == MAX_RETRIES - 1:
             # Restore original on failure
-            filepath.write_text(original_text)
+            write_text_atomic(filepath, original_text)
             backup_path.unlink(missing_ok=True)
             print("❌ Failed after retries — original restored")
             return False
 
         print("Fixing with Claude...")
-        compressed = call_claude(
+        fixed = call_claude(
             build_fix_prompt(original_text, compressed, result.errors)
         )
-        filepath.write_text(compressed)
+        if fixed is None or not fixed.strip():
+            # CLI failure — keep the current attempt on disk; the next
+            # validation round re-checks it and the retry cap still applies.
+            print("   Fix attempt returned no output — retrying validation.")
+            continue
+        compressed = fixed
+        write_text_atomic(filepath, compressed)
 
     return True

--- a/plugins/caveman/skills/caveman-compress/scripts/validate.py
+++ b/plugins/caveman/skills/caveman-compress/scripts/validate.py
@@ -28,7 +28,7 @@ class ValidationResult:
 
 
 def read_file(path: Path) -> str:
-    return path.read_text(errors="ignore")
+    return path.read_text(encoding="utf-8", errors="ignore")
 
 
 # ---------- Extractors ----------

--- a/skills/caveman-compress/scripts/benchmark.py
+++ b/skills/caveman-compress/scripts/benchmark.py
@@ -23,8 +23,8 @@ def count_tokens(text):
 
 
 def benchmark_pair(orig_path: Path, comp_path: Path):
-    orig_text = orig_path.read_text()
-    comp_text = comp_path.read_text()
+    orig_text = orig_path.read_text(encoding="utf-8", errors="ignore")
+    comp_text = comp_path.read_text(encoding="utf-8", errors="ignore")
 
     orig_tokens = count_tokens(orig_text)
     comp_tokens = count_tokens(comp_text)

--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import List
 
@@ -114,6 +115,31 @@ from .detect import should_compress
 from .validate import validate
 
 MAX_RETRIES = 2
+
+
+def write_text_atomic(path: Path, text: str) -> None:
+    """UTF-8 write that can never truncate or half-write the destination.
+
+    Path.write_text opens-and-truncates the target BEFORE encoding the string,
+    so on Windows (cp1252 default) a UnicodeEncodeError on characters like →
+    left the live file 0 bytes (issue #533). Encode first, write a temp file
+    in the same directory, fsync, then os.replace — atomic on POSIX and
+    Windows, and a failure at any step leaves the destination untouched.
+    """
+    data = text.encode("utf-8")
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 # ---------- Claude Calls ----------
@@ -246,7 +272,7 @@ def compress_file(filepath: Path) -> bool:
         print("Skipping (not natural language)")
         return False
 
-    original_text = filepath.read_text(errors="ignore")
+    original_text = filepath.read_text(encoding="utf-8", errors="ignore")
     # Store backup outside the source directory so skill auto-loaders don't
     # re-ingest the `.original.md` copy as a live file. Mirror the source's
     # parent-dir name + stem under a platform-aware base to reduce collisions.
@@ -300,8 +326,8 @@ def compress_file(filepath: Path) -> bool:
     # touching the input file. If the filesystem dropped bytes (encoding,
     # antivirus, disk full), unlink the bad backup and abort instead of
     # leaving the user with a corrupt backup + compressed primary.
-    backup_path.write_text(original_text)
-    backup_readback = backup_path.read_text(errors="ignore")
+    write_text_atomic(backup_path, original_text)
+    backup_readback = backup_path.read_text(encoding="utf-8", errors="ignore")
     if backup_readback != original_text:
         print(f"❌ Backup write verification failed: {backup_path}")
         print("   In-memory original differs from on-disk backup. Aborting before touching the input file.")
@@ -310,7 +336,7 @@ def compress_file(filepath: Path) -> bool:
         except OSError:
             pass
         return False
-    filepath.write_text(compressed)
+    write_text_atomic(filepath, compressed)
 
     # Step 2: Validate + Retry
     for attempt in range(MAX_RETRIES):
@@ -328,15 +354,21 @@ def compress_file(filepath: Path) -> bool:
 
         if attempt == MAX_RETRIES - 1:
             # Restore original on failure
-            filepath.write_text(original_text)
+            write_text_atomic(filepath, original_text)
             backup_path.unlink(missing_ok=True)
             print("❌ Failed after retries — original restored")
             return False
 
         print("Fixing with Claude...")
-        compressed = call_claude(
+        fixed = call_claude(
             build_fix_prompt(original_text, compressed, result.errors)
         )
-        filepath.write_text(compressed)
+        if fixed is None or not fixed.strip():
+            # CLI failure — keep the current attempt on disk; the next
+            # validation round re-checks it and the retry cap still applies.
+            print("   Fix attempt returned no output — retrying validation.")
+            continue
+        compressed = fixed
+        write_text_atomic(filepath, compressed)
 
     return True

--- a/skills/caveman-compress/scripts/validate.py
+++ b/skills/caveman-compress/scripts/validate.py
@@ -28,7 +28,7 @@ class ValidationResult:
 
 
 def read_file(path: Path) -> str:
-    return path.read_text(errors="ignore")
+    return path.read_text(encoding="utf-8", errors="ignore")
 
 
 # ---------- Extractors ----------

--- a/tests/test_compress_safety.py
+++ b/tests/test_compress_safety.py
@@ -91,3 +91,61 @@ class CompressSafetyTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class Utf8AtomicWriteTests(unittest.TestCase):
+    """Regression tests for issue #533 — cp1252 write crash truncated live file."""
+
+    def test_write_text_atomic_utf8_bytes_on_disk(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "unicode.md"
+            text = "# Arrows\n\nA → B — C ✓ 中文\n"
+            compress_mod.write_text_atomic(path, text)
+            self.assertEqual(path.read_bytes().decode("utf-8"), text)
+
+    def test_write_text_atomic_failure_leaves_destination_untouched(self):
+        # Path.write_text truncates before encoding, so an encode error used to
+        # zero the file. The atomic writer must fail WITHOUT touching it.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "keep.md"
+            path.write_text("precious content", encoding="utf-8")
+            with self.assertRaises(UnicodeEncodeError):
+                compress_mod.write_text_atomic(path, "bad \ud800 surrogate")
+            self.assertEqual(path.read_text(encoding="utf-8"), "precious content")
+            leftovers = [p for p in Path(tmp).iterdir() if p.name != "keep.md"]
+            self.assertEqual(leftovers, [], "temp file must not leak on failure")
+
+    def test_unicode_content_round_trips_through_compression(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+             tempfile.TemporaryDirectory() as data_home, \
+             mock.patch.dict(os.environ, {"XDG_DATA_HOME": data_home, "LOCALAPPDATA": data_home}):
+            original = "# Título\n\nFlow: A → B — depois C. Ünïcödé everywhere ✓\n"
+            compressed = "# Título\n\nA → B — C. ✓\n"
+            path = Path(tmp) / "task.md"
+            path.write_text(original, encoding="utf-8")
+            with mock.patch.object(compress_mod, "call_claude", return_value=compressed), \
+                 mock.patch.object(compress_mod, "validate") as v:
+                v.return_value = mock.Mock(is_valid=True, errors=[], warnings=[])
+                ok = compress_mod.compress_file(path)
+            self.assertTrue(ok)
+            self.assertEqual(path.read_bytes().decode("utf-8"), compressed)
+            backup = compress_mod.backup_dir_for(path.resolve()) / "task.original.md"
+            self.assertEqual(backup.read_bytes().decode("utf-8"), original)
+
+    def test_fix_retry_none_output_restores_original(self):
+        # call_claude returning None/empty during the fix-retry loop used to
+        # crash Path.write_text AFTER truncating the live file.
+        with tempfile.TemporaryDirectory() as tmp, \
+             tempfile.TemporaryDirectory() as data_home, \
+             mock.patch.dict(os.environ, {"XDG_DATA_HOME": data_home, "LOCALAPPDATA": data_home}):
+            original = "# Heading\n\nProse to compress with → unicode.\n"
+            path = Path(tmp) / "task.md"
+            path.write_text(original, encoding="utf-8")
+            invalid = mock.Mock(is_valid=False, errors=["broken"], warnings=[])
+            with mock.patch.object(compress_mod, "call_claude",
+                                   side_effect=["# H\n\nBad output.\n", None, None]), \
+                 mock.patch.object(compress_mod, "validate", return_value=invalid):
+                ok = compress_mod.compress_file(path)
+            self.assertFalse(ok)
+            self.assertEqual(path.read_text(encoding="utf-8"), original,
+                             "original must be restored after failed retries")


### PR DESCRIPTION
## What happen

Every file read/write in `compress.py` / `validate.py` / `benchmark.py` used the platform default encoding. On Windows that's cp1252, so any non-ASCII character (`→`, `—`, accented text, CJK) crashed with `UnicodeEncodeError` — and because `Path.write_text` **opens-and-truncates the destination before encoding the string**, the crash left the user's live file at 0 bytes. At that point the backup readback hadn't completed its job either, so there was no recovery path.

Reproduced in a clean `node:20-bookworm` container by forcing the same failure class (`LC_ALL=C PYTHONUTF8=0` → ASCII default encoding, mocked `call_claude`):

| | result | live file after |
|---|---|---|
| `main` | `UnicodeEncodeError: 'ascii' codec can't encode '\u2192'` | **0 bytes (wiped)** |
| this branch | `ok=True` | 19 bytes, `A → B done.` intact |

Fixes #533.

## Fix

- **`encoding='utf-8'`** pinned on every file read (`compress.py:249,304`, `validate.py:31`, `benchmark.py:26-27`). The repo already pins UTF-8 for the CLI subprocess and stdout — file I/O was the gap.
- **New `write_text_atomic()`** used for all four writes (backup, live write, retry write, restore): encode **first** (an encode error can no longer touch the file), write to a temp file in the same directory, fsync, `os.replace` — atomic on POSIX and Windows. Failure at any step leaves the destination untouched and cleans up the temp file.
- **Fix-retry loop guarded against `call_claude` returning `None`/empty** — previously `Path.write_text(None)` raised `TypeError` *after* truncating the live file (same data-loss class). Now it skips the write and lets the retry cap restore the original.
- `detect.py:79` deliberately left alone: reads with `errors='ignore'` never crash, it's classification-only, and PR #606 already touches that region — avoiding a cross-PR conflict.
- Plugin mirror (`plugins/caveman/skills/caveman-compress/scripts/`) synced in the same commit, since the CI sync workflow only triggers on `SKILL.md` changes.

## Tests

Four new tests in `tests/test_compress_safety.py`: UTF-8 bytes on disk; **write failure leaves destination untouched + no temp-file litter** (surrogate encode error); full unicode round-trip through `compress_file` (file + backup); `None` fix-retry output restores the original instead of crashing. Full safety suite passes locally (exit 0) and in the container.