### PR TITLE
Fix caveman-stats blank rendering in VSCode extension

### DIFF
--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -70,9 +70,8 @@ process.stdin.on('end', () => {
       }
     }
 
-    // /caveman-stats [--share] — block the prompt and inject stats output as
-    // the hook's reason. The script reads the active session log, so we pass
-    // transcript_path through when Claude Code provides it.
+    // /caveman-stats [--share] — block the prompt and inject stats output via stderr + exit 2
+    // to ensure compatibility with Claude Code VSCode extension which doesn't render decision:block reason.
     const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
     if (statsMatch) {
       const tailArgs = (statsMatch[1] || '').trim().split(/\s+/).filter(Boolean);
@@ -87,14 +86,12 @@ process.stdin.on('end', () => {
           argv.push('--since', tailArgs[sinceIdx + 1]);
         }
         const out = execFileSync(process.execPath, argv, { encoding: 'utf8', timeout: 5000 });
-        process.stdout.write(JSON.stringify({ decision: 'block', reason: out.trim() }));
+        process.stderr.write(out.trim() + '\n');
+        process.exit(2);
       } catch (e) {
-        process.stdout.write(JSON.stringify({
-          decision: 'block',
-          reason: 'caveman-stats: could not run stats script.\nTry manually: node hooks/caveman-stats.js'
-        }));
+        process.stderr.write('caveman-stats: could not run stats script.\nTry manually: node hooks/caveman-stats.js\n');
+        process.exit(2);
       }
-      return;
     }
 
     // Match /caveman commands. Independent one-shot modes remember the prose

--- a/tests/test_caveman_stats.js
+++ b/tests/test_caveman_stats.js
@@ -101,15 +101,20 @@ test('mode tracker handles /caveman-stats with decision block', (tmp) => {
   ]);
   const claudeDir = path.join(tmp, '.claude');
   fs.writeFileSync(path.join(claudeDir, '.caveman-active'), 'full');
-  const out = execFileSync(process.execPath, [TRACKER], {
-    encoding: 'utf8',
-    env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir, HOME: tmp },
-    input: JSON.stringify({ prompt: '/caveman-stats', transcript_path: sess }),
-  });
-  const parsed = JSON.parse(out);
-  assert.strictEqual(parsed.decision, 'block');
-  assert.match(parsed.reason, /Caveman Stats/);
-  assert.match(parsed.reason, /Output tokens:\s+100/);
+  let err = null;
+  try {
+    execFileSync(process.execPath, [TRACKER], {
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir, HOME: tmp },
+      input: JSON.stringify({ prompt: '/caveman-stats', transcript_path: sess }),
+    });
+  } catch (e) {
+    err = e;
+  }
+  assert.ok(err, 'should exit non-zero');
+  assert.strictEqual(err.status, 2);
+  assert.match(err.stderr, /Caveman Stats/);
+  assert.match(err.stderr, /Output tokens:\s+100/);
 });
 
 test('mode tracker preserves caveman flag when /caveman-stats fires', (tmp) => {
@@ -118,11 +123,15 @@ test('mode tracker preserves caveman flag when /caveman-stats fires', (tmp) => {
   ]);
   const claudeDir = path.join(tmp, '.claude');
   fs.writeFileSync(path.join(claudeDir, '.caveman-active'), 'full');
-  execFileSync(process.execPath, [TRACKER], {
-    encoding: 'utf8',
-    env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir, HOME: tmp },
-    input: JSON.stringify({ prompt: '/caveman-stats', transcript_path: sess }),
-  });
+  try {
+    execFileSync(process.execPath, [TRACKER], {
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir, HOME: tmp },
+      input: JSON.stringify({ prompt: '/caveman-stats', transcript_path: sess }),
+    });
+  } catch (e) {
+    // Expected to exit with code 2
+  }
   // The flag must still say 'full' — the stats command must not change mode.
   assert.strictEqual(fs.readFileSync(path.join(claudeDir, '.caveman-active'), 'utf8'), 'full');
 });
@@ -450,14 +459,19 @@ test('mode tracker forwards --share to stats script', (tmp) => {
   ]);
   const claudeDir = path.join(tmp, '.claude');
   fs.writeFileSync(path.join(claudeDir, '.caveman-active'), 'full');
-  const out = execFileSync(process.execPath, [TRACKER], {
-    encoding: 'utf8',
-    env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir, HOME: tmp },
-    input: JSON.stringify({ prompt: '/caveman-stats --share', transcript_path: sess }),
-  });
-  const parsed = JSON.parse(out);
-  assert.strictEqual(parsed.decision, 'block');
-  assert.match(parsed.reason, /^🪨 Saved 650 output tokens/);
+  let err = null;
+  try {
+    execFileSync(process.execPath, [TRACKER], {
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir, HOME: tmp },
+      input: JSON.stringify({ prompt: '/caveman-stats --share', transcript_path: sess }),
+    });
+  } catch (e) {
+    err = e;
+  }
+  assert.ok(err, 'should exit non-zero');
+  assert.strictEqual(err.status, 2);
+  assert.match(err.stderr, /^🪨 Saved 650 output tokens/m);
 });
 
 // ── Output-reduction share (never a "usage"/"budget" claim) ────────────────


### PR DESCRIPTION
This PR fixes the issue where `caveman-stats` renders blank in the VSCode extension (Issue #556):

### Root Cause
The Claude Code VSCode extension does not render the `reason` field of the `decision: 'block'` response returned by the `UserPromptSubmit` hook.

### Fix
Changed the `/caveman-stats` handling in `src/hooks/caveman-mode-tracker.js` to output the formatted stats string to `stderr` and exit with code 2. Exit code 2 is standard for blocking in Claude Code, ensuring that the prompt is correctly blocked and the output written to `stderr` is rendered in the integrated terminal/extension host window.

Updated associated unit tests in `tests/test_caveman_stats.js` to expect the exit 2 and inspect `stderr` for correct outputs.
