### PR TITLE
fix(skill): keep particles, scope hanja to wenyan

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -22,6 +22,11 @@ Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleas
 
 Preserve user's dominant language. User write Portuguese → reply Portuguese caveman. User write Spanish → reply Spanish caveman. Compress the style, not the language. No forced English openings or status phrases. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim — unless user explicitly ask for translation.
 
+"Drop articles" rule apply to article languages only. Case particles and connective endings ARE grammar — mark who do what to whom. Keep them; drop one only when word order recover exact meaning. Compress instead: politeness forms, hedging, filler. Rule hold at every level — lite, full, ultra.
+
+Not: "캐시 서버 요청 차단" — particles dropped, who block whom unclear.
+Yes: "캐시가 서버 요청을 차단." — particles stay, still terse.
+
 No self-reference. Never name or announce the style. No "caveman mode on", "me caveman think", no third-person caveman tags. Output caveman-only — never normal answer plus "Caveman:" recap. Exception: user explicitly ask what the mode is.
 
 Pattern: `[thing] [action] [reason]. [next step].`
@@ -55,6 +60,8 @@ Example — "Explain database connection pooling."
 - wenyan-full: "池蓄已開之連，不逐請而新開，省握手之費。"
 - wenyan-ultra: "池蓄連，免逐請新開，省握手。"
 
+Classical characters and wenyan register belong to wenyan modes ONLY. Other levels, any language: that language's own everyday script — never swap word to classical character to shorten (있음, never 有; 연결, never 連結). One-off classical-style request cover that answer only — next answer revert to level. Wenyan examples above = wenyan targets, not vocabulary for other levels.
+
 ## Auto-Clarity
 
 Drop caveman when:
@@ -76,3 +83,5 @@ Example — destructive op:
 ## Boundaries
 
 Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+
+Non-wenyan level: everyday script only, every answer. Previous classical answer = no precedent.


### PR DESCRIPTION
Fixes #680.

## Problem

Korean sessions break SKILL.md's own promise ("Preserve user's dominant language. … Compress the style, not the language", Rules section):

1. **Particle drops flip subject/object.** "Drop articles (a/an/the)" is English morphology; models generalize it to Korean case particles (조사), which carry the case relations themselves. Reproduced at `ultra`: `부모 그리면 자식도 그림` — with the subject particle dropped and a transitive verb, agent/patient flips. The terse control compressed the same fact unambiguously.
2. **Classical characters leak into Korean output.** The six in-context wenyan examples supply classical-character material that compression pressure occasionally borrows (있음 → 有). Field-reproduced: 4×12-turn Korean-only sessions (no prompt mentions anything classical), 1/48 turns emitted hanja inside an otherwise normal Korean table cell (`지연 有`) — matching the intermittent pattern Korean users report.

## Fix — 10 added lines in `skills/caveman/SKILL.md`, pure addition, no line rewritten

1. **Rules:** scope "drop articles" to article languages; case particles and connective endings are grammar — keep them, compress politeness/hedging/filler instead. Stated as a general principle (no language-name list, per #665's drift concern) + one Korean Not/Yes pair mirroring the existing example format.
2. **After the wenyan examples:** classical characters and wenyan register belong to wenyan modes only — never swap a word to a classical character to shorten (있음, never 有; 연결, never 連結).
3. **Final line:** per-answer script guard (recency anchor).

## Measured results (real runs)

Token savings — Korean, `ultra`, **skill vs terse** per the repo's honest-delta rule, claude-fable-5, 10 prompts, tiktoken o200k (approximates Claude tokenizer for CJK; ratios meaningful, absolutes approximate):

| | before fix | after fix |
|---|---|---|
| median savings | 8.8% | **23.3%** |
| pooled savings | 8.9% | **25.1%** |
| worst prompt | **−27.7%** (worse than terse) | +8.1% |

The particle rule gives the model an explicit Korean compression strategy (cut politeness forms/hedging/filler, keep particles), so savings become consistent instead of occasionally negative.

Particle ambiguity — `ultra`, the #680 React repro prompt, 5 after-fix runs: **0/5** ambiguous transitive clauses; the same clause now renders with the particle retained (`부모가 그리면 자식도 그림`).

Hanja under adversarial stress — 20 two-turn sessions (claude-opus-4-8), turn 1 elicits a wenyan-register answer into history, turn 2 asks plain Korean: before **16/20** turn-2 outputs contained classical characters → after **11/20**. Honest limitation: register momentum in conversation history partially beats system-prompt text; this diff halves the adversarial case but does not eliminate it (noted in #680 — full elimination likely needs hook-level handling). The field condition — no wenyan in history, leakage from the in-context examples alone — is the primary target.

Single-shot Korean after fix: 0 hanja across 30 outputs.

## Relationship to open work

- **#658** — complementary, no textual conflict (its SKILL.md hunk inserts after L11; these sit at ~L25/L60/EOF). Its "article/filler-drop rules apply to the per-language equivalent" clause needs exactly this guardrail so models don't pick particles as the Korean article-equivalent.
- **#667** — line 23 untouched; additions only.
- **#665** — no new language-name tokens in always-in-context rules.
- **#536** — wenyan modes untouched, only scoped.
- `plugins/caveman/skills/` mirror left for the CI sync workflow per CLAUDE.md.

Raw transcripts of all runs retained; happy to attach.