### PR TITLE
fix(installer): honor package runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ Configured in `settings.json` under `statusLine.command`. PowerShell counterpart
 
 **Standalone install** — `bin/install.js` (the unified Node installer) copies hook files into `$CLAUDE_CONFIG_DIR/hooks/` and merges SessionStart + UserPromptSubmit + statusline into `settings.json`. Uses the JSONC-tolerant helpers in `bin/lib/settings.js` so a commented `settings.json` no longer crashes the merge. Defensive `validateHookFields` runs before every write to prevent a single malformed hook from poisoning the entire file (Claude Code Zod silently discards the whole `settings.json` on schema mismatch).
 
-The `install.sh` / `install.ps1` shims at the repo root delegate to `bin/install.js` via `node` (local clone) or `npx -y github:JuliusBrussee/caveman` (curl|bash). No legacy fallback path remains — earlier `install.sh.legacy` / `install.ps1.legacy` files were removed.
+The `install.sh` / `install.ps1` shims at the repo root delegate to `bin/install.js`. `install.sh` defaults to `node` (local clone) or `npx -y github:JuliusBrussee/caveman` (curl|bash), with shim-only `--bun` and `--pnpm` runner switches. No legacy fallback path remains — earlier `install.sh.legacy` / `install.ps1.legacy` files were removed.
 
 **Uninstall** — `npx -y github:JuliusBrussee/caveman -- --uninstall` (or `node bin/install.js --uninstall` from a clone). Strips caveman hook entries from `settings.json` via substring marker `caveman`, deletes hook files, and removes the Claude plugin / Gemini extension. Skill installs done via `npx skills add` must be removed via the IDE's skill manager (we don't track them).
 
@@ -302,5 +302,5 @@ To reproduce: `uv run python benchmarks/run.py` (needs `ANTHROPIC_API_KEY` in `.
 - Hook files must silent-fail on all filesystem errors. Never let hook crash block session start.
 - Any new flag file write must go through `safeWriteFlag()` in `caveman-config.js`. Direct `fs.writeFileSync` on predictable user-owned paths reopens the symlink-clobber attack surface.
 - Hooks must respect `CLAUDE_CONFIG_DIR` env var, not hardcode `~/.claude`. Same for `bin/install.js` / statusline scripts.
-- `bin/install.js` is the only installer source. `install.sh` / `install.ps1` at repo root are 30-line shims that delegate to it. Never re-add per-OS install logic to the shims — that's how we got the Windows quoting bug (#249).
+- `bin/install.js` is the only installer source. `install.sh` / `install.ps1` at repo root are shims that delegate to it; keep platform install logic in `bin/install.js`. Never re-add per-OS install logic to the shims — that's how we got the Windows quoting bug (#249).
 - Any settings.json read in installer or hooks must go through `bin/lib/settings.js` `readSettings()` so JSONC comments don't crash the merge. Any settings.json write must run through `validateHookFields()` first.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ A handful of invariants that have bitten us before. Keep them.
 - **Validate hook entries before writing.** Use `validateHookFields()` in `bin/lib/settings.js`. Claude Code's Zod schema silently discards the **entire** `settings.json` on a single bad hook entry — one malformed write poisons the user's whole config.
 - **Symlink-safe flag writes via `safeWriteFlag()`** in `src/hooks/caveman-config.js`. The flag file lives at a predictable path under `$CLAUDE_CONFIG_DIR/`; without `O_NOFOLLOW` and a parent-symlink check, a local attacker can clobber any file the user can write.
 - **Honor `CLAUDE_CONFIG_DIR`.** Hooks, the installer, and the statusline scripts must respect it — never hardcode `~/.claude`.
-- **`install.sh` and `install.ps1` at the repo root are 30-line shims** that delegate to `bin/install.js`. Don't re-add per-OS install logic to them. Quoting bugs that way lie.
+- **`install.sh` and `install.ps1` at the repo root are shims** that delegate to `bin/install.js`. Don't re-add per-OS install logic to them. Quoting bugs that way lie.
 
 ---
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,6 +33,19 @@ Want to preview before installing? Use `--dry-run`:
 curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.sh | bash -s -- --dry-run
 ```
 
+Prefer a different package runner for the shell shim:
+
+```bash
+# Default: Node + npx
+curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.sh | bash -s -- --node --dry-run
+
+# Bun-only path: uses bunx --bun and does not require Node
+curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.sh | bash -s -- --bun --dry-run
+
+# pnpm path: uses pnpx
+curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.sh | bash -s -- --pnpm --dry-run
+```
+
 ## Per-agent install
 
 If you want to install for one agent (or want to know exactly what command runs under the hood), use the table below. Every row also works as `--only <id>` to the unified installer.
@@ -85,6 +98,7 @@ For "auto-activates? No" agents, type `/caveman` once per session (or use natura
 # Either of these works (install.sh / install.ps1 are thin shims that
 # forward all flags to bin/install.js):
 bash install.sh --list             # macOS / Linux / WSL, from a local clone
+bash install.sh --bun --list       # same shim, run through Bun instead
 pwsh install.ps1 --list            # Windows / PowerShell, from a local clone
 node bin/install.js --list         # any platform, from a local clone
 npx -y github:JuliusBrussee/caveman -- --list   # no clone needed
@@ -130,6 +144,14 @@ Useful flags:
 | `--list` | Print full agent matrix and exit. |
 | `--force` | Re-run even if already installed. |
 | `--uninstall` | Remove everything. See below. |
+
+Shell-shim-only flags:
+
+| Flag | What |
+|---|---|
+| `--node` / `--npm` | Explicit default. Local clone runs `node bin/install.js`; curl-pipe runs `npx -y github:JuliusBrussee/caveman`. |
+| `--bun` | Local clone runs `bun bin/install.js`; curl-pipe runs `bunx --bun github:JuliusBrussee/caveman`. Node is not required. |
+| `--pnpm` | Local clone still runs `node bin/install.js`; curl-pipe runs `pnpx github:JuliusBrussee/caveman`. |
 
 ## Always-on rules
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.
 irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 | iex
 ```
 
-~30 seconds. Needs Node ≥18. Skips agents you no have. Safe to re-run.
+~30 seconds. Default path needs Node ≥18; `--bun` uses Bun instead. Skips agents you no have. Safe to re-run.
 
 > [!TIP]
 > **Turn it on:** type `/caveman` or say *"talk like caveman"*. **Turn it off:** say *"normal mode"*. On Claude Code, Codex, and Gemini it's already on from message one. No command needed.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ Once installed, nothing in caveman touches the network. Verified against the cod
 
 ### At install time: exactly these network requests, nothing else
 
-- `curl … install.sh | bash` (or `irm … install.ps1 | iex`) fetches the shim from raw.githubusercontent.com, which delegates to `npx -y github:JuliusBrussee/caveman` — npm fetches this repo from GitHub.
+- `curl … install.sh | bash` fetches the shim from raw.githubusercontent.com, which delegates to `npx -y github:JuliusBrussee/caveman` by default. Passing `--bun` delegates to `bunx --bun github:JuliusBrussee/caveman`; passing `--pnpm` delegates to `pnpx github:JuliusBrussee/caveman`. `irm … install.ps1 | iex` delegates to npx. The selected package runner fetches this repo from GitHub.
 - The installer shells out to per-agent CLIs which fetch from their own registries: `claude plugin marketplace add` / `claude plugin install` (Anthropic/GitHub), `gemini extensions install`, `npm view caveman-shrink`, `npx -y skills add` (npm).
 - **Rare fallback:** if the installer runs detached from a repo checkout, it downloads the hook files from raw.githubusercontent.com **pinned to an immutable release tag** and verifies each against a published SHA-256 manifest before wiring anything (a mismatch aborts). From a normal clone or npx run, files are copied locally — offline installs work.
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -8,7 +8,7 @@
 //
 // Distribution:
 //   Local clone: node bin/install.js [flags]
-//   curl|bash:   delegated from install.sh shim → npx -y github:JuliusBrussee/caveman -- [flags]
+//   curl|bash:   install.sh shim → npx (default), bunx, or pnpx → this script
 //   Windows:     pwsh install.ps1 [flags] → same npx delegation
 //
 // Pure stdlib, zero npm runtime deps.
@@ -415,6 +415,36 @@ function runSpawn(cmd, args, opts, dry) {
   return spawnXplat(cmd, args, Object.assign({ stdio: 'inherit' }, opts || {}));
 }
 
+function skillsAddRunner() {
+  switch (String(process.env.CAVEMAN_PACKAGE_RUNNER || '').toLowerCase()) {
+    case 'bun':
+    case 'bunx':
+      return { cmd: 'bunx', prefixArgs: ['--bun'], label: 'bunx' };
+    case 'pnpm':
+    case 'pnpx':
+      return { cmd: 'pnpx', prefixArgs: [], label: 'pnpx' };
+    case 'node':
+    case 'npm':
+    case 'npx':
+    default:
+      return { cmd: 'npx', prefixArgs: ['-y'], label: 'npx' };
+  }
+}
+
+function skillsAddArgs(...args) {
+  const runner = skillsAddRunner();
+  return [runner.cmd, [...runner.prefixArgs, 'skills', 'add', ...args]];
+}
+
+function skillsAddFailure(scope) {
+  return `${skillsAddRunner().label} skills add (${scope}) failed`;
+}
+
+function installMechanism(prov) {
+  if (prov.profile) return `${skillsAddRunner().label} skills add (${prov.profile})`;
+  return prov.mech;
+}
+
 // Create env with TMPDIR pointing to a temp dir inside configDir.
 // Workaround for Claude Code plugin install EXDEV bug: it tries to rename
 // from ~/.claude/plugins/cache/ to /tmp/ which fails when /tmp is on a
@@ -585,10 +615,10 @@ function installViaSkills(ctx, prov) {
   // ignores the `-a prov.profile` selection and writes every skill through
   // every agent adapter (see issue #389). `--skill '*' -a <agent>` is the
   // documented form for "install every skill into a specific agent".
-  const args = ['-y', 'skills', 'add', REPO, '--skill', '*', '-a', prov.profile, '--yes'];
-  const r = runSpawn('npx', args, null, opts.dryRun);
+  const [cmd, args] = skillsAddArgs(REPO, '--skill', '*', '-a', prov.profile, '--yes');
+  const r = runSpawn(cmd, args, null, opts.dryRun);
   if (spawnOk(r)) results.installed.push(prov.id);
-  else results.failed.push([prov.id, `npx skills add (${prov.profile}) failed`]);
+  else results.failed.push([prov.id, skillsAddFailure(prov.profile)]);
   process.stdout.write('\n');
 }
 
@@ -1351,7 +1381,7 @@ function printList(noColor) {
   process.stdout.write(`  ${pad('--', 13)} ${pad('-----', 22)} -----------------\n`);
   for (const p of PROVIDERS) {
     const tag = p.soft ? ' (soft)' : '';
-    process.stdout.write(`  ${pad(p.id, 13)} ${pad(p.label, 22)} ${p.mech}${tag}\n`);
+    process.stdout.write(`  ${pad(p.id, 13)} ${pad(p.label, 22)} ${installMechanism(p)}${tag}\n`);
   }
   process.stdout.write('\n');
   process.stdout.write(c.dim('  Defaults: --with-hooks ON, --with-init OFF, --with-mcp-shrink OFF.\n'));
@@ -1368,7 +1398,9 @@ function printHelp() {
 USAGE
   npx -y github:JuliusBrussee/caveman -- [flags]
   node bin/install.js [flags]
-  bash install.sh [flags]              # shim → npx
+  bash install.sh [flags]              # shim → npx by default
+  bash install.sh --bun [flags]        # shim → bunx --bun
+  bash install.sh --pnpm [flags]       # shim → pnpx
   pwsh install.ps1 [flags]             # shim → npx
 
 FLAGS
@@ -1376,7 +1408,7 @@ FLAGS
   --force               Re-run even if a target reports already installed.
   --only <agent>        Install only for the named agent. Repeatable.
                         See --list for valid ids.
-  --skip-skills         Don't run the npx-skills auto-detect fallback.
+  --skip-skills         Don't run the ${skillsAddRunner().label} skills auto-detect fallback.
   --all                 Turn on hooks + init. (mcp-shrink needs an upstream;
                         pass --with-mcp-shrink="<cmd>" to add it.)
   --minimal             Just the plugin/extension install.
@@ -1476,12 +1508,13 @@ async function main() {
 
   // Auto-detect fallback if nothing matched
   if (!opts.skipSkills && opts.only.length === 0 && ctx.results.detected === 0) {
-    ctx.say('→ no known agents detected — running npx-skills auto-detect fallback');
+    ctx.say(`→ no known agents detected — running ${skillsAddRunner().label} skills auto-detect fallback`);
     // --yes --all for the same reason as installViaSkills above (issue #370):
     // skip the interactive skill picker so curl|bash actually installs.
-    const r = runSpawn('npx', ['-y', 'skills', 'add', REPO, '--yes', '--all'], null, opts.dryRun);
+    const [cmd, args] = skillsAddArgs(REPO, '--yes', '--all');
+    const r = runSpawn(cmd, args, null, opts.dryRun);
     if (spawnOk(r)) ctx.results.installed.push('skills-auto');
-    else ctx.results.failed.push(['skills-auto', 'npx skills add (auto) failed']);
+    else ctx.results.failed.push(['skills-auto', skillsAddFailure('auto')]);
     process.stdout.write('\n');
   }
 

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,10 @@
 #
 # Local clone:
 #   bash install.sh [flags]
+#   bash install.sh --node [flags]   # explicit default: Node + npx
+#   bash install.sh --npm [flags]    # alias for --node
+#   bash install.sh --bun [flags]    # curl-pipe path uses bunx
+#   bash install.sh --pnpm [flags]   # curl-pipe path uses pnpx
 #
 # Why a Node installer? install.sh + install.ps1 used to be parallel sources
 # of truth and constantly drifted (issue #249, etc.). One Node script works
@@ -18,21 +22,69 @@
 set -euo pipefail
 
 REPO="JuliusBrussee/caveman"
+RUNNER="npx"
+RUNNER_FLAG=""
+PACKAGE_RUNNER="node"
+INSTALLER_ARGS=()
 
-# Require Node ≥18. nvm is a common path; print a hint if missing.
-if ! command -v node >/dev/null 2>&1; then
-  echo "caveman: Node.js (≥18) required. Install:" >&2
-  echo "  macOS:  brew install node" >&2
-  echo "  Linux:  see https://nodejs.org or use nvm (https://github.com/nvm-sh/nvm)" >&2
-  exit 1
-fi
+for arg in "$@"; do
+  case "$arg" in
+    --node|--npm)
+      if [ -n "$RUNNER_FLAG" ]; then
+        echo "caveman: choose only one package manager flag (--node, --npm, --bun, --pnpm)." >&2
+        exit 2
+      fi
+      RUNNER="npx"
+      RUNNER_FLAG="$arg"
+      PACKAGE_RUNNER="node"
+      ;;
+    --bun)
+      if [ -n "$RUNNER_FLAG" ]; then
+        echo "caveman: choose only one package manager flag (--node, --npm, --bun, --pnpm)." >&2
+        exit 2
+      fi
+      RUNNER="bunx"
+      RUNNER_FLAG="$arg"
+      PACKAGE_RUNNER="bun"
+      ;;
+    --pnpm)
+      if [ -n "$RUNNER_FLAG" ]; then
+        echo "caveman: choose only one package manager flag (--node, --npm, --bun, --pnpm)." >&2
+        exit 2
+      fi
+      RUNNER="pnpx"
+      RUNNER_FLAG="$arg"
+      PACKAGE_RUNNER="pnpm"
+      ;;
+    *)
+      INSTALLER_ARGS+=("$arg")
+      ;;
+  esac
+done
 
-NODE_MAJOR=$(node -p "process.versions.node.split('.')[0]")
-if [ "$NODE_MAJOR" -lt 18 ]; then
-  echo "caveman: Node $NODE_MAJOR too old. Need Node ≥18." >&2
-  echo "  Upgrade: https://nodejs.org" >&2
-  exit 1
-fi
+require_node() {
+  # Require Node ≥18. nvm is a common path; print a hint if missing.
+  if ! command -v node >/dev/null 2>&1; then
+    echo "caveman: Node.js (≥18) required. Install:" >&2
+    echo "  macOS:  brew install node" >&2
+    echo "  Linux:  see https://nodejs.org or use nvm (https://github.com/nvm-sh/nvm)" >&2
+    exit 1
+  fi
+
+  NODE_MAJOR=$(node -p "process.versions.node.split('.')[0]")
+  if [ "$NODE_MAJOR" -lt 18 ]; then
+    echo "caveman: Node $NODE_MAJOR too old. Need Node ≥18." >&2
+    echo "  Upgrade: https://nodejs.org" >&2
+    exit 1
+  fi
+}
+
+require_bun() {
+  if ! command -v bun >/dev/null 2>&1; then
+    echo "caveman: Bun required for --bun. Install: https://bun.sh" >&2
+    exit 1
+  fi
+}
 
 # If we're inside the repo clone, run the local installer directly — saves
 # the npx round-trip and keeps offline installs working. BASH_SOURCE is unset
@@ -40,15 +92,44 @@ fi
 # bare reference — default to empty so the curl-pipe path falls through cleanly.
 here="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)" || here=""
 if [ -n "$here" ] && [ -f "$here/bin/install.js" ]; then
-  exec node "$here/bin/install.js" "$@"
+  case "$RUNNER" in
+    bunx)
+      require_bun
+      CAVEMAN_PACKAGE_RUNNER="$PACKAGE_RUNNER" exec bun "$here/bin/install.js" "${INSTALLER_ARGS[@]+"${INSTALLER_ARGS[@]}"}"
+      ;;
+    *)
+      require_node
+      CAVEMAN_PACKAGE_RUNNER="$PACKAGE_RUNNER" exec node "$here/bin/install.js" "${INSTALLER_ARGS[@]+"${INSTALLER_ARGS[@]}"}"
+      ;;
+  esac
 fi
 
-# Curl-pipe path: delegate to npx. We do NOT pass `--` here — npm 7+ npx
-# already forwards trailing args to the package, and a literal `--` tripped
-# bin/install.js's parseArgs as an unknown flag.
-if ! command -v npx >/dev/null 2>&1; then
-  echo "caveman: npx required (ships with Node ≥18). Reinstall Node.js." >&2
-  exit 1
-fi
-
-exec npx -y "github:$REPO" "$@"
+# Curl-pipe path: delegate to the selected package runner. We do NOT pass `--`
+# here — npm 7+ npx already forwards trailing args to the package, and a
+# literal `--` tripped bin/install.js's parseArgs as an unknown flag.
+case "$RUNNER" in
+  npx)
+    require_node
+    if ! command -v npx >/dev/null 2>&1; then
+      echo "caveman: npx required (ships with Node ≥18). Reinstall Node.js." >&2
+      exit 1
+    fi
+    CAVEMAN_PACKAGE_RUNNER="$PACKAGE_RUNNER" exec npx -y "github:$REPO" "${INSTALLER_ARGS[@]+"${INSTALLER_ARGS[@]}"}"
+    ;;
+  bunx)
+    require_bun
+    if ! command -v bunx >/dev/null 2>&1; then
+      echo "caveman: bunx required for --bun. Install Bun: https://bun.sh" >&2
+      exit 1
+    fi
+    CAVEMAN_PACKAGE_RUNNER="$PACKAGE_RUNNER" exec bunx --bun "github:$REPO" "${INSTALLER_ARGS[@]+"${INSTALLER_ARGS[@]}"}"
+    ;;
+  pnpx)
+    require_node
+    if ! command -v pnpx >/dev/null 2>&1; then
+      echo "caveman: pnpx required for --pnpm. Install pnpm: https://pnpm.io" >&2
+      exit 1
+    fi
+    CAVEMAN_PACKAGE_RUNNER="$PACKAGE_RUNNER" exec pnpx "github:$REPO" "${INSTALLER_ARGS[@]+"${INSTALLER_ARGS[@]}"}"
+    ;;
+esac

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,43 @@
       "source": "JuliusBrussee/caveman",
       "sourceType": "github",
       "skillPath": "skills/cavecrew/SKILL.md",
-      "computedHash": "06d45a7308d8603365313decf400020106b985cb5ce500ee169bfba9c71dd147"
+      "computedHash": "c5527c994fbd4c22b36714e3b124a0f167a533d114ab164fb1d35e2123533917"
+    },
+    "caveman": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman/SKILL.md",
+      "computedHash": "d18cdf73a5f5c496d681a43a6846336b110223bdffa6817b8992529c57f1a815"
+    },
+    "caveman-commit": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-commit/SKILL.md",
+      "computedHash": "790a4eeace0be35c6691faf923518ba5bd50f1f1305d1101d09dd4971be94e00"
+    },
+    "caveman-compress": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-compress/SKILL.md",
+      "computedHash": "84517cd4cf7a49d8d2bc1baf00f61bc359306c6ad9389756b6937eff958bd374"
+    },
+    "caveman-help": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-help/SKILL.md",
+      "computedHash": "dd85267e76baad76995157e7b9f762dfa557cd58951ee92af0c283f48aa26537"
+    },
+    "caveman-review": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-review/SKILL.md",
+      "computedHash": "fb7214a1c5793bae6ba8b1be4329e2e6f40dbec6dd911dfb335ad29f09c316a1"
+    },
+    "caveman-stats": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-stats/SKILL.md",
+      "computedHash": "47ce2de3d6cb39a75047b5c962e4eb3da15594e7397c94103e9a104d42626553"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add shell shim package-manager flags for node/npm, bun, and pnpm paths
- Propagate the selected runner into the Node installer for nested `skills add`
- Update install docs and generated skill lock metadata

## Verification
- `bash -n install.sh`
- `node --test tests/installer/unit.argv.test.mjs tests/installer/ps1-pipe.test.mjs`
- `bash install.sh --bun --dry-run --only codex --non-interactive --no-mcp-shrink`
- `bash install.sh --pnpm --dry-run --only codex --non-interactive --no-mcp-shrink`