### PR TITLE
fix: SessionStart re-fires must not clobber an already-active mode

### DIFF
--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -9,7 +9,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { getDefaultMode, safeWriteFlag, recordModeChange } = require('./caveman-config');
+const { getDefaultMode, safeWriteFlag, readFlag, recordModeChange } = require('./caveman-config');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');
@@ -22,19 +22,27 @@ try {
   applyOverrides(resolvePluginRoot(__dirname));
 } catch (e) {}
 
-const mode = getDefaultMode();
+// SessionStart fires more than once per conversation (resume, context
+// compaction). If a valid flag is already on disk, a mode change happened
+// via /caveman <level> or a direct edit after the last SessionStart — honor
+// it instead of stomping it back to the configured default every re-fire.
+const existingMode = readFlag(flagPath);
+const mode = existingMode || getDefaultMode();
 
 // "off" mode — skip activation entirely, don't write flag or emit rules
 if (mode === 'off') {
-  recordModeChange(claudeDir, null); // #601: timestamped transition log
+  if (!existingMode) recordModeChange(claudeDir, null); // #601: timestamped transition log
   try { fs.unlinkSync(flagPath); } catch (e) {}
   process.stdout.write('OK');
   process.exit(0);
 }
 
-// 1. Write flag file (symlink-safe)
-recordModeChange(claudeDir, mode); // #601
-safeWriteFlag(flagPath, mode);
+// 1. Write flag file (symlink-safe) — only when there's no existing valid
+// override to preserve (see above).
+if (!existingMode) {
+  recordModeChange(claudeDir, mode); // #601
+  safeWriteFlag(flagPath, mode);
+}
 
 // 2. Emit full caveman ruleset, filtered to the active intensity level.
 //    The old 2-sentence summary was too weak — models drifted back to verbose

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -214,6 +214,31 @@ class HookScriptTests(unittest.TestCase):
 
             self.assertIn("PLUGIN ROOT MARKER RULESET", result.stdout)
 
+    # Regression: SessionStart fires more than once per conversation (resume,
+    # context compaction). It must not stomp a mode the user already set via
+    # /caveman <level> back to the configured default on re-fire.
+    def test_activate_preserves_existing_flag_across_rerun(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-preserve-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+            (claude_dir / ".caveman-active").write_text("ultra")
+
+            result = self.run_cmd(["node", "src/hooks/caveman-activate.js"], home)
+
+            self.assertEqual((claude_dir / ".caveman-active").read_text(), "ultra")
+            self.assertIn("| **ultra** |", result.stdout)
+            self.assertNotIn("| **full** |", result.stdout)
+
+    def test_activate_writes_default_when_no_existing_flag(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-nodefault-") as tmp:
+            home = Path(tmp)
+            (home / ".claude").mkdir(parents=True)
+
+            self.run_cmd(["node", "src/hooks/caveman-activate.js"], home)
+
+            self.assertEqual((home / ".claude" / ".caveman-active").read_text(), "full")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`caveman-activate.js` (SessionStart hook) unconditionally calls
`safeWriteFlag(flagPath, getDefaultMode())` every time it runs.
Claude Code fires SessionStart more than once per conversation
(session resume, context compaction), so any mode change made at
runtime — `/caveman ultra`, a natural-language switch, or a direct
edit of `.caveman-active` — gets silently reset back to the
configured default (project/user config file, or `full`) on the
next re-fire. In practice this shows up as caveman intensity
randomly reverting mid-session with no user action to explain it.

## Fix

Read the existing flag before deciding what to write. If it already
holds a valid mode, keep it (and skip the `off`-unlink branch too) —
SessionStart only writes the resolved default when there's no
existing flag to preserve.

## Tests

Added two regression tests to `tests/test_hooks.py`:
- `test_activate_preserves_existing_flag_across_rerun` — pre-seeds
  `.caveman-active` with `ultra`, re-runs the hook, asserts the flag
  and emitted ruleset both stay on `ultra` instead of reverting to
  the default `full`.
- `test_activate_writes_default_when_no_existing_flag` — confirms
  the original "write configured default when nothing is set yet"
  behavior is unchanged.

Full suite (`tests/test_hooks.py`, `test_mode_tracker.py`,
`test_detect.py`, `test_validate_inline.py`,
`test_compress_safety.py`, `test_repo_local_config.js`,
`test_symlink_flag.js`) passes locally with no regressions.