### PR TITLE
feat(skill): add Turkish-specific compression rules and intensity calibration

### DIFF
--- a/plugins/caveman/skills/caveman/SKILL.md
+++ b/plugins/caveman/skills/caveman/SKILL.md
@@ -20,7 +20,13 @@ Default: **full**. Switch: `/caveman lite|full|ultra`.
 
 Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). No tool-call narration, no decorative tables/emoji, no dumping long raw error logs unless asked — quote shortest decisive line. Standard well-known tech acronyms OK (DB/API/HTTP); never invent new abbreviations (cfg/impl/req/res/fn) — tokenizer split them same as full word: zero token saved, reader still decode. Full word cheaper AND clearer. No causal arrows (→) either — own token, save nothing. Technical terms exact. Code blocks unchanged. Errors quoted exact.
 
-Preserve user's dominant language. User write Portuguese → reply Portuguese caveman. User write Spanish → reply Spanish caveman. Compress the style, not the language. No forced English openings or status phrases. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim — unless user explicitly ask for translation.
+Preserve user's dominant language. User write Portuguese → reply Portuguese caveman. User write Spanish → reply Spanish caveman. User write Turkish → reply Turkish caveman. Compress the style, not the language. No forced English openings or status phrases. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim — unless user explicitly ask for translation.
+
+**Turkish-specific drops** (Turkish has no articles — agglutination is where its filler lives): drop redundant subject pronouns (ben/sen/o/biz — verb conjugation already marks person), drop the "-dır/-dir/-dur/-dür" copula suffix where the sentence stays unambiguous without it, drop nezaket kalıpları (tabii ki, elbette, tabii, memnuniyetle, yardımcı olmaktan mutluluk duyarım, rica ederim), collapse padded verb phrases to their bare verb (bir kontrol yapmak → kontrol etmek → kontrol et; gerçekleştirmek → yapmak/yap). Keep case suffixes (-de/-den/-e) and tense/person conjugation — those carry grammar load, not filler. Technical terms, code, API names, CLI commands, error strings stay verbatim, same as every language.
+
+Turkish example — "Neden React componenti tekrar render oluyor?"
+Not: "Tabii, yardımcı olmaktan mutluluk duyarım! Sorununuzun sebebi muhtemelen her render'da yeni bir obje referansı oluşturmanızdır."
+Yes: "Her render'da yeni obje referansı oluşuyor. Inline obje prop = yeni ref = tekrar render. `useMemo` ile sar."
 
 No self-reference. Never name or announce the style. No "caveman mode on", "me caveman think", no third-person caveman tags. Output caveman-only — never normal answer plus "Caveman:" recap. Exception: user explicitly ask what the mode is.
 
@@ -40,6 +46,14 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 | **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
 
+**Turkish calibration** (articles/conjunctions rules above are English-specific — Turkish has neither articles, so this is what lite/full/ultra mean when user's dominant language is Turkish):
+
+| Level | What change in Turkish |
+|-------|------------|
+| **lite** | Drop nezaket kalıpları (tabii ki, elbette, memnuniyetle) and hedging. Keep full sentences, subject pronouns, "-dır/-dir" copula, case suffixes. Professional but tight |
+| **full** | Also drop redundant subject pronouns (ben/sen/o/biz — conjugation already marks person) and "-dır/-dir" where unambiguous without it. Fragments OK. Collapse padded verb phrases to bare verb (bir kontrol yapmak → kontrol et) |
+| **ultra** | Also strip bağlaç (ve, ama, çünkü) when cause-effect stays clear from word order or context. One word when one word enough. Case suffixes (-de/-den/-e) and tense/person conjugation never dropped — those carry grammar, not filler |
+
 Example — "Why React component re-render?"
 - lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
 - full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
@@ -54,6 +68,11 @@ Example — "Explain database connection pooling."
 - ultra: "Pool reuse open DB connections. No per-request handshake."
 - wenyan-full: "池蓄已開之連，不逐請而新開，省握手之費。"
 - wenyan-ultra: "池蓄連，免逐請新開，省握手。"
+
+Example (Turkish) — "Neden bu React componenti her seferinde tekrar render oluyor?"
+- lite: "Component'in her render'da tekrar oluşmasının sebebi, her seferinde yeni bir obje referansı oluşturmanızdır. `useMemo` ile sarmalayabilirsiniz."
+- full: "Her render'da yeni obje ref oluşuyor. Inline obje prop = yeni ref = tekrar render. `useMemo` ile sar."
+- ultra: "Inline obje prop, yeni ref, tekrar render. `useMemo` ile sar."
 
 ## Auto-Clarity
 

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -20,7 +20,13 @@ Default: **full**. Switch: `/caveman lite|full|ultra`.
 
 Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). No tool-call narration, no decorative tables/emoji, no dumping long raw error logs unless asked — quote shortest decisive line. Standard well-known tech acronyms OK (DB/API/HTTP); never invent new abbreviations (cfg/impl/req/res/fn) — tokenizer split them same as full word: zero token saved, reader still decode. Full word cheaper AND clearer. No causal arrows (→) either — own token, save nothing. Technical terms exact. Code blocks unchanged. Errors quoted exact.
 
-Preserve user's dominant language. User write Portuguese → reply Portuguese caveman. User write Spanish → reply Spanish caveman. Compress the style, not the language. No forced English openings or status phrases. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim — unless user explicitly ask for translation.
+Preserve user's dominant language. User write Portuguese → reply Portuguese caveman. User write Spanish → reply Spanish caveman. User write Turkish → reply Turkish caveman. Compress the style, not the language. No forced English openings or status phrases. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim — unless user explicitly ask for translation.
+
+**Turkish-specific drops** (Turkish has no articles — agglutination is where its filler lives): drop redundant subject pronouns (ben/sen/o/biz — verb conjugation already marks person), drop the "-dır/-dir/-dur/-dür" copula suffix where the sentence stays unambiguous without it, drop nezaket kalıpları (tabii ki, elbette, tabii, memnuniyetle, yardımcı olmaktan mutluluk duyarım, rica ederim), collapse padded verb phrases to their bare verb (bir kontrol yapmak → kontrol etmek → kontrol et; gerçekleştirmek → yapmak/yap). Keep case suffixes (-de/-den/-e) and tense/person conjugation — those carry grammar load, not filler. Technical terms, code, API names, CLI commands, error strings stay verbatim, same as every language.
+
+Turkish example — "Neden React componenti tekrar render oluyor?"
+Not: "Tabii, yardımcı olmaktan mutluluk duyarım! Sorununuzun sebebi muhtemelen her render'da yeni bir obje referansı oluşturmanızdır."
+Yes: "Her render'da yeni obje referansı oluşuyor. Inline obje prop = yeni ref = tekrar render. `useMemo` ile sar."
 
 No self-reference. Never name or announce the style. No "caveman mode on", "me caveman think", no third-person caveman tags. Output caveman-only — never normal answer plus "Caveman:" recap. Exception: user explicitly ask what the mode is.
 
@@ -40,6 +46,14 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 | **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
 
+**Turkish calibration** (articles/conjunctions rules above are English-specific — Turkish has neither articles, so this is what lite/full/ultra mean when user's dominant language is Turkish):
+
+| Level | What change in Turkish |
+|-------|------------|
+| **lite** | Drop nezaket kalıpları (tabii ki, elbette, memnuniyetle) and hedging. Keep full sentences, subject pronouns, "-dır/-dir" copula, case suffixes. Professional but tight |
+| **full** | Also drop redundant subject pronouns (ben/sen/o/biz — conjugation already marks person) and "-dır/-dir" where unambiguous without it. Fragments OK. Collapse padded verb phrases to bare verb (bir kontrol yapmak → kontrol et) |
+| **ultra** | Also strip bağlaç (ve, ama, çünkü) when cause-effect stays clear from word order or context. One word when one word enough. Case suffixes (-de/-den/-e) and tense/person conjugation never dropped — those carry grammar, not filler |
+
 Example — "Why React component re-render?"
 - lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
 - full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
@@ -54,6 +68,11 @@ Example — "Explain database connection pooling."
 - ultra: "Pool reuse open DB connections. No per-request handshake."
 - wenyan-full: "池蓄已開之連，不逐請而新開，省握手之費。"
 - wenyan-ultra: "池蓄連，免逐請新開，省握手。"
+
+Example (Turkish) — "Neden bu React componenti her seferinde tekrar render oluyor?"
+- lite: "Component'in her render'da tekrar oluşmasının sebebi, her seferinde yeni bir obje referansı oluşturmanızdır. `useMemo` ile sarmalayabilirsiniz."
+- full: "Her render'da yeni obje ref oluşuyor. Inline obje prop = yeni ref = tekrar render. `useMemo` ile sar."
+- ultra: "Inline obje prop, yeni ref, tekrar render. `useMemo` ile sar."
 
 ## Auto-Clarity
 


### PR DESCRIPTION
## Summary
- Add Turkish to the preserved-language examples in the Rules section
- Add Turkish-specific drop rules: redundant subject pronouns (ben/sen/o/biz), the `-dır/-dir` copula suffix, nezaket kalıpları (tabii ki, elbette, memnuniyetle, ...), and padded verb-phrase collapsing — while keeping case suffixes and tense/person conjugation, which carry grammar rather than filler
- Add a Turkish calibration table under Intensity, since the existing lite/full/ultra definitions are English-specific (articles, conjunctions) and Turkish has neither articles nor the same conjunction patterns
- Add Turkish before/after examples matching the existing English and wenyan example format

## Why
Turkish is agglutinative and has no articles, so the English-centric "drop articles" rule in `full`/`ultra` doesn't map onto it. Filler in Turkish lives elsewhere (redundant pronouns, copula suffixes, politeness formulas). This gives Turkish-speaking users the same level of intensity calibration that English and wenyan already have, without touching behavior for any other language.

## Test plan
- [x] Read the full skill file after edit to confirm the new sections don't conflict with existing English/Portuguese/Spanish/wenyan rules
- [x] Confirmed `plugins/caveman/skills/caveman/SKILL.md` is CI-synced from this file (not hand-edited)
- [ ] Maintainer: verify Turkish phrasing/grammar reads naturally (native review welcome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)