### PR TITLE
fix(uninstall): remove hook/stats state files from config dir

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1182,6 +1182,24 @@ function uninstall(ctx) {
     // Don't rmdir hooksDir — other plugins may use it.
   }
 
+  // State files the hooks/stats own (issue #635). Left behind, they poison a
+  // later reinstall: .caveman-mode-log.jsonl feeds stale transition rows into
+  // the #601 attribution, .caveman-statusline-suffix resurrects the old
+  // lifetime badge, and a set .caveman-active re-arms caveman immediately.
+  // .caveman-history.jsonl stays — it's the user's lifetime stats record —
+  // with a note so the choice is visible.
+  const STATE_FILES = ['.caveman-active', '.caveman-active.prev', '.caveman-mode-log.jsonl', '.caveman-statusline-suffix'];
+  for (const f of STATE_FILES) {
+    const p = path.join(configDir, f);
+    if (!fs.existsSync(p)) continue;
+    if (!opts.dryRun) { try { fs.unlinkSync(p); } catch (_) {} }
+    note(`  removed ${p}`);
+  }
+  const historyPath = path.join(configDir, '.caveman-history.jsonl');
+  if (fs.existsSync(historyPath)) {
+    note(`  kept ${historyPath} (lifetime stats) — delete manually if unwanted`);
+  }
+
   // Plugin uninstall on Claude. Probe `plugin list` first so a re-run on a
   // machine where caveman was never installed (or was already removed) doesn't
   // print "Plugin not installed" stderr noise.
@@ -1315,9 +1333,7 @@ function uninstall(ctx) {
     if (prunedHermes) ok('  pruned caveman skills from Hermes');
   }
 
-  // Flag file
-  const flag = path.join(configDir, '.caveman-active');
-  if (fs.existsSync(flag) && !opts.dryRun) { try { fs.unlinkSync(flag); } catch (_) {} }
+  // .caveman-active is handled with the other state files above (issue #635).
 
   process.stdout.write('\n');
   ok('uninstall done.');

--- a/tests/installer/e2e.freshinstall.test.mjs
+++ b/tests/installer/e2e.freshinstall.test.mjs
@@ -554,3 +554,34 @@ test('missing claude CLI: reports failure and falls back to standalone hook wiri
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// ── Test: uninstall removes caveman state files (issue #635) ────────────────
+// The hooks/stats write five state files into $CLAUDE_CONFIG_DIR. Uninstall
+// must remove the ephemeral four (a stale mode-log poisons #601 attribution
+// on reinstall; a stale suffix resurrects the old lifetime badge; a set
+// .caveman-active re-arms caveman immediately) and keep the lifetime history.
+test('uninstall removes state files, keeps lifetime history', () => {
+  const dir = freshTmpDir();
+  const emptyBin = path.join(dir, 'empty-bin');
+  fs.mkdirSync(emptyBin);
+  const cfg = path.join(dir, 'cfg');
+  fs.mkdirSync(path.join(cfg, 'hooks'), { recursive: true });
+  const state = ['.caveman-active', '.caveman-active.prev', '.caveman-mode-log.jsonl', '.caveman-statusline-suffix'];
+  for (const f of state) fs.writeFileSync(path.join(cfg, f), 'x');
+  fs.writeFileSync(path.join(cfg, '.caveman-history.jsonl'), '{"ts":1}\n');
+  fs.writeFileSync(path.join(cfg, 'hooks', 'caveman-activate.js'), '');
+  try {
+    const r = spawnSync(process.execPath, [
+      INSTALLER, '--uninstall', '--non-interactive', '--config-dir', cfg,
+    ], { env: { ...process.env, PATH: emptyBin, CLAUDE_CONFIG_DIR: cfg, NO_COLOR: '1' }, encoding: 'utf8' });
+    assert.equal(r.status, 0, r.stderr);
+    for (const f of state) {
+      assert.equal(fs.existsSync(path.join(cfg, f)), false, `${f} should be removed by uninstall`);
+    }
+    assert.ok(fs.existsSync(path.join(cfg, '.caveman-history.jsonl')), 'lifetime history must be kept');
+    assert.match(r.stdout, /kept .*caveman-history\.jsonl/);
+    assert.equal(fs.existsSync(path.join(cfg, 'hooks', 'caveman-activate.js')), false, 'hook file should be removed');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What happen

`--uninstall` removes `.caveman-active` but leaves the newer state files behind in `$CLAUDE_CONFIG_DIR`:

- `.caveman-active.prev` — one-shot mode restore (from #608)
- `.caveman-mode-log.jsonl` — the #601 mode-transition log (e9cb843)
- `.caveman-statusline-suffix` — pre-rendered lifetime badge

On a later reinstall, the stale mode-log feeds transition rows from the previous install into the #601 stats attribution, and the suffix resurrects the old lifetime number immediately. Verified in a clean `node:20-bookworm` container (details and an honest correction of my original repro in #635).

Fixes #635.

## Fix

Consolidates state-file removal into one block in `uninstall()` (replacing the lone `// Flag file` removal at the tail): `.caveman-active`, `.caveman-active.prev`, `.caveman-mode-log.jsonl`, `.caveman-statusline-suffix` are removed; `.caveman-history.jsonl` is **deliberately kept** — it's the user's lifetime stats record — with a printed `kept … delete manually if unwanted` note so the choice is visible rather than silent. Happy to flip that to remove-by-default if you'd rather uninstall leave zero trace.

## Tests

New e2e test (runs without the `claude` CLI — empty PATH, so it exercises everywhere): seeds all five files + a hook file, runs `--uninstall`, asserts the four ephemeral files and the hook are gone, history kept, and the note printed. Container run: 51 tests, 47 pass, 4 skipped (claude-CLI-dependent), 0 fail; live container round-trip leaves only `.caveman-history.jsonl`.