### PR TITLE
fix(install): guard non-array hook events in rewrite

### DIFF
--- a/bin/lib/settings.js
+++ b/bin/lib/settings.js
@@ -253,6 +253,10 @@ function rewriteLegacyManagedHookCommands(settings, absoluteNode) {
   let rewritten = 0;
   const reBare = /^node\s+("([^"]+)"|'([^']+)'|(\S+))\s*$/;
   for (const ev of Object.keys(settings.hooks)) {
+    // Malformed shape (string / object instead of array) survives JSONC parse
+    // and reaches here before validateHookFields runs — skip it rather than
+    // throw mid-install; validation cleans it up before the eventual write.
+    if (!Array.isArray(settings.hooks[ev])) continue;
     for (const entry of settings.hooks[ev]) {
       if (!entry || !Array.isArray(entry.hooks)) continue;
       for (const h of entry.hooks) {

--- a/tests/installer/unit.settings.test.mjs
+++ b/tests/installer/unit.settings.test.mjs
@@ -207,6 +207,23 @@ test('rewriteLegacyManagedHookCommands rewrites bare-node managed scripts', () =
   assert.equal(s.hooks.SessionStart[0].hooks[1].command, 'node /abs/hooks/some-user-hook.js');
 });
 
+test('rewriteLegacyManagedHookCommands tolerates malformed hook event values without throwing', () => {
+  // Same class as the removeCavemanHooks crash above: a non-array event value
+  // survives JSONC parse and used to throw "not iterable" here, killing the
+  // installer mid-run before validateHookFields ever saw the file.
+  const s = {
+    hooks: {
+      SessionStart: { hooks: [] },
+      UserPromptSubmit: 'oops',
+      Stop: [{ hooks: [{ type: 'command', command: 'node /abs/hooks/caveman-stats.js' }] }],
+    },
+  };
+  let n;
+  assert.doesNotThrow(() => { n = SETTINGS.rewriteLegacyManagedHookCommands(s, '/usr/local/bin/node'); });
+  assert.equal(n, 1, 'well-formed sibling event should still be rewritten');
+  assert.match(s.hooks.Stop[0].hooks[0].command, /"\/usr\/local\/bin\/node" "\/abs\/hooks\/caveman-stats\.js"/);
+});
+
 test('rewriteLegacyManagedHookCommands ignores already-absolute node commands', () => {
   const s = {
     hooks: {


### PR DESCRIPTION
## What

Installer crash mid-run on malformed `settings.json`. `installHooks` call `rewriteLegacyManagedHookCommands` **before** `validateHookFields`; a hook event that is object/string instead of array survive JSONC parse, then `for (const entry of settings.hooks[ev])` throw:

TypeError: settings.hooks[ev] is not iterable

Whole installer die unhandled — hook files copied, settings.json never wired, no summary. Exactly the malformation `validateHookFields` exist to clean.

 ## Fix

`Array.isArray` guard, skip malformed event, validation still clean it before write. Same guard `removeCavemanHooks` already got for identical crash (see existing test at `unit.settings.test.mjs:137`).

## Tests

New case in `tests/installer/unit.settings.test.mjs`: malformed events not throw, well-formed sibling still rewritten. `npm test`: 113/113 pass.
