### PR TITLE
fix(hooks): unwrap Claude Code slash-command envelope so /caveman <level> and /caveman off work (#537)

### DIFF
--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -29,7 +29,26 @@ process.stdin.on('end', () => {
     const data = JSON.parse(input);
     // Collapse whitespace so phrase triggers still match multiline prompts —
     // every regex below sees a single-line prompt (#598).
-    const prompt = (data.prompt || '').trim().toLowerCase().replace(/\s+/g, ' ');
+    let prompt = (data.prompt || '').trim().toLowerCase().replace(/\s+/g, ' ');
+
+    // Claude Code delivers slash commands as an envelope, not the literal
+    // command (#537):
+    //   <command-message>caveman</command-message>
+    //   <command-name>/caveman</command-name>
+    //   <command-args>ultra</command-args>
+    // (newline-separated or one-line — the collapse above normalizes both;
+    // <command-args> may be empty or absent). The startsWith('/caveman')
+    // gate below saw '<command-message>…' first, so every envelope switch —
+    // including '/caveman off' — was a silent no-op. Reconstruct
+    // '<name> <args>' and let it flow through the existing parsing (stats
+    // regex included) exactly as if the user had typed the command raw.
+    // Only /caveman* names are unwrapped: foreign commands keep the raw
+    // prompt so NL detection still sees the user's own words.
+    const envName = /<command-name>\s*(\/[^<]+?)\s*<\/command-name>/.exec(prompt);
+    if (envName && envName[1].startsWith('/caveman')) {
+      const envArgs = /<command-args>\s*([^<]*?)\s*<\/command-args>/.exec(prompt);
+      prompt = (envName[1] + ' ' + (envArgs ? envArgs[1] : '')).trim();
+    }
 
     // Deactivation intent — computed FIRST so "turn caveman mode off" never
     // falls through to the activation patterns (#598: the old contiguous

--- a/tests/test_mode_tracker.py
+++ b/tests/test_mode_tracker.py
@@ -11,6 +11,11 @@ deactivated it.
 #599: one-shot independent modes (/caveman-commit etc.) permanently
 overwrote the active prose level, and the plugin-namespaced
 /caveman:caveman-commit|-review variants were not recognized at all.
+
+#537: Claude Code delivers slash commands as a <command-message>/
+<command-name>/<command-args> envelope, not the literal command string.
+The startsWith('/caveman') gate never matched it, so every level switch
+AND '/caveman off' from the real slash UI was a silent no-op.
 """
 
 import json
@@ -190,6 +195,71 @@ class ModeTrackerTests(unittest.TestCase):
         self.assertFalse(self.prev.exists(), "prev file must not survive deactivation")
         self.send("ordinary prompt")
         self.assertIsNone(self.flag_value(), "nothing should resurrect the mode")
+
+    # ── #537: Claude Code slash-command envelope unwrap ─────────────────
+
+    @staticmethod
+    def envelope(name, args, newlines=False):
+        sep = "\n" if newlines else ""
+        return (
+            f"<command-message>{name.lstrip('/')}</command-message>{sep}"
+            f"<command-name>{name}</command-name>{sep}"
+            f"<command-args>{args}</command-args>"
+        )
+
+    def test_envelope_one_line_switches_level(self):
+        # Envelope args=lite with preset full. Pre-fix the flag stayed
+        # 'full' and reinforcement kept naming the old level.
+        self.flag.write_text("full")
+        r = self.send(self.envelope("/caveman", "lite"))
+        self.assertEqual(self.flag_value(), "lite")
+        self.assertIn("CAVEMAN MODE ACTIVE (lite)", r.stdout)
+
+    def test_envelope_one_line_activates_without_preset(self):
+        # Envelope args=lite, no flag preset. Pre-fix the flag stayed
+        # absent — activation via the slash UI was dead.
+        self.send(self.envelope("/caveman", "lite"))
+        self.assertEqual(self.flag_value(), "lite")
+
+    def test_envelope_newline_form_switches_level(self):
+        # The exact newline-separated form from issue #537.
+        self.flag.write_text("full")
+        self.send(self.envelope("/caveman", "ultra", newlines=True))
+        self.assertEqual(self.flag_value(), "ultra")
+
+    def test_envelope_off_deactivates(self):
+        # '/caveman off' via envelope must delete the flag. Pre-fix
+        # deactivation was dead too — worse than a stuck level.
+        self.flag.write_text("full")
+        self.send(self.envelope("/caveman", "off", newlines=True))
+        self.assertIsNone(self.flag_value())
+
+    def test_envelope_stats_passthrough_does_not_touch_flag(self):
+        # /caveman-stats via envelope must reach the stats branch (block
+        # decision) and must not disturb the active level.
+        self.flag.write_text("full")
+        r = self.send(self.envelope("/caveman-stats", "", newlines=True))
+        self.assertEqual(self.flag_value(), "full")
+        self.assertIn('"decision":"block"', r.stdout)
+
+    def test_envelope_non_level_arg_does_not_flip(self):
+        # Non-level arg = task at current level; no silent flag overwrite —
+        # same contract as raw-typed '/caveman <non-level>'.
+        self.flag.write_text("ultra")
+        self.send(self.envelope("/caveman", "explain connection pooling"))
+        self.assertEqual(self.flag_value(), "ultra")
+
+    def test_raw_typed_command_still_works_after_unwrap(self):
+        # The literal path must stay intact alongside the envelope path.
+        self.send("/caveman lite")
+        self.assertEqual(self.flag_value(), "lite")
+
+    def test_foreign_command_envelope_untouched(self):
+        # A non-caveman command envelope must not be rewritten — and must
+        # not disturb the flag.
+        self.flag.write_text("full")
+        self.send(self.envelope("/commit", "fix the caveman parser", newlines=True))
+        self.assertEqual(self.flag_value(), "full")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #537.

## Bug mechanism

Claude Code delivers slash commands to `UserPromptSubmit` hooks as an envelope, not the literal command string:

```
<command-message>caveman</command-message>
<command-name>/caveman</command-name>
<command-args>ultra</command-args>
```

`caveman-mode-tracker.js` gates all slash parsing on `prompt.startsWith('/caveman')`. The envelope starts with `<command-message>`, so that branch never ran: `<command-args>` was never read, `safeWriteFlag` was never called, and every `/caveman <level>` switch — **and `/caveman off`** — issued through the real slash UI was a silent no-op. The flag stayed at the SessionStart default and the per-turn reinforcement kept naming the old level. Only raw-typed commands (pasted as plain text) ever worked.

## Fix

Immediately after the existing whitespace collapse — before the `/caveman-stats` regex and the `startsWith` gate — extract `<command-name>` and `<command-args>` (one-line and newline-separated forms both; the collapse normalizes them) and, **only when the name starts with `/caveman`**, reconstruct `'<name> <args>'` and let it flow through the existing parsing unchanged. No new parsing paths: stats, level switch, off, namespaced `/caveman:caveman-*`, and one-shot independent modes all reuse the code that already handled raw-typed commands. Foreign-command envelopes (e.g. `/commit`) are left untouched, so NL detection still sees the user's own words and never misfires on another command's arguments.

## Tests

8 new cases in `tests/test_mode_tracker.py`:
- one-line envelope switches level (full → lite) and reinforcement names the new level
- one-line envelope activates with no prior flag
- newline envelope (the exact #537 form) switches full → ultra
- `/caveman off` envelope deletes the flag
- `/caveman-stats` envelope still reaches the stats branch (`"decision":"block"`) and leaves the flag alone
- non-level arg via envelope does not silently overwrite the flag (same contract as raw)
- raw-typed `/caveman lite` regression guard
- foreign-command envelope is not rewritten and does not disturb the flag

Full suites green: `tests.test_mode_tracker` (31), `tests.test_hooks` + `tests.test_detect` (14), `npm test` (108 pass / 0 fail / 4 skipped), `tests/test_mode_tracker_stdin.js` (2).

The issue's self-contained repro (envelope payload, flag preset `full`, isolated `CLAUDE_CONFIG_DIR`) was re-run 3x against the patched hook: flag flips to `ultra` every time; pre-patch it stayed `full`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
