### PR TITLE
fix(hooks): respect repo-local defaultMode=off in per-turn reinforcement

### DIFF
--- a/src/hooks/caveman-config.js
+++ b/src/hooks/caveman-config.js
@@ -87,7 +87,11 @@ function readModeFromConfigFile(configPath) {
   return null;
 }
 
-function getDefaultMode() {
+// `startDir` (optional) overrides where the repo-local config walk begins.
+// Hooks that receive a per-event `cwd` on stdin (e.g. UserPromptSubmit) should
+// pass it so directory-scoped config tracks mid-session directory changes
+// instead of the hook process's spawn cwd.
+function getDefaultMode(startDir) {
   // 1. Environment variable (highest priority)
   const envMode = process.env.CAVEMAN_DEFAULT_MODE;
   if (envMode && VALID_MODES.includes(envMode.toLowerCase())) {
@@ -95,7 +99,7 @@ function getDefaultMode() {
   }
 
   // 2. Repo-local config (checked-in, per-project default)
-  const repoConfigPath = findRepoConfigPath(process.cwd());
+  const repoConfigPath = findRepoConfigPath(startDir || process.cwd());
   if (repoConfigPath) {
     const repoMode = readModeFromConfigFile(repoConfigPath);
     if (repoMode) return repoMode;

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -62,7 +62,7 @@ process.stdin.on('end', () => {
           /\bcaveman\s+mode\s+(on|please|now)\b/.test(prompt) ||
           /^caveman(\s+mode)?\s*[.!]*$/.test(prompt) ||
           /\b(less tokens|fewer tokens|be brief|be terse|shorter answers)\b(?!\s+(in|for|on|about|when|during|with)\b)/.test(prompt)) {
-        const mode = getDefaultMode();
+        const mode = getDefaultMode(data.cwd);
         if (mode !== 'off') {
           recordModeChange(claudeDir, mode); // #601: timestamped transition log
           safeWriteFlag(flagPath, mode);
@@ -190,7 +190,13 @@ process.stdin.on('end', () => {
       }
     }
 
-    if (activeMode && !INDEPENDENT_MODES.has(activeMode)) {
+    // Also gate on directory-scoped config: the flag file is global
+    // ($CLAUDE_CONFIG_DIR/.caveman-active), so a concurrent session in another
+    // directory can write it while this session sits in a tree whose
+    // .caveman.json says defaultMode "off". Without this check that stale/
+    // foreign flag would re-inject caveman reinforcement here every prompt.
+    if (activeMode && !INDEPENDENT_MODES.has(activeMode) &&
+        getDefaultMode(data.cwd) !== 'off') {
       process.stdout.write(JSON.stringify({
         hookSpecificOutput: {
           hookEventName: "UserPromptSubmit",


### PR DESCRIPTION
## Problem

The UserPromptSubmit flag file (`$CLAUDE_CONFIG_DIR/.caveman-active`) is global, shared across all concurrent Claude Code sessions on a machine. If session A (in some directory) activates caveman mode, it writes that flag. A concurrent session B sitting in a repo whose `.caveman.json` sets `defaultMode: "off"` would still see B's stale/foreign flag and re-inject the per-turn "CAVEMAN MODE ACTIVE" reinforcement context on every prompt — silently defeating the repo-local off config.

Separately, `getDefaultMode()` always resolved the repo-local config walk from `process.cwd()` (the hook process's spawn cwd) rather than the cwd of the prompt actually being handled, so directory-scoped config could miss mid-session directory changes.

## Fix

- `src/hooks/caveman-config.js`: `getDefaultMode()` gains an optional `startDir` param, used as the start of the repo-local config walk (`findRepoConfigPath(startDir || process.cwd())`). Fully backward compatible — existing callers passing nothing behave identically.
- `src/hooks/caveman-mode-tracker.js`:
  - Natural-language activation now calls `getDefaultMode(data.cwd)`, using the per-prompt `cwd` from the hook's stdin JSON instead of the hook process's spawn cwd.
  - The per-turn reinforcement emit is additionally gated on `getDefaultMode(data.cwd) !== 'off'`, so a foreign/stale global flag can no longer override a directory's repo-local `off` config.

## Verification

Ran the full existing suite against the patched clone — all pass, no regressions:
- `npm test` — 112/112 pass
- `python3 -m unittest tests.test_compress_safety` — OK
- `node tests/test_caveman_init.js` — 8/8 pass
- `node tests/test_symlink_flag.js` — 12/12 pass

Additionally hand-verified the exact scenario this fixes, using a scratch `CLAUDE_CONFIG_DIR` and a test dir with `.caveman.json` = `{"defaultMode":"off"}`, piping JSON directly into `caveman-mode-tracker.js`:

| # | stdin | flag before | Expected | Result |
|---|---|---|---|---|
| A | `{"prompt":"hello there","cwd":"<off-dir>"}` | `full` | no output | ✅ no output |
| B | `{"prompt":"hello there","cwd":"<normal-dir>"}` | `full` | JSON `additionalContext` emitted | ✅ emitted |
| C | `{"prompt":"be brief please","cwd":"<off-dir>"}` | none | flag NOT created | ✅ not created |
| D | `{"prompt":"be brief please","cwd":"<normal-dir>"}` | none | flag created, contents `full` | ✅ created, `full` |

Also smoke-tested `caveman-activate.js` (SessionStart hook, unaffected by this change) run from the off-dir vs. a normal dir to confirm no regression: off-dir → no flag written, mode `off`; normal dir → flag written, `full`.

## Backward compatibility

`getDefaultMode()` is called elsewhere (e.g. `caveman-activate.js`) with no argument — `startDir` is optional and falls back to `process.cwd()`, so those call sites are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)