### PR TITLE
feat: add Pi provider, Cursor CLI detection, Junie always-on rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,11 +245,12 @@ How caveman reaches each agent type:
 | Gemini CLI | Extension with `GEMINI.md` context file | Yes — context file loads every session |
 | opencode | Native plugin (`src/plugins/opencode/`) copied into `~/.config/opencode/plugins/caveman/` + `AGENTS.md` ruleset + skills/agents/commands directories. Plugin uses `session.created` and `tui.prompt.append` lifecycle hooks. No statusline (opencode TUI exposes no plugin-writable badge). | Yes — `session.created` writes flag, `AGENTS.md` carries always-on ruleset |
 | OpenClaw | Workspace skill at `~/.openclaw/workspace/skills/caveman/SKILL.md` (frontmatter merged with `version` + `always: true`) plus a marker-fenced bootstrap block in `~/.openclaw/workspace/SOUL.md`. Both writes go through `bin/lib/openclaw.js`; workspace path is overridable via `OPENCLAW_WORKSPACE`. | Yes — SOUL.md is auto-injected each turn under "Project Context" (subject to OpenClaw's 12K-per-file / 60K-total bootstrap caps) |
-| Cursor | `npx skills add ... -a cursor` (default via `--only cursor`) writes the upstream skill profile; per-repo `.cursor/rules/caveman.mdc` via `--with-init` (calls `src/tools/caveman-init.js`) | Yes — always-on rule |
+| Cursor (IDE + `cursor-agent` CLI) | `npx skills add ... -a cursor` (default via `--only cursor`) writes the upstream skill profile; per-repo `.cursor/rules/caveman.mdc` via `--with-init` (calls `src/tools/caveman-init.js`) | Yes — always-on rule |
 | Windsurf | `npx skills add ... -a windsurf` (default via `--only windsurf`); per-repo `.windsurf/rules/caveman.md` via `--with-init` | Yes — always-on rule |
 | Cline | `npx skills add ... -a cline` (default via `--only cline`); per-repo `.clinerules/caveman.md` via `--with-init` | Yes — Cline auto-discovers `.clinerules/` |
 | Copilot | `npx skills add ... -a github-copilot` (soft probe — pass `--only copilot`); per-repo `.github/copilot-instructions.md` + `AGENTS.md` via `--with-init` | Yes — repo-wide instructions |
-| Others (Junie, Trae, Warp, Tabnine, Mistral, Qwen, Devin, Droid, ForgeCode, Bob, Crush, iFlow, OpenHands, Qoder, Rovo Dev, Replit, Antigravity, …) | `npx skills add JuliusBrussee/caveman -a <profile>` | No — user must say `/caveman` each session |
+| Junie | `npx skills add ... -a junie` (soft probe — pass `--only junie`); per-repo `.junie/guidelines.md` via `--with-init` | Yes with `--with-init` — Junie auto-loads `.junie/guidelines.md` |
+| Others (Pi, Trae, Warp, Tabnine, Mistral, Qwen, Devin, Droid, ForgeCode, Bob, Crush, iFlow, OpenHands, Qoder, Rovo Dev, Replit, Antigravity, …) | `npx skills add JuliusBrussee/caveman -a <profile>` | No — user must say `/caveman` each session |
 
 opencode reaches Tier 1 minus the statusline (opencode's TUI has no plugin-writable badge). Mode flag lives at `~/.config/opencode/.caveman-active` for any external tooling that wants to surface it.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,7 +45,7 @@ If you want to install for one agent (or want to know exactly what command runs 
 | **OpenClaw** | `npx -y github:JuliusBrussee/caveman -- --only openclaw` | Yes (workspace skill + SOUL.md) |
 | **Hermes Agent** | `npx -y github:JuliusBrussee/caveman -- --only hermes` *(or `node bin/install.js --only hermes` from a clone)* | Yes (native skills, enabled on load) |
 | **Codex CLI** | `npx skills add JuliusBrussee/caveman -a codex` | Per-session: `/caveman` |
-| **Cursor** | `npx skills add JuliusBrussee/caveman -a cursor` | Per-session by default; `--with-init` for an always-on rule file |
+| **Cursor** *(IDE + `cursor-agent` CLI)* | `npx skills add JuliusBrussee/caveman -a cursor` | Per-session by default; `--with-init` for an always-on rule file |
 | **Windsurf** | `npx skills add JuliusBrussee/caveman -a windsurf` | Per-session by default; `--with-init` for an always-on rule file |
 | **Cline** | `npx skills add JuliusBrussee/caveman -a cline` | Per-session by default; `--with-init` for an always-on rule file |
 | **GitHub Copilot** *(soft probe)* | `npx -y github:JuliusBrussee/caveman -- --only copilot --with-init` | Repo-wide instructions via `--with-init` |
@@ -65,13 +65,14 @@ If you want to install for one agent (or want to know exactly what command runs 
 | **Kiro CLI** | `npx skills add JuliusBrussee/caveman -a kiro-cli` | No |
 | **Mistral Vibe** | `npx skills add JuliusBrussee/caveman -a mistral-vibe` | No |
 | **OpenHands** | `npx skills add JuliusBrussee/caveman -a openhands` | No |
+| **Pi (badlogic)** | `npx skills add JuliusBrussee/caveman -a pi` | No |
 | **Qwen Code** | `npx skills add JuliusBrussee/caveman -a qwen-code` | No |
 | **Atlassian Rovo Dev** | `npx skills add JuliusBrussee/caveman -a rovodev` | No |
 | **Tabnine CLI** | `npx skills add JuliusBrussee/caveman -a tabnine-cli` | No |
 | **Trae** | `npx skills add JuliusBrussee/caveman -a trae` | No |
 | **Warp** | `npx skills add JuliusBrussee/caveman -a warp` | No |
 | **Replit Agent** | `npx skills add JuliusBrussee/caveman -a replit` | No |
-| **JetBrains Junie** *(soft probe)* | `npx skills add JuliusBrussee/caveman -a junie` | No |
+| **JetBrains Junie** *(soft probe)* | `npx skills add JuliusBrussee/caveman -a junie` | Per-session by default; `--with-init` writes `.junie/guidelines.md` for always-on |
 | **Qoder** *(soft probe)* | `npx skills add JuliusBrussee/caveman -a qoder` | No |
 | **Google Antigravity** *(soft probe)* | `npx skills add JuliusBrussee/caveman -a antigravity` | No |
 
@@ -144,7 +145,7 @@ curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/src/rule
   > .cursor/rules/caveman.mdc   # or .windsurf/rules/caveman.md, .clinerules/caveman.md, .github/copilot-instructions.md
 ```
 
-`--with-init` writes the rule into every supported per-agent location it can detect (`.cursor/rules/`, `.windsurf/rules/`, `.clinerules/`, `.github/copilot-instructions.md`, `.opencode/AGENTS.md`, `AGENTS.md`). It also installs the OpenClaw workspace bootstrap (skill folder + SOUL.md marker block) when `~/.openclaw/workspace/` exists. Single source: [`src/rules/caveman-activate.md`](src/rules/caveman-activate.md).
+`--with-init` writes the rule into every supported per-agent location it can detect (`.cursor/rules/`, `.windsurf/rules/`, `.clinerules/`, `.github/copilot-instructions.md`, `.junie/guidelines.md`, `.opencode/AGENTS.md`, `AGENTS.md`). It also installs the OpenClaw workspace bootstrap (skill folder + SOUL.md marker block) when `~/.openclaw/workspace/` exists. Single source: [`src/rules/caveman-activate.md`](src/rules/caveman-activate.md).
 
 ## Verify
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -213,7 +213,7 @@ const PROVIDERS = [
   // IDE / VS Code-family — extension probes are precise. Cursor/Windsurf also
   // ship CLI binaries; we drop the dir fallback because the dir lingers after
   // uninstall and false-positives heavily.
-  { id: 'cursor',     label: 'Cursor',              mech: 'npx skills add (cursor)',       detect: 'command:cursor||macapp:Cursor', profile: 'cursor' },
+  { id: 'cursor',     label: 'Cursor (IDE + CLI)',  mech: 'npx skills add (cursor)',       detect: 'command:cursor||command:cursor-agent||macapp:Cursor', profile: 'cursor' },
   { id: 'windsurf',   label: 'Windsurf',            mech: 'npx skills add (windsurf)',     detect: 'command:windsurf||macapp:Windsurf', profile: 'windsurf' },
   { id: 'cline',      label: 'Cline',               mech: 'npx skills add (cline)',        detect: 'vscode-ext:cline',        profile: 'cline' },
   { id: 'continue',   label: 'Continue',            mech: 'npx skills add (continue)',     detect: 'vscode-ext:continue.continue||vscode-ext:continue', profile: 'continue' },
@@ -242,6 +242,7 @@ const PROVIDERS = [
   { id: 'kiro',       label: 'Kiro CLI',            mech: 'npx skills add (kiro-cli)',     detect: 'command:kiro', profile: 'kiro-cli' },
   { id: 'mistral',    label: 'Mistral Vibe',        mech: 'npx skills add (mistral-vibe)', detect: 'command:mistral', profile: 'mistral-vibe' },
   { id: 'openhands',  label: 'OpenHands',           mech: 'npx skills add (openhands)',    detect: 'command:openhands', profile: 'openhands' },
+  { id: 'pi',         label: 'Pi (badlogic)',       mech: 'npx skills add (pi)',           detect: 'command:pi', profile: 'pi' },
   { id: 'qwen',       label: 'Qwen Code',           mech: 'npx skills add (qwen-code)',    detect: 'command:qwen', profile: 'qwen-code' },
   { id: 'rovodev',    label: 'Atlassian Rovo Dev',  mech: 'npx skills add (rovodev)',      detect: 'command:rovodev', profile: 'rovodev' },
   { id: 'tabnine',    label: 'Tabnine CLI',         mech: 'npx skills add (tabnine-cli)',  detect: 'command:tabnine', profile: 'tabnine-cli' },

--- a/src/tools/caveman-init.js
+++ b/src/tools/caveman-init.js
@@ -7,7 +7,7 @@
 //   curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/src/tools/caveman-init.js | node - [args]
 //
 // Without args, runs in cwd. Generates the rule files for Cursor, Windsurf,
-// Cline, Copilot, and AGENTS.md. Does NOT modify CLAUDE.md or compress
+// Cline, Copilot, Junie, and AGENTS.md. Does NOT modify CLAUDE.md or compress
 // existing memory files — that's the job of `/caveman:compress`.
 
 const fs = require('fs');
@@ -55,6 +55,9 @@ const AGENTS = [
     frontmatter: '',
     mode: 'replace' },
   { id: 'copilot',  file: '.github/copilot-instructions.md',
+    frontmatter: '',
+    mode: 'append' },
+  { id: 'junie',    file: '.junie/guidelines.md',
     frontmatter: '',
     mode: 'append' },
   { id: 'opencode', file: '.opencode/AGENTS.md',

--- a/tests/test_caveman_init.js
+++ b/tests/test_caveman_init.js
@@ -51,6 +51,8 @@ test('greenfield: creates all rule files with proper frontmatter', (tmp) => {
   assert.match(cline, /^Respond terse/);
   const copilot = fs.readFileSync(path.join(tmp, '.github/copilot-instructions.md'), 'utf8');
   assert.match(copilot, /Respond terse/);
+  const junie = fs.readFileSync(path.join(tmp, '.junie/guidelines.md'), 'utf8');
+  assert.match(junie, /Respond terse/);
   const agents = fs.readFileSync(path.join(tmp, 'AGENTS.md'), 'utf8');
   assert.match(agents, /Respond terse/);
   const opencode = fs.readFileSync(path.join(tmp, '.opencode/AGENTS.md'), 'utf8');
@@ -60,8 +62,8 @@ test('greenfield: creates all rule files with proper frontmatter', (tmp) => {
 test('idempotent: re-running on a clean install skips all', (tmp) => {
   runInit(tmp);
   const out = runInit(tmp);
-  // 6 repo rule files skipped-already-installed + openclaw skipped (no workspace)
-  assert.match(out, /7 skipped/);
+  // 7 repo rule files skipped-already-installed + openclaw skipped (no workspace)
+  assert.match(out, /8 skipped/);
   assert.doesNotMatch(out, /[1-9]\d* added/);
 });
 
@@ -96,7 +98,7 @@ test('--force overwrites existing rule files', (tmp) => {
 test('--dry-run: announces but writes nothing', (tmp) => {
   const out = runInit(tmp, '--dry-run');
   assert.match(out, /\(dry run\)/);
-  assert.match(out, /6 added/);
+  assert.match(out, /7 added/);
   assert.ok(!fs.existsSync(path.join(tmp, '.cursor')));
   assert.ok(!fs.existsSync(path.join(tmp, '.windsurf')));
   assert.ok(!fs.existsSync(path.join(tmp, '.clinerules')));


### PR DESCRIPTION
Pi (badlogic pi-mono) missing from installer entirely; Cursor entry never fired for CLI-only installs (binary is cursor-agent, not cursor); Junie had no always-on path — it auto-loads .junie/guidelines.md, so caveman-init now writes one.