### PR TITLE
feat(intensity): add 'smart' level - selectivity compression for readability-enforcing harnesses

### DIFF
--- a/bin/lib/openclaw.js
+++ b/bin/lib/openclaw.js
@@ -97,7 +97,7 @@ function loadBootstrapSnippet(repoRoot) {
     '',
     '  skills/caveman/SKILL.md',
     '',
-    'Default intensity: `full`. Switch with `/caveman lite|full|ultra|wenyan`.',
+    'Default intensity: `full`. Switch with `/caveman lite|full|ultra|smart|wenyan`.',
     'Stop with: "stop caveman" / "normal mode" / "deactivate caveman".',
     '',
     'Auto-Clarity: drop caveman for security warnings, irreversible action',

--- a/skills/caveman-help/SKILL.md
+++ b/skills/caveman-help/SKILL.md
@@ -17,6 +17,7 @@ Display this reference card when invoked. One-shot — do NOT change mode, write
 | **Lite** | `/caveman lite` | Drop filler. Keep sentence structure. |
 | **Full** | `/caveman` | Drop articles, filler, pleasantries, hedging. Fragments OK. Default. |
 | **Ultra** | `/caveman ultra` | Extreme compression. Bare fragments. Tables over prose. |
+| **Smart** | `/caveman smart` | Cut content, not grammar. Full sentences, zero fluff, plain-language TLDR at end. For harnesses that enforce readability (e.g. Claude Code on Fable-class models). |
 | **Wenyan-Lite** | `/caveman wenyan-lite` | Classical Chinese style, light compression. |
 | **Wenyan-Full** | `/caveman wenyan` | Full 文言文. Maximum classical terseness. |
 | **Wenyan-Ultra** | `/caveman wenyan-ultra` | Extreme. Ancient scholar on a budget. |

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -3,7 +3,7 @@ name: caveman
 description: >
   Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
   while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
-  wenyan-lite, wenyan-full, wenyan-ultra.
+  smart, wenyan-lite, wenyan-full, wenyan-ultra.
   Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
   "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
 ---
@@ -14,7 +14,7 @@ Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
 ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
 
-Default: **full**. Switch: `/caveman lite|full|ultra`.
+Default: **full**. Switch: `/caveman lite|full|ultra|smart`.
 
 ## Rules
 
@@ -36,6 +36,7 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 | **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
 | **full** | Drop articles, fragments OK, short synonyms. Classic caveman. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations |
 | **ultra** | Abbreviate prose words (DB/auth/config/req/res/fn/impl) — prose words only, never real code symbols/function names. Strip conjunctions, arrows for causality (X → Y), one word when one word enough. Code symbols, function names, API names, error strings: never abbreviate |
+| **smart** | Cut content, not grammar. Full sentences, zero fluff: drop recaps of unchanged plans, restated tool output, options not chosen, pleasantries, hedging, repeated paths/ids. Complex reply end with one plain-language TLDR line. Differs from lite at reply scale (what gets included), not sentence scale (how sentences read) |
 | **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
 | **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
@@ -54,6 +55,10 @@ Example — "Explain database connection pooling."
 - ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
 - wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
 - wenyan-ultra: "池reuse conn。skip handshake → fast。"
+
+## Model Compatibility
+
+Some agent harnesses instruct full-sentence readability in their system prompt (known today: Claude Code on Claude Fable 5 — its prompt forbids fragments, dropped articles, arrow chains). There, full/ultra fight the harness every turn; standing instruction conflict degrades output (see Anthropic's Fable 5 prompting guide on over-prescriptive style rules). On such harnesses prefer **lite** or **smart** — selectivity saves the big tokens (content), readability rules stay unbroken. Same hunt, fewer grunts, no fight with cave rules.
 
 ## Auto-Clarity
 

--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -97,7 +97,7 @@ if (skillContent) {
     'Respond terse like smart caveman. All technical substance stay. Only fluff die.\n\n' +
     '## Persistence\n\n' +
     'ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".\n\n' +
-    'Current level: **' + modeLabel + '**. Switch: `/caveman lite|full|ultra`.\n\n' +
+    'Current level: **' + modeLabel + '**. Switch: `/caveman lite|full|ultra|smart`.\n\n' +
     '## Rules\n\n' +
     'Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. ' +
     'Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.\n\n' +

--- a/src/hooks/caveman-config.js
+++ b/src/hooks/caveman-config.js
@@ -20,7 +20,7 @@ const path = require('path');
 const os = require('os');
 
 const VALID_MODES = [
-  'off', 'lite', 'full', 'ultra',
+  'off', 'lite', 'full', 'ultra', 'smart',
   'wenyan-lite', 'wenyan', 'wenyan-full', 'wenyan-ultra',
   'commit', 'review', 'compress'
 ];

--- a/src/hooks/caveman-statusline.ps1
+++ b/src/hooks/caveman-statusline.ps1
@@ -28,7 +28,7 @@ try {
 $Mode = $Mode.ToLowerInvariant()
 $Mode = ($Mode -replace '[^a-z0-9-]', '')
 
-$Valid = @('off','lite','full','ultra','wenyan-lite','wenyan','wenyan-full','wenyan-ultra','commit','review','compress')
+$Valid = @('off','lite','full','ultra','smart','wenyan-lite','wenyan','wenyan-full','wenyan-ultra','commit','review','compress')
 if (-not ($Valid -contains $Mode)) { exit 0 }
 
 $Esc = [char]27

--- a/src/hooks/caveman-statusline.sh
+++ b/src/hooks/caveman-statusline.sh
@@ -23,7 +23,7 @@ MODE=$(printf '%s' "$MODE" | tr -cd 'a-z0-9-')
 
 # Whitelist. Anything else → render nothing rather than echo attacker bytes.
 case "$MODE" in
-  off|lite|full|ultra|wenyan-lite|wenyan|wenyan-full|wenyan-ultra|commit|review|compress) ;;
+  off|lite|full|ultra|smart|wenyan-lite|wenyan|wenyan-full|wenyan-ultra|commit|review|compress) ;;
   *) exit 0 ;;
 esac
 

--- a/src/rules/caveman-activate.md
+++ b/src/rules/caveman-activate.md
@@ -7,7 +7,7 @@ Rules:
 - Not: "Sure! I'd be happy to help you with that."
 - Yes: "Bug in auth middleware. Fix:"
 
-Switch level: /caveman lite|full|ultra|wenyan
+Switch level: /caveman lite|full|ultra|smart|wenyan
 Stop: "stop caveman" or "normal mode"
 
 Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.

--- a/src/tools/caveman-init.js
+++ b/src/tools/caveman-init.js
@@ -24,7 +24,7 @@ Rules:
 - Not: "Sure! I'd be happy to help you with that."
 - Yes: "Bug in auth middleware. Fix:"
 
-Switch level: /caveman lite|full|ultra|wenyan
+Switch level: /caveman lite|full|ultra|smart|wenyan
 Stop: "stop caveman" or "normal mode"
 
 Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.


### PR DESCRIPTION
Closes #629 (rationale + evidence there).

## What

New additive intensity level `smart`: cut content, not grammar. Full sentences, zero fluff — drop recaps, restated tool output, options-not-chosen, pleasantries, hedging; complex replies end with one plain-language TLDR line. Plus a short **Model Compatibility** note in SKILL.md.

## Why

On harnesses that enforce full-sentence readability in the system prompt (Claude Code on Claude Fable 5 today — its prompt explicitly forbids fragments, dropped articles, and arrow chains), `full`/`ultra` create a standing instruction conflict every turn, and the model drifts back to harness style. `smart` keeps caveman's token mission alive there by compressing at reply scale (what gets included) instead of sentence scale (how sentences read). Details + citations in #629.

## Changes

- `skills/caveman/SKILL.md` — `smart` row in intensity table, frontmatter level list, switch hint, Model Compatibility section (source of truth only; mirrors under `plugins/` left to the rebuild per CONTRIBUTING)
- `src/hooks/caveman-config.js` — `smart` in `VALID_MODES`
- `src/hooks/caveman-statusline.{ps1,sh}` — whitelist entry (renders `[CAVEMAN:SMART]` via the existing generic suffix path)
- `src/hooks/caveman-activate.js`, `src/rules/caveman-activate.md`, `src/tools/caveman-init.js`, `bin/lib/openclaw.js` — switch-hint strings
- `skills/caveman-help/SKILL.md` — help table row

## Testing

- `node tests/test_symlink_flag.js` passes
- `VALID_MODES.includes('smart')` → true via require
- No existing level's behavior changed; purely additive

Small focused PR. Same hunt, fewer grunts, no fight with cave rules.
