### PR TITLE
feat: reply in user's language under caveman mode

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -10,6 +10,10 @@ description: >
 
 Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
+## Language
+
+Reply in SAME language user wrote. User writes Chinese -> reply Chinese; Spanish -> Spanish; etc. Caveman style means terseness, NOT English — these rules are written in English but the output language always matches the user. Article/filler-drop rules apply to the per-language equivalent (e.g. Chinese drop 的/了/其实/一些).
+
 ## Persistence
 
 ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".

--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -122,6 +122,10 @@ if (skillContent) {
   output =
     'CAVEMAN MODE ACTIVE — level: ' + modeLabel + '\n\n' +
     'Respond terse like smart caveman. All technical substance stay. Only fluff die.\n\n' +
+    '## Language\n\n' +
+    'Reply in SAME language user wrote. User writes Chinese -> reply Chinese. ' +
+    'Caveman style means terseness, NOT English — these rules are English but output language matches the user. ' +
+    'Article/filler-drop rules apply to the per-language equivalent.\n\n' +
     '## Persistence\n\n' +
     'ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".\n\n' +
     'Current level: **' + modeLabel + '**. Switch: `/caveman lite|full|ultra`.\n\n' +

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -195,6 +195,7 @@ process.stdin.on('end', () => {
         hookSpecificOutput: {
           hookEventName: "UserPromptSubmit",
           additionalContext: "CAVEMAN MODE ACTIVE (" + activeMode + "). " +
+            "Reply in the user's language (Chinese in -> Chinese out). Caveman means terse, not English. " +
             "Drop articles/filler/pleasantries/hedging. Fragments OK. " +
             "Code/commits/security: write normal."
         }


### PR DESCRIPTION
## Problem

Caveman's rulesets are written in English with English-only examples (`Drop articles (a/an/the)`, `Token expiry check use \`<\` not \`<=\``) and never tell the model to keep the user's language. For non-English users, caveman replies drift to English — the model only switches back after the user explicitly asks for their language. Reproduced in Claude Code with a Chinese-speaking user: every turn came back in English until "讲中文".

Root cause: terseness rules bias the model toward the language they're written in, and there's no counter-instruction pinning output to the user's language.

## Fix

Add a `Language` rule at all three injection points so **caveman = terse, not English**:

| File | Change |
|------|--------|
| `skills/caveman/SKILL.md` | New `## Language` section (behavior source of truth) |
| `src/hooks/caveman-activate.js` | Same rule in the standalone-install fallback ruleset |
| `src/hooks/caveman-mode-tracker.js` | Per-turn reinforcement reminder now carries the language rule |

Output language always matches the user (Chinese in → Chinese out); article/filler-drop rules apply to the per-language equivalent.

Did not touch `plugins/caveman/skills/` — left for the CI sync workflow per `CLAUDE.md`.

## Testing

- `node -c` passes on both edited hooks.
- `npm test` failures are limited to the two pre-existing environment-dependent cases (`uninstall … skipped without claude CLI`, `openclaw uninstall …`) — identical failures on clean `main` before this change; no new failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)