### PR TITLE
feat(compress): --undo restores the pre-compression backup

### DIFF
--- a/plugins/caveman/skills/caveman-compress/SKILL.md
+++ b/plugins/caveman/skills/caveman-compress/SKILL.md
@@ -17,6 +17,10 @@ Compress natural language files (CLAUDE.md, todos, preferences) into caveman-spe
 
 `/caveman-compress <filepath>` or when user asks to compress a memory file.
 
+## Undo
+
+User asks to undo/restore/revert a compression → run `python3 -m scripts --undo <absolute_filepath>` from the directory containing this SKILL.md. Restores the file from its backup byte-exact and removes the backup (compression refuses to run while a backup exists). Errors clearly when no backup exists.
+
 ## Process
 
 1. The compression scripts live in `scripts/` (adjacent to this SKILL.md). If the path is not immediately available, search for `scripts/__main__.py` next to this SKILL.md.

--- a/plugins/caveman/skills/caveman-compress/scripts/cli.py
+++ b/plugins/caveman/skills/caveman-compress/scripts/cli.py
@@ -21,20 +21,89 @@ for _stream in (sys.stdout, sys.stderr):
 
 from pathlib import Path
 
+import os
+import tempfile
+
 from .compress import backup_dir_for, compress_file
 from .detect import detect_file_type, should_compress
 
 
 def print_usage():
     print("Usage: caveman <filepath>")
+    print("       caveman --undo <filepath>   restore the pre-compression backup")
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Write bytes via temp file + os.replace so a failure never truncates."""
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def undo_file(filepath: Path) -> int:
+    """Restore <file> from its pre-compression backup and remove the backup.
+
+    Looks in the current out-of-tree backup dir first (issue #420 layout),
+    then falls back to the legacy in-tree `<file>.original.md` sibling.
+    Removing the backup after a verified restore matters: compress_file
+    refuses to run while a backup exists, so a kept backup would block the
+    next compression of the same file.
+    """
+    filepath = filepath.resolve()
+    candidates = [
+        backup_dir_for(filepath) / (filepath.stem + ".original.md"),
+        filepath.parent / (filepath.stem + ".original.md"),
+    ]
+    backup_path = next((p for p in candidates if p.is_file()), None)
+    if backup_path is None:
+        print(f"❌ No backup found for {filepath}")
+        print("   Looked in:")
+        for p in candidates:
+            print(f"   - {p}")
+        print("   (Backups are created by compression; nothing to undo.)")
+        return 1
+
+    data = backup_path.read_bytes()
+    _atomic_write_bytes(filepath, data)
+    if filepath.read_bytes() != data:
+        print(f"❌ Restore verification failed for {filepath} — backup kept at {backup_path}")
+        return 2
+    try:
+        backup_path.unlink()
+    except OSError:
+        print(f"⚠️ Restored, but could not remove backup: {backup_path}")
+        print("   Remove it manually — compression refuses to run while it exists.")
+        return 0
+    print(f"Restored: {filepath}")
+    print(f"Removed backup: {backup_path}")
+    return 0
 
 
 def main():
-    if len(sys.argv) != 2:
+    args = [a for a in sys.argv[1:] if a != "--undo"]
+    undo = "--undo" in sys.argv[1:]
+    if len(args) != 1:
         print_usage()
         sys.exit(1)
 
-    filepath = Path(sys.argv[1])
+    if undo:
+        target = Path(args[0])
+        if not target.is_file():
+            print(f"❌ File not found: {target}")
+            sys.exit(1)
+        sys.exit(undo_file(target))
+
+    filepath = Path(args[0])
 
     # Check file exists
     if not filepath.exists():

--- a/skills/caveman-compress/SKILL.md
+++ b/skills/caveman-compress/SKILL.md
@@ -17,6 +17,10 @@ Compress natural language files (CLAUDE.md, todos, preferences) into caveman-spe
 
 `/caveman-compress <filepath>` or when user asks to compress a memory file.
 
+## Undo
+
+User asks to undo/restore/revert a compression → run `python3 -m scripts --undo <absolute_filepath>` from the directory containing this SKILL.md. Restores the file from its backup byte-exact and removes the backup (compression refuses to run while a backup exists). Errors clearly when no backup exists.
+
 ## Process
 
 1. The compression scripts live in `scripts/` (adjacent to this SKILL.md). If the path is not immediately available, search for `scripts/__main__.py` next to this SKILL.md.

--- a/skills/caveman-compress/scripts/cli.py
+++ b/skills/caveman-compress/scripts/cli.py
@@ -21,20 +21,89 @@ for _stream in (sys.stdout, sys.stderr):
 
 from pathlib import Path
 
+import os
+import tempfile
+
 from .compress import backup_dir_for, compress_file
 from .detect import detect_file_type, should_compress
 
 
 def print_usage():
     print("Usage: caveman <filepath>")
+    print("       caveman --undo <filepath>   restore the pre-compression backup")
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Write bytes via temp file + os.replace so a failure never truncates."""
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def undo_file(filepath: Path) -> int:
+    """Restore <file> from its pre-compression backup and remove the backup.
+
+    Looks in the current out-of-tree backup dir first (issue #420 layout),
+    then falls back to the legacy in-tree `<file>.original.md` sibling.
+    Removing the backup after a verified restore matters: compress_file
+    refuses to run while a backup exists, so a kept backup would block the
+    next compression of the same file.
+    """
+    filepath = filepath.resolve()
+    candidates = [
+        backup_dir_for(filepath) / (filepath.stem + ".original.md"),
+        filepath.parent / (filepath.stem + ".original.md"),
+    ]
+    backup_path = next((p for p in candidates if p.is_file()), None)
+    if backup_path is None:
+        print(f"❌ No backup found for {filepath}")
+        print("   Looked in:")
+        for p in candidates:
+            print(f"   - {p}")
+        print("   (Backups are created by compression; nothing to undo.)")
+        return 1
+
+    data = backup_path.read_bytes()
+    _atomic_write_bytes(filepath, data)
+    if filepath.read_bytes() != data:
+        print(f"❌ Restore verification failed for {filepath} — backup kept at {backup_path}")
+        return 2
+    try:
+        backup_path.unlink()
+    except OSError:
+        print(f"⚠️ Restored, but could not remove backup: {backup_path}")
+        print("   Remove it manually — compression refuses to run while it exists.")
+        return 0
+    print(f"Restored: {filepath}")
+    print(f"Removed backup: {backup_path}")
+    return 0
 
 
 def main():
-    if len(sys.argv) != 2:
+    args = [a for a in sys.argv[1:] if a != "--undo"]
+    undo = "--undo" in sys.argv[1:]
+    if len(args) != 1:
         print_usage()
         sys.exit(1)
 
-    filepath = Path(sys.argv[1])
+    if undo:
+        target = Path(args[0])
+        if not target.is_file():
+            print(f"❌ File not found: {target}")
+            sys.exit(1)
+        sys.exit(undo_file(target))
+
+    filepath = Path(args[0])
 
     # Check file exists
     if not filepath.exists():

--- a/tests/test_compress_undo.py
+++ b/tests/test_compress_undo.py
@@ -1,0 +1,95 @@
+"""Tests for `python -m scripts --undo <file>` (compress backup restore).
+
+Undo must restore the pre-compression bytes exactly, remove the backup so a
+future compression is not blocked by the backup-exists guard, support the
+legacy in-tree sibling backup, and fail loudly (file untouched) when no
+backup exists.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_DIR = REPO_ROOT / "skills" / "caveman-compress"
+sys.path.insert(0, str(PKG_DIR))
+
+from scripts import compress as compress_mod  # noqa: E402
+
+
+def run_undo(target: Path, data_home: Path):
+    env = os.environ.copy()
+    env["XDG_DATA_HOME"] = str(data_home)
+    env["LOCALAPPDATA"] = str(data_home)
+    return subprocess.run(
+        [sys.executable, "-m", "scripts", "--undo", str(target)],
+        cwd=PKG_DIR,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+class CompressUndoTests(unittest.TestCase):
+    def test_undo_restores_out_of_tree_backup_and_removes_it(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+             tempfile.TemporaryDirectory() as data_home:
+            original = "# Doc\n\nOriginal prose with unicode → intact.\n"
+            path = Path(tmp) / "task.md"
+            path.write_text("# Doc\n\nCompressed.\n", encoding="utf-8")
+            env_backup = {"XDG_DATA_HOME": data_home, "LOCALAPPDATA": data_home}
+            os.environ.update(env_backup)
+            try:
+                backup_dir = compress_mod.backup_dir_for(path.resolve())
+            finally:
+                for k in env_backup:
+                    os.environ.pop(k, None)
+            backup_dir.mkdir(parents=True, exist_ok=True)
+            backup = backup_dir / "task.original.md"
+            backup.write_text(original, encoding="utf-8")
+
+            r = run_undo(path, Path(data_home))
+
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertEqual(path.read_text(encoding="utf-8"), original)
+            self.assertFalse(backup.exists(), "backup must be removed after restore")
+
+    def test_undo_falls_back_to_legacy_sibling_backup(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+             tempfile.TemporaryDirectory() as data_home:
+            original = "# Doc\n\nLegacy layout original.\n"
+            path = Path(tmp) / "task.md"
+            path.write_text("compressed", encoding="utf-8")
+            sibling = Path(tmp) / "task.original.md"
+            sibling.write_text(original, encoding="utf-8")
+
+            r = run_undo(path, Path(data_home))
+
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertEqual(path.read_text(encoding="utf-8"), original)
+            self.assertFalse(sibling.exists())
+
+    def test_undo_without_backup_fails_and_leaves_file_alone(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+             tempfile.TemporaryDirectory() as data_home:
+            path = Path(tmp) / "task.md"
+            path.write_text("current content", encoding="utf-8")
+
+            r = run_undo(path, Path(data_home))
+
+            self.assertEqual(r.returncode, 1)
+            self.assertIn("No backup found", r.stdout)
+            self.assertEqual(path.read_text(encoding="utf-8"), "current content")
+
+    def test_undo_missing_file_errors(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+             tempfile.TemporaryDirectory() as data_home:
+            r = run_undo(Path(tmp) / "absent.md", Path(data_home))
+            self.assertEqual(r.returncode, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`caveman-compress` keeps a backup, but restoring it means manually copying a file out of a platform-specific data dir most users will never find. New command:

```
python3 -m scripts --undo <file>
```

Finds the backup (out-of-tree #420 layout first, legacy in-tree `<file>.original.md` sibling as fallback), restores **byte-exact** via atomic temp+`os.replace`, verifies the readback, then removes the backup — `compress_file` refuses to run while a backup exists, so keeping it would block the next compression of the same file. Clear error (file untouched) when there's nothing to undo. SKILL.md documents the trigger ("undo/restore/revert a compression"); mirror synced same-commit.

Deliberately implemented entirely in `cli.py` so it can't conflict with #626 (which touches `compress.py`).

## Tests

4 new tests: out-of-tree restore + backup removal, legacy sibling fallback, no-backup error path leaves the file alone, missing file errors. Validated in a clean `node:20-bookworm` container: 9/9 (undo + compress-safety suites), plus a live round-trip — unicode content restored byte-exact.