### PR TITLE
fix(plugin): declare skills dir in plugin.json — plugin installs currently register hooks only (#569)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,6 +5,8 @@
     "name": "Julius Brussee",
     "url": "https://github.com/JuliusBrussee"
   },
+  "skills": "./skills/",
+  "commands": "./commands/",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
One-liner (plus a `commands` twin) for #569.

**Problem:** `.claude-plugin/plugin.json` has no `"skills"` key. With `marketplace.json` source `"./"`, Claude Code loads the manifest as-is and registers only what it declares — so `claude plugin install caveman@caveman` wires the hooks but registers **zero** of the six skills; `/caveman-stats` and friends come back as Unknown command. Reporter-verified in #569; manifest-verified against the [plugin manifest reference](https://code.claude.com/docs/en/plugins-reference).

**Fix:** declare `"skills": "./skills/"` (and `"commands": "./commands/"` for explicitness — pointing at the default dir is documented as warning-free).

No behavior change for hook-only standalone installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)