### PR TITLE
fix: remove duplicate command files shadowed by skills

### DIFF
--- a/commands/caveman-commit.md
+++ b/commands/caveman-commit.md
@@ -1,5 +1,0 @@
----
-description: Generate terse caveman-style commit message
----
-
-Generate a terse commit message for the current staged changes. Conventional Commits format. Subject: ≤50 chars, imperative, lowercase after type. Body: only when 'why' isn't obvious from subject. Why over what. No period on subject.

--- a/commands/caveman-commit.toml
+++ b/commands/caveman-commit.toml
@@ -1,2 +1,0 @@
-description = "Generate terse caveman-style commit message"
-prompt = "Generate a terse commit message for the current staged changes. Conventional Commits format. Subject: ≤50 chars, imperative, lowercase after type. Body: only when 'why' isn't obvious from subject. Why over what. No period on subject."

--- a/commands/caveman-review.md
+++ b/commands/caveman-review.md
@@ -1,5 +1,0 @@
----
-description: One-line code review comments
----
-
-Review the current code changes. One-line per finding. Format: L<line>: <severity> <problem>. <fix>. Severity: bug, risk, nit, q. Skip praise. Skip obvious. If code look good, say 'LGTM' and stop.

--- a/commands/caveman-review.toml
+++ b/commands/caveman-review.toml
@@ -1,2 +1,0 @@
-description = "One-line code review comments"
-prompt = "Review the current code changes. One-line per finding. Format: L<line>: <severity> <problem>. <fix>. Severity: bug, risk, nit, q. Skip praise. Skip obvious. If code look good, say 'LGTM' and stop."

--- a/commands/caveman-stats.md
+++ b/commands/caveman-stats.md
@@ -1,6 +1,0 @@
----
-description: Real session token usage + lifetime savings + USD. Tweetable line via --share.
-argument-hint: "[--share|--all|--since 7d]"
----
-
-/caveman-stats $ARGUMENTS

--- a/commands/caveman-stats.toml
+++ b/commands/caveman-stats.toml
@@ -1,2 +1,0 @@
-description = "Real session token usage + lifetime savings + USD. Tweetable line via --share."
-prompt = "/caveman-stats {{args}}"

--- a/commands/caveman.md
+++ b/commands/caveman.md
@@ -1,6 +1,0 @@
----
-description: Switch caveman intensity level (lite/full/ultra/wenyan)
-argument-hint: "[lite|full|ultra|wenyan]"
----
-
-Switch to caveman $ARGUMENTS mode. If no level specified, use full. Respond terse like smart caveman — drop articles, filler, pleasantries. Fragments OK. Technical terms exact. Code unchanged. Pattern: [thing] [action] [reason]. [next step].

--- a/commands/caveman.toml
+++ b/commands/caveman.toml
@@ -1,2 +1,0 @@
-description = "Switch caveman intensity level (lite/full/ultra/wenyan)"
-prompt = "Switch to caveman {{args}} mode. If no level specified, use full. Respond terse like smart caveman — drop articles, filler, pleasantries. Fragments OK. Technical terms exact. Code unchanged. Pattern: [thing] [action] [reason]. [next step]."


### PR DESCRIPTION
## Problem

Four features are registered twice, once as a legacy slash command
under `commands/`, once as a skill under `skills/`:

| name           | command file                          | skill dir                    |
|----------------|----------------------------------------|-------------------------------|
| `caveman`      | `commands/caveman.md` + `.toml`        | `skills/caveman/`             |
| `caveman-commit` | `commands/caveman-commit.md` + `.toml` | `skills/caveman-commit/`     |
| `caveman-review` | `commands/caveman-review.md` + `.toml` | `skills/caveman-review/`     |
| `caveman-stats`  | `commands/caveman-stats.md` + `.toml`  | `skills/caveman-stats/`      |

Claude Code (and likely other agent platforms that support both
command and skill plugin surfaces) treats these as two separate
registries. Both get exposed under `/`, so each of the four names
above shows up twice in the slash-command menu — once as a bare
`/name`, once as `plugin:name` — with slightly different, drifted
descriptions for what is meant to be the same feature. This is
confusing for anyone typing `/` to discover commands and makes the
plugin look broken/duplicated.

`commands/caveman-init.md` is the one command with no skill
counterpart — it's unaffected and left in place.

## Fix

Delete the four redundant `commands/*.md` + `.toml` pairs that are
fully superseded by their skill equivalents. The skills already cover
the same trigger phrases (`/caveman`, `/caveman-commit`, etc.) via
their `description` frontmatter, so no functionality is lost.

## Testing

Confirmed no other file in the repo (docs, README, other skills)
references the deleted command paths.