### PR TITLE
fix(gemini): make extension install cleanly

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,7 +40,7 @@ If you want to install for one agent (or want to know exactly what command runs 
 | Agent | Install command | Auto-activates? |
 |---|---|:-:|
 | **Claude Code** | `claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman` | Yes |
-| **Gemini CLI** | `gemini extensions install https://github.com/JuliusBrussee/caveman` | Yes |
+| **Gemini CLI** | `gemini extensions install https://github.com/JuliusBrussee/caveman --consent` | Yes |
 | **opencode** | `node bin/install.js --only opencode` *(or `npx -y github:JuliusBrussee/caveman -- --only opencode`)* | Yes (plugin + AGENTS.md) |
 | **OpenClaw** | `npx -y github:JuliusBrussee/caveman -- --only openclaw` | Yes (workspace skill + SOUL.md) |
 | **Hermes Agent** | `npx -y github:JuliusBrussee/caveman -- --only hermes` *(or `node bin/install.js --only hermes` from a clone)* | Yes (native skills, enabled on load) |

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Every agent has its own path (plugin, extension, rule file, or `npx skills add`)
 claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman
 
 # Gemini CLI extension
-gemini extensions install https://github.com/JuliusBrussee/caveman
+gemini extensions install https://github.com/JuliusBrussee/caveman --consent
 
 # Cursor / Windsurf / Cline / Codex / 30+ more, via the skills registry
 npx skills add JuliusBrussee/caveman -a cursor

--- a/agents/cavecrew-builder.md
+++ b/agents/cavecrew-builder.md
@@ -6,7 +6,6 @@ description: >
   scope. Returns caveman diff receipt. Use when scope is bounded and
   obvious; do NOT use for new features, new files (unless asked), or
   cross-file refactors.
-tools: [Read, Edit, Write, Grep, Glob]
 ---
 
 Caveman-ultra. Drop articles/filler. Code/paths exact, backticked. No narration.
@@ -16,7 +15,7 @@ Caveman-ultra. Drop articles/filler. Code/paths exact, backticked. No narration.
 1 file ideal. 2 OK. 3+ → refuse.
 Edit existing only (new file iff user asked).
 No new abstractions. No drive-by refactors. No comment additions.
-No `Bash` available — cannot shell out, cannot push, cannot delete.
+No shell commands — cannot push, cannot delete.
 
 ## Workflow
 

--- a/agents/cavecrew-investigator.md
+++ b/agents/cavecrew-investigator.md
@@ -5,7 +5,6 @@ description: >
   "what calls Y", "list all uses of Z", "map this directory". Output is
   caveman-compressed so the main thread eats ~60% fewer tokens than
   vanilla Explore. Refuses to suggest fixes.
-tools: [Read, Grep, Glob, Bash]
 model: haiku
 ---
 
@@ -29,7 +28,7 @@ Last line → totals: `2 defs, 5 refs.` (omit if 0 or 1).
 
 ## Tools
 
-`Grep` for symbols/strings. `Glob` for paths. `Read` only specific ranges. `Bash` for `git log -S`/`git grep`/`find` when faster.
+Use search for symbols/strings, glob for paths, and reads only for specific ranges. Shell only for read-only `git log -S`/`git grep`/`find` when faster.
 
 ## Refusals
 

--- a/agents/cavecrew-reviewer.md
+++ b/agents/cavecrew-reviewer.md
@@ -5,7 +5,6 @@ description: >
   no scope creep. Output format `path:line: <emoji> <severity>: <problem>. <fix>.`
   Use for "review this PR", "review my diff", "audit this file". Skips
   formatting nits unless they change meaning.
-tools: [Read, Grep, Bash]
 model: haiku
 ---
 
@@ -41,7 +40,7 @@ File order, ascending line numbers within file.
 
 ## Tools
 
-`Bash` only for `git diff`/`git log -p`/`git show`. No mutating commands.
+Shell only for read-only `git diff`/`git log -p`/`git show`. No mutating commands.
 
 ## Auto-clarity
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -565,7 +565,7 @@ function installGemini(ctx) {
       return;
     }
   }
-  const r = runSpawn('gemini', ['extensions', 'install', `https://github.com/${REPO}`], null, opts.dryRun);
+  const r = runSpawn('gemini', ['extensions', 'install', `https://github.com/${REPO}`, '--consent'], null, opts.dryRun);
   if (spawnOk(r)) results.installed.push('gemini');
   else results.failed.push(['gemini', 'gemini extensions install failed']);
   process.stdout.write('\n');
@@ -752,11 +752,10 @@ function installOpencode(ctx) {
       process.stdout.write(`  installed: ${dest}\n`);
     }
 
-    // 3. Subagents. Source files target Claude Code's schema (`tools: [...]`
-    //    YAML array); opencode rejects that form and refuses to boot until the
-    //    file is removed. Strip the `tools:` line on copy — opencode falls back
-    //    to its default tool set, and subagent prompts already self-restrict in
-    //    the body. Issue #386.
+    // 3. Subagents. Strip `tools:` defensively for legacy agent files: older
+    //    caveman releases used Claude Code's `tools: [...]` array, which made
+    //    opencode refuse to boot. Current source agents omit provider-specific
+    //    tool names so Gemini can load the extension directly too.
     fs.mkdirSync(agentsDir, { recursive: true });
     const agentSrcDir = path.join(repoRoot, 'agents');
     for (const f of OPENCODE_AGENT_FILES) {

--- a/bin/lib/opencode-agent.js
+++ b/bin/lib/opencode-agent.js
@@ -8,10 +8,9 @@
 //   ↳ Expected object | undefined, got ["Read","Grep","Bash"] tools
 //
 // opencode allows `tools` to be a map (`{read: true, grep: true}`) or
-// omitted entirely. Omitting falls back to opencode's default tool set,
-// which is what the cavecrew subagent prompts already self-restrict against
-// in their body ("Read-only locator", "No `Bash` available", etc.), so
-// dropping the array form is safe.
+// omitted entirely. Omitting falls back to opencode's default tool set, and
+// the cavecrew subagent prompts self-restrict in their body ("Read-only
+// locator", "No shell commands", etc.), so dropping the array form is safe.
 
 const TOOLS_FIELD_RE = /^tools[ \t]*:/;
 const CONTINUATION_RE = /^[ \t]/;

--- a/tests/installer/gemini.test.mjs
+++ b/tests/installer/gemini.test.mjs
@@ -1,0 +1,80 @@
+// Gemini CLI regression coverage.
+//
+// Gemini extension installs prompt for third-party consent unless --consent is
+// passed, which is hostile to curl|bash and non-interactive installer flows.
+// Gemini also loads root agents/*.md directly; those files must avoid
+// provider-specific tool names that Gemini rejects during extension loading.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const INSTALLER = path.join(REPO_ROOT, 'bin', 'install.js');
+const AGENTS_DIR = path.join(REPO_ROOT, 'agents');
+const CAVE_CREW_AGENT_FILES = [
+  'cavecrew-investigator.md',
+  'cavecrew-builder.md',
+  'cavecrew-reviewer.md',
+];
+
+function frontmatter(content) {
+  const m = content.match(/^---\n([\s\S]*?)\n---\n/);
+  assert.ok(m, 'frontmatter present');
+  return m[1];
+}
+
+function makeFakeGeminiBin() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cm-gemini-bin-'));
+  const bin = path.join(dir, 'gemini');
+  fs.writeFileSync(bin, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args.join(' ') === 'extensions list') {
+  console.log('No extensions installed.');
+  process.exit(0);
+}
+console.error('unexpected gemini args:', args.join(' '));
+process.exit(1);
+`);
+  fs.chmodSync(bin, 0o755);
+  return dir;
+}
+
+test('Gemini installer uses --consent to avoid the extension security prompt', () => {
+  const binDir = makeFakeGeminiBin();
+  const r = spawnSync(process.execPath, [
+    INSTALLER,
+    '--dry-run',
+    '--only', 'gemini',
+    '--non-interactive',
+  ], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ''}`,
+    },
+  });
+
+  assert.equal(r.status, 0);
+  assert.match(
+    r.stdout,
+    /would run: gemini extensions install https:\/\/github\.com\/JuliusBrussee\/caveman --consent/,
+  );
+});
+
+test('root cavecrew agents omit provider-specific tool names for Gemini compatibility', () => {
+  for (const f of CAVE_CREW_AGENT_FILES) {
+    const src = fs.readFileSync(path.join(AGENTS_DIR, f), 'utf8');
+    const fm = frontmatter(src);
+    assert.doesNotMatch(
+      fm,
+      /^tools:/m,
+      `${f}: Gemini validates tool names and rejects Claude-style names such as Read/Grep/Bash`,
+    );
+  }
+});

--- a/tests/installer/opencode-agent.test.mjs
+++ b/tests/installer/opencode-agent.test.mjs
@@ -1,7 +1,7 @@
 // Subagent frontmatter sanitizer for opencode (issue #386).
 //
-// opencode rejects the YAML array form `tools: [Read, Grep, Bash]` that
-// Claude Code accepts. Copying agents/cavecrew-*.md verbatim into
+// opencode rejects the YAML array form `tools: [Read, Grep, Bash]` that older
+// caveman agent files used. Copying those agents verbatim into
 // ~/.config/opencode/agents/ broke opencode startup with:
 //   Configuration is invalid at .../cavecrew-reviewer.md
 //   ↳ Expected object | undefined, got ["Read","Grep","Bash"] tools
@@ -116,15 +116,12 @@ test('non-string input returns unchanged', () => {
   assert.deepEqual(stripOpencodeAgentTools({ x: 1 }), { x: 1 });
 });
 
-// ── Real shipped agent files: every one must transform to opencode-safe ──
-// This is the RED-state proof: each `agents/cavecrew-*.md` in the repo today
-// contains the offending `tools: [...]` form, which is what broke opencode
-// startup in the reported bug. After transform, the field is gone.
-test('all shipped cavecrew agent files contain offending tools array (RED proof)', () => {
+// ── Real shipped agent files: every one must be opencode-safe ─────────────
+test('all shipped cavecrew agent files omit provider-specific tools field', () => {
   for (const f of SHIPPED_AGENT_FILES) {
     const src = fs.readFileSync(path.join(REPO_ROOT, 'agents', f), 'utf8');
     const fm = frontmatter(src);
-    assert.match(fm, /^tools:\s*\[/m, `source ${f} should contain inline array form (this is the bug)`);
+    assert.doesNotMatch(fm, /^tools:/m, `source ${f} should not contain provider-specific tools field`);
   }
 });
 


### PR DESCRIPTION
## Summary
- Pass `--consent` when the installer invokes `gemini extensions install` so non-interactive installs do not stall on Gemini's extension security prompt.
- Remove provider-specific `tools:` frontmatter from the shared cavecrew agent files so Gemini can load the extension root `agents/` directly.
- Keep the opencode sanitizer covering legacy `tools: [...]` agent files and add Gemini regression coverage.

## Root cause
Gemini CLI validates subagent `tools` entries against Gemini tool names while loading extension root `agents/*.md`. The shared cavecrew agents used Claude-style names like `Read`, `Grep`, and `Bash`, which made Gemini report `Invalid tool name` after installing the extension. The installer also invoked Gemini without `--consent`, leaving curl-pipe/non-interactive users at the third-party extension confirmation prompt.

## Validation
Revalidated on 2026-08-02 against unchanged upstream `main` (`0d95a81`):

- `node --test tests/installer/gemini.test.mjs` (2/2 passing)
- `node --test tests/installer/opencode-agent.test.mjs` (9/9 passing)
- `node --test tests/test_cavecrew_model_overrides.js` (24/24 passing)
- `npm test` (114/114 passing)
- Current Gemini CLI extension documentation confirms `--consent` remains supported for non-interactive installation.

The extension was also validated with `gemini extensions validate .` when the fix was originally prepared. Gemini CLI was not available locally during the 2026-08-02 revalidation, so that manual command was not rerun.
