### PR TITLE
feat(cli): caveman config show/get/set/unset

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1407,13 +1407,118 @@ EXAMPLES
   npx -y github:JuliusBrussee/caveman -- --all               # all the trimmings
   npx -y github:JuliusBrussee/caveman -- --only claude --no-mcp-shrink
   npx -y github:JuliusBrussee/caveman -- --uninstall
+  npx -y github:JuliusBrussee/caveman -- config show     # mode resolution
+  npx -y github:JuliusBrussee/caveman -- config set intensity ultra
+  npx -y github:JuliusBrussee/caveman -- config set mode full --project
 
   Issues: https://github.com/${REPO}/issues
 `);
 }
 
+// ── `caveman config` subcommand ────────────────────────────────────────────
+// CLI sugar over the config files the hooks already read:
+//   caveman config show                 resolution chain + effective mode
+//   caveman config get <key>            effective value
+//   caveman config set <key> <value>    user scope (--project → repo scope)
+//   caveman config unset <key>          remove key from chosen scope
+// Keys: defaultMode (aliases: mode, intensity). Values validated against
+// VALID_MODES so a typo can't silently break activation.
+function loadHookConfig() {
+  try { return require(path.join(__dirname, '..', 'src', 'hooks', 'caveman-config')); }
+  catch (_) { return null; }
+}
+
+const CONFIG_KEY_ALIASES = { mode: 'defaultMode', intensity: 'defaultMode', defaultmode: 'defaultMode' };
+
+function runConfigCommand(args) {
+  const hookCfg = loadHookConfig();
+  if (!hookCfg) {
+    process.stderr.write('caveman config: cannot load src/hooks/caveman-config.js (run from the caveman package)\n');
+    return 2;
+  }
+  const { VALID_MODES, getConfigPath, findRepoConfigPath, getDefaultMode } = hookCfg;
+
+  const project = args.includes('--project');
+  const rest = args.filter(a => a !== '--project');
+  const verb = rest[0];
+
+  const userPath = getConfigPath();
+  const repoPath = findRepoConfigPath(process.cwd());
+  // set/unset --project: update the nearest checked-in config if one exists,
+  // else create ./.caveman/config.json in the current directory.
+  const projectPath = repoPath || path.join(process.cwd(), '.caveman', 'config.json');
+  const targetPath = project ? projectPath : userPath;
+
+  const readJson = (p) => {
+    const parsed = SETTINGS.readSettings(p);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  };
+
+  const resolveKey = (k) => {
+    const key = CONFIG_KEY_ALIASES[String(k || '').toLowerCase()];
+    if (!key) {
+      process.stderr.write(`caveman config: unknown key '${k}'. Known keys: defaultMode (aliases: mode, intensity)\n`);
+      return null;
+    }
+    return key;
+  };
+
+  if (verb === 'show') {
+    const env = process.env.CAVEMAN_DEFAULT_MODE || null;
+    const repoCfg = repoPath ? readJson(repoPath) : null;
+    const userCfg = readJson(userPath);
+    process.stdout.write('caveman config resolution (first match wins):\n');
+    process.stdout.write(`  1. env CAVEMAN_DEFAULT_MODE: ${env || '(not set)'}\n`);
+    process.stdout.write(`  2. repo config ${repoPath || '(none found walking up from cwd)'}: ${repoCfg && repoCfg.defaultMode ? repoCfg.defaultMode : '(no defaultMode)'}\n`);
+    process.stdout.write(`  3. user config ${userPath}${fs.existsSync(userPath) ? '' : ' (absent)'}: ${userCfg.defaultMode || '(no defaultMode)'}\n`);
+    process.stdout.write('  4. built-in default: full\n');
+    process.stdout.write(`Effective mode: ${getDefaultMode()}\n`);
+    return 0;
+  }
+
+  if (verb === 'get') {
+    const key = resolveKey(rest[1]);
+    if (!key) return 2;
+    process.stdout.write(getDefaultMode() + '\n');
+    return 0;
+  }
+
+  if (verb === 'set') {
+    const key = resolveKey(rest[1]);
+    if (!key) return 2;
+    const value = String(rest[2] || '').toLowerCase();
+    if (!VALID_MODES.includes(value)) {
+      process.stderr.write(`caveman config: invalid mode '${rest[2] || ''}'. Valid: ${VALID_MODES.join(', ')}\n`);
+      return 2;
+    }
+    const cfg = readJson(targetPath);
+    cfg[key] = value;
+    SETTINGS.writeSettings(targetPath, cfg);
+    process.stdout.write(`set ${key}=${value} in ${targetPath}\n`);
+    return 0;
+  }
+
+  if (verb === 'unset') {
+    const key = resolveKey(rest[1]);
+    if (!key) return 2;
+    if (!fs.existsSync(targetPath)) { process.stdout.write(`nothing to unset — ${targetPath} absent\n`); return 0; }
+    const cfg = readJson(targetPath);
+    if (!(key in cfg)) { process.stdout.write(`nothing to unset — ${key} not in ${targetPath}\n`); return 0; }
+    delete cfg[key];
+    SETTINGS.writeSettings(targetPath, cfg);
+    process.stdout.write(`unset ${key} in ${targetPath}\n`);
+    return 0;
+  }
+
+  process.stderr.write('Usage: caveman config <show|get|set|unset> [key] [value] [--project]\n');
+  return 2;
+}
+
 // ── Main ───────────────────────────────────────────────────────────────────
 async function main() {
+  if (process.argv[2] === 'config') {
+    return runConfigCommand(process.argv.slice(3));
+  }
   const opts = parseArgs(process.argv.slice(2));
   const c = makeChalk(opts.noColor);
   if (opts.help) { printHelp(); return 0; }

--- a/tests/installer/e2e.config.test.mjs
+++ b/tests/installer/e2e.config.test.mjs
@@ -1,0 +1,115 @@
+// End-to-end: `caveman config` subcommand — CLI sugar over the config files
+// src/hooks/caveman-config.js already reads. The killer assertion: a mode set
+// via the CLI is honored by the real SessionStart hook.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const INSTALLER = path.join(REPO_ROOT, 'bin', 'install.js');
+const ACTIVATE = path.join(REPO_ROOT, 'src', 'hooks', 'caveman-activate.js');
+
+function freshTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cm-config-'));
+}
+
+function runConfig(args, { cwd, env = {} } = {}) {
+  const base = { ...process.env, NO_COLOR: '1', ...env };
+  delete base.CAVEMAN_DEFAULT_MODE; // hermetic: env short-circuits resolution
+  return spawnSync(process.execPath, [INSTALLER, 'config', ...args], {
+    cwd: cwd || REPO_ROOT, env: base, encoding: 'utf8',
+  });
+}
+
+test('config set writes user config and the SessionStart hook honors it', () => {
+  const dir = freshTmpDir();
+  const xdg = path.join(dir, 'xdg');
+  const home = path.join(dir, 'home');
+  const claude = path.join(dir, 'claude');
+  fs.mkdirSync(home, { recursive: true });
+  const cwd = path.join(dir, 'work');
+  fs.mkdirSync(cwd);
+  const env = { XDG_CONFIG_HOME: xdg, APPDATA: xdg, HOME: home, USERPROFILE: home, CLAUDE_CONFIG_DIR: claude };
+  try {
+    const r = runConfig(['set', 'intensity', 'ultra'], { cwd, env });
+    assert.equal(r.status, 0, r.stderr);
+    const cfgPath = path.join(xdg, 'caveman', 'config.json');
+    assert.equal(JSON.parse(fs.readFileSync(cfgPath, 'utf8')).defaultMode, 'ultra');
+
+    const g = runConfig(['get', 'mode'], { cwd, env });
+    assert.equal(g.stdout.trim(), 'ultra');
+
+    // The real hook must pick it up: flag file content == configured mode.
+    const hook = spawnSync(process.execPath, [ACTIVATE], {
+      cwd, env: { ...process.env, ...env, CAVEMAN_DEFAULT_MODE: '' }, encoding: 'utf8',
+    });
+    assert.equal(hook.status, 0, hook.stderr);
+    assert.equal(fs.readFileSync(path.join(claude, '.caveman-active'), 'utf8'), 'ultra');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('config set --project writes repo config; subdir updates the same file', () => {
+  const dir = freshTmpDir();
+  const xdg = path.join(dir, 'xdg');
+  const env = { XDG_CONFIG_HOME: xdg, APPDATA: xdg };
+  try {
+    const r1 = runConfig(['set', 'mode', 'lite', '--project'], { cwd: dir, env });
+    assert.equal(r1.status, 0, r1.stderr);
+    const cfgPath = path.join(dir, '.caveman', 'config.json');
+    assert.equal(JSON.parse(fs.readFileSync(cfgPath, 'utf8')).defaultMode, 'lite');
+
+    // From a nested dir, --project must find and update the SAME file
+    const sub = path.join(dir, 'a', 'b');
+    fs.mkdirSync(sub, { recursive: true });
+    const r2 = runConfig(['set', 'mode', 'wenyan-full', '--project'], { cwd: sub, env });
+    assert.equal(r2.status, 0, r2.stderr);
+    assert.equal(JSON.parse(fs.readFileSync(cfgPath, 'utf8')).defaultMode, 'wenyan-full');
+    assert.equal(fs.existsSync(path.join(sub, '.caveman')), false, 'must not create a second config');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('config set rejects invalid mode and unknown key without writing', () => {
+  const dir = freshTmpDir();
+  const xdg = path.join(dir, 'xdg');
+  const env = { XDG_CONFIG_HOME: xdg, APPDATA: xdg };
+  try {
+    const bad = runConfig(['set', 'mode', 'shouty'], { cwd: dir, env });
+    assert.equal(bad.status, 2);
+    assert.match(bad.stderr, /invalid mode/);
+    const unk = runConfig(['set', 'volume', 'high'], { cwd: dir, env });
+    assert.equal(unk.status, 2);
+    assert.match(unk.stderr, /unknown key/);
+    assert.equal(fs.existsSync(path.join(xdg, 'caveman', 'config.json')), false);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('config unset removes the key; show reports resolution', () => {
+  const dir = freshTmpDir();
+  const xdg = path.join(dir, 'xdg');
+  const env = { XDG_CONFIG_HOME: xdg, APPDATA: xdg };
+  try {
+    runConfig(['set', 'mode', 'ultra'], { cwd: dir, env });
+    const u = runConfig(['unset', 'mode'], { cwd: dir, env });
+    assert.equal(u.status, 0, u.stderr);
+    const cfgPath = path.join(xdg, 'caveman', 'config.json');
+    assert.equal('defaultMode' in JSON.parse(fs.readFileSync(cfgPath, 'utf8')), false);
+
+    const s = runConfig(['show'], { cwd: dir, env });
+    assert.equal(s.status, 0, s.stderr);
+    assert.match(s.stdout, /Effective mode: full/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

The repo-local and user config files already drive the default mode (the `getDefaultMode` resolution chain), but changing them means hand-editing JSON in a platform-specific path (`~/.config/caveman/`, `%APPDATA%\caveman\`, `.caveman/config.json`). CLI sugar over the exact same files:

```
npx -y github:JuliusBrussee/caveman -- config show              # resolution chain + effective mode
npx -y github:JuliusBrussee/caveman -- config set intensity ultra
npx -y github:JuliusBrussee/caveman -- config set mode full --project
npx -y github:JuliusBrussee/caveman -- config unset mode
```

- Canonical key is `defaultMode` (what the hooks read); `mode` and `intensity` are accepted aliases since the README speaks in intensities.
- Values validated against `VALID_MODES` — a typo exits 2 and writes nothing, so a bad value can never silently break activation.
- `--project` updates the **nearest** checked-in config via the existing walk-up (`findRepoConfigPath`) instead of sprinkling new `.caveman/` dirs in subdirectories.
- Reuses the JSONC-tolerant atomic read/write from `bin/lib/settings.js`; resolution logic is required from `src/hooks/caveman-config.js`, not duplicated.

## Tests

4 e2e tests, the key one being the full loop: `config set intensity ultra` → `config get mode` returns `ultra` → **the real SessionStart hook writes `ultra` to the flag file**. Plus: subdir `--project` updates the same parent config (no second file created), invalid mode/unknown key reject without writing, unset + show. Green locally and in a clean `node:20-bookworm` container (live round-trip included).