### PR TITLE
Add Lists rule: keep list structure (one item per line) when compressing

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -29,6 +29,20 @@ Pattern: `[thing] [action] [reason]. [next step].`
 Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
 Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 
+## Lists
+
+Keep list structure. One item per line. Compress item text, not layout. Never collapse list onto one line — reader lose the steps.
+
+Not: "Steps: 1. clone 2. build 3. test 4. ship."
+
+Yes:
+1. clone
+2. build
+3. test
+4. ship
+
+Same for bullets — each item own line. List = structure, not fluff.
+
 ## Intensity
 
 | Level | What change |

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -33,15 +33,21 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 
 Keep list structure. One item per line. Compress item text, not layout. Never collapse list onto one line — reader lose the steps.
 
+Child list too. Sub-items each own line, indented under parent. Never inline a sub-list inside a parent item — worst offender when a numbered step have its own bullet detail.
+
 Not: "Steps: 1. clone 2. build 3. test 4. ship."
 
-Yes:
-1. clone
-2. build
-3. test
-4. ship
+Not (child list smashed into parent):
+1. Create secret — keys: SECRET_KEY, DATABASE_URL, REDIS_URL 2. Create redis-secret
 
-Same for bullets — each item own line. List = structure, not fluff.
+Yes:
+1. Create secret — keys:
+   - SECRET_KEY
+   - DATABASE_URL
+   - REDIS_URL
+2. Create redis-secret
+
+Same for bullets — each item own line, nested items indented. List = structure, not fluff.
 
 ## Intensity
 


### PR DESCRIPTION
Small focused SKILL.md addition: a `## Lists` rule so caveman keeps list **structure** when compressing — including **nested/child lists**, which is the most common failure.

**Before** (child bullet list smashed into the parent numbered item):

> 1. Create secret — keys: SECRET_KEY, DATABASE_URL, REDIS_URL 2. Create redis-secret

**After** (item text still terse, structure kept, sub-items indented):

> 1. Create secret — keys:
>    - SECRET_KEY
>    - DATABASE_URL
>    - REDIS_URL
> 2. Create redis-secret

**Why:** an inline-collapsed list is unreadable in any renderer (terminal, Markdown, chat UIs) and loses step order; the nested case is worst — a numbered step with its own bullet detail gets flattened into one run-on line. Caveman should shorten words, not destroy list layout. This also lines up with the existing **Auto-Clarity** rule about compression not garbling multi-step sequences.

(Origin: caveman-mode agents whose output renders as chat HTML, where smashed nested lists are especially bad — but the fix is renderer-agnostic, kept general here.)