### PR TITLE
feat: propagate caveman mode to subagents

### DIFF
--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -9,7 +9,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { getDefaultMode, safeWriteFlag, recordModeChange } = require('./caveman-config');
+const { getDefaultMode, getPropagateToSubagents, safeWriteFlag, recordModeChange } = require('./caveman-config');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');
@@ -167,6 +167,11 @@ try {
   }
 } catch (e) {
   // Silent fail — don't block session start over statusline detection
+}
+
+if (getPropagateToSubagents()) {
+  output += "\n\nSUBAGENT PROPAGATION: When spawning subagents, prepend this to their prompt: " +
+    "'Respond terse like smart caveman. Drop articles/filler/hedging. Technical terms exact. Code unchanged. Pattern: [thing] [action] [reason].'";
 }
 
 process.stdout.write(output);

--- a/src/hooks/caveman-config.js
+++ b/src/hooks/caveman-config.js
@@ -345,4 +345,32 @@ function readHistory(filePath) {
   }
 }
 
-module.exports = { getDefaultMode, getConfigDir, getConfigPath, findRepoConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory, recordModeChange, MODE_LOG_BASENAME };
+function getPropagateToSubagents() {
+  const env = process.env.CAVEMAN_PROPAGATE;
+  if (env !== undefined) {
+    return env !== '0' && env.toLowerCase() !== 'false';
+  }
+
+  const repoConfigPath = findRepoConfigPath(process.cwd());
+  if (repoConfigPath) {
+    try {
+      const raw = fs.readFileSync(repoConfigPath, 'utf8');
+      const config = JSON.parse(raw);
+      if (config && typeof config.propagateToSubagents === 'boolean') {
+        return config.propagateToSubagents;
+      }
+    } catch (e) {}
+  }
+
+  try {
+    const raw = fs.readFileSync(getConfigPath(), 'utf8');
+    const config = JSON.parse(raw);
+    if (config && typeof config.propagateToSubagents === 'boolean') {
+      return config.propagateToSubagents;
+    }
+  } catch (e) {}
+
+  return true;
+}
+
+module.exports = { getDefaultMode, getPropagateToSubagents, getConfigDir, getConfigPath, findRepoConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory, recordModeChange, MODE_LOG_BASENAME };


### PR DESCRIPTION
Add propagateToSubagents config option (default: true) that appends a short caveman instruction for subagent prompts. Disable with CAVEMAN_PROPAGATE=0 or {"propagateToSubagents": false} in config.

Closes #672.