### PR TITLE
fix(skill): localize Auto-Clarity warning example

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -66,6 +66,8 @@ Drop caveman when:
 
 Resume caveman after clear part done.
 
+Example below show FORMAT only — write the warning in session language, not example's language.
+
 Example — destructive op:
 > **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
 > ```sql


### PR DESCRIPTION
Fixes #679.

## Problem

The Auto-Clarity section's only concrete output template is an English warning block. In non-English sessions that trigger Auto-Clarity, the model intermittently reproduces that template near-verbatim in English inside an otherwise fully localized response — violating the Rules-section language-preservation promise. Reproduction transcript in #679 (Korean session, `full` level: whole answer Korean except the warning, which matched the SKILL.md example's English structure).

## Fix — 1 added line in `skills/caveman/SKILL.md`

A line immediately before the example marking it as format-only: the warning must be written in the session language.

## Validation (real runs)

5/5 after-fix runs of the #679 repro prompt (claude-fable-5, `full`): Auto-Clarity fired every time, warning rendered in Korean every time, 0/5 English. Example:

> **경고:** `DROP COLUMN`은 해당 컬럼의 모든 데이터를 영구 삭제하며 복구할 수 없습니다. 실행 전 반드시 백업을 확인하세요.

Complementary to #658 (general output-language preservation) — this targets the hardcoded example template specifically; no shared hunks. `plugins/caveman/skills/` mirror left for the CI sync workflow per CLAUDE.md.