### PR TITLE
fix(hooks): render stats via additional context

### DIFF
--- a/plugins/caveman/skills/caveman-stats/SKILL.md
+++ b/plugins/caveman/skills/caveman-stats/SKILL.md
@@ -7,4 +7,4 @@ description: >
   the model itself does not compute the numbers.
 ---
 
-This skill is delivered by `hooks/caveman-stats.js` (read by `hooks/caveman-mode-tracker.js` on `/caveman-stats`). The model does not need to do anything when this skill fires — the hook returns `decision: "block"` with the formatted stats as the reason. The user sees the numbers immediately.
+This skill is delivered by `hooks/caveman-stats.js` (read by `hooks/caveman-mode-tracker.js` on `/caveman-stats`). The model does not need to calculate anything when this skill fires — the hook injects the formatted stats as additional context. The user sees the numbers immediately.

--- a/skills/caveman-stats/README.md
+++ b/skills/caveman-stats/README.md
@@ -4,7 +4,7 @@ Real session token receipts. No AI estimation.
 
 ## What it does
 
-Reads the current Claude Code session log directly and reports actual input/output token usage plus estimated savings versus a non-caveman baseline. Numbers come from the JSONL session log on disk — the model itself does not compute or estimate them. Output is injected by the `caveman-mode-tracker` hook, which intercepts `/caveman-stats` and returns the formatted stats as a blocked-decision reason.
+Reads the current Claude Code session log directly and reports actual input/output token usage plus estimated savings versus a non-caveman baseline. Numbers come from the JSONL session log on disk — the model itself does not compute or estimate them. Output is injected by the `caveman-mode-tracker` hook, which intercepts `/caveman-stats` and returns the formatted stats as additional context.
 
 Each run also writes a lifetime-savings suffix file used by the statusline badge (`⛏ 12.4k`).
 

--- a/skills/caveman-stats/SKILL.md
+++ b/skills/caveman-stats/SKILL.md
@@ -7,4 +7,4 @@ description: >
   the model itself does not compute the numbers.
 ---
 
-This skill is delivered by `hooks/caveman-stats.js` (read by `hooks/caveman-mode-tracker.js` on `/caveman-stats`). The model does not need to do anything when this skill fires — the hook returns `decision: "block"` with the formatted stats as the reason. The user sees the numbers immediately.
+This skill is delivered by `hooks/caveman-stats.js` (read by `hooks/caveman-mode-tracker.js` on `/caveman-stats`). The model does not need to calculate anything when this skill fires — the hook injects the formatted stats as additional context. The user sees the numbers immediately.

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -11,6 +11,13 @@ const { getDefaultMode, safeWriteFlag, readFlag, recordModeChange, VALID_MODES }
 // Modes handled by their own slash commands (/caveman-commit, etc.) — not
 // selectable via /caveman <arg>.
 const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
+const HOOK_EVENT_NAME = 'UserPromptSubmit';
+const STATS_SUCCESS_CONTEXT_PREFIX =
+  'The user ran /caveman-stats. Print the stats block below inside a code block, ' +
+  'verbatim, with no summary, reformatting, or commentary:\n\n';
+const STATS_FAILURE_CONTEXT =
+  'The user ran /caveman-stats but the stats script failed. ' +
+  'Tell them to run it manually: node hooks/caveman-stats.js';
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');
@@ -70,12 +77,14 @@ process.stdin.on('end', () => {
       }
     }
 
-    // /caveman-stats [--share] — block the prompt and inject stats output as
-    // the hook's reason. The script reads the active session log, so we pass
-    // transcript_path through when Claude Code provides it.
+    // /caveman-stats [--share] — inject stats output as additional context so
+    // GUI clients render it; some clients honor decision:block but hide reason.
+    // The script reads the active session log, so we pass transcript_path
+    // through when Claude Code provides it.
     const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
     if (statsMatch) {
       const tailArgs = (statsMatch[1] || '').trim().split(/\s+/).filter(Boolean);
+      let context;
       try {
         const statsPath = path.join(__dirname, 'caveman-stats.js');
         const argv = [statsPath];
@@ -87,13 +96,16 @@ process.stdin.on('end', () => {
           argv.push('--since', tailArgs[sinceIdx + 1]);
         }
         const out = execFileSync(process.execPath, argv, { encoding: 'utf8', timeout: 5000 });
-        process.stdout.write(JSON.stringify({ decision: 'block', reason: out.trim() }));
+        context = STATS_SUCCESS_CONTEXT_PREFIX + out.trim();
       } catch (e) {
-        process.stdout.write(JSON.stringify({
-          decision: 'block',
-          reason: 'caveman-stats: could not run stats script.\nTry manually: node hooks/caveman-stats.js'
-        }));
+        context = STATS_FAILURE_CONTEXT;
       }
+      process.stdout.write(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: HOOK_EVENT_NAME,
+          additionalContext: context
+        }
+      }));
       return;
     }
 
@@ -193,7 +205,7 @@ process.stdin.on('end', () => {
     if (activeMode && !INDEPENDENT_MODES.has(activeMode)) {
       process.stdout.write(JSON.stringify({
         hookSpecificOutput: {
-          hookEventName: "UserPromptSubmit",
+          hookEventName: HOOK_EVENT_NAME,
           additionalContext: "CAVEMAN MODE ACTIVE (" + activeMode + "). " +
             "Drop articles/filler/pleasantries/hedging. Fragments OK. " +
             "Code/commits/security: write normal."

--- a/tests/test_caveman_stats.js
+++ b/tests/test_caveman_stats.js
@@ -11,6 +11,7 @@ const { execFileSync } = require('child_process');
 const ROOT = path.resolve(__dirname, '..');
 const STATS = path.join(ROOT, 'src', 'hooks', 'caveman-stats.js');
 const TRACKER = path.join(ROOT, 'src', 'hooks', 'caveman-mode-tracker.js');
+const HOOK_EVENT_NAME = 'UserPromptSubmit';
 
 let passed = 0;
 let failed = 0;
@@ -95,7 +96,7 @@ test('reports no-session when no .jsonl exists', (tmp) => {
   assert.match(err.stderr, /no Claude Code session found/);
 });
 
-test('mode tracker handles /caveman-stats with decision block', (tmp) => {
+test('mode tracker handles /caveman-stats with additional context', (tmp) => {
   const sess = makeSession(tmp, [
     { type: 'assistant', message: { usage: { output_tokens: 100 } } },
   ]);
@@ -107,9 +108,12 @@ test('mode tracker handles /caveman-stats with decision block', (tmp) => {
     input: JSON.stringify({ prompt: '/caveman-stats', transcript_path: sess }),
   });
   const parsed = JSON.parse(out);
-  assert.strictEqual(parsed.decision, 'block');
-  assert.match(parsed.reason, /Caveman Stats/);
-  assert.match(parsed.reason, /Output tokens:\s+100/);
+  assert.notStrictEqual(parsed.decision, 'block');
+  assert.strictEqual(parsed.hookSpecificOutput.hookEventName, HOOK_EVENT_NAME);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /inside a code block/);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /no summary, reformatting, or commentary/);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /Caveman Stats/);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /Output tokens:\s+100/);
 });
 
 test('mode tracker preserves caveman flag when /caveman-stats fires', (tmp) => {
@@ -456,8 +460,9 @@ test('mode tracker forwards --share to stats script', (tmp) => {
     input: JSON.stringify({ prompt: '/caveman-stats --share', transcript_path: sess }),
   });
   const parsed = JSON.parse(out);
-  assert.strictEqual(parsed.decision, 'block');
-  assert.match(parsed.reason, /^🪨 Saved 650 output tokens/);
+  assert.notStrictEqual(parsed.decision, 'block');
+  assert.strictEqual(parsed.hookSpecificOutput.hookEventName, HOOK_EVENT_NAME);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /🪨 Saved 650 output tokens/);
 });
 
 // ── Output-reduction share (never a "usage"/"budget" claim) ────────────────

--- a/tests/test_mode_tracker.py
+++ b/tests/test_mode_tracker.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TRACKER = REPO_ROOT / "src" / "hooks" / "caveman-mode-tracker.js"
+STATS_COMMAND = "/caveman-stats"
+HOOK_EVENT_NAME = "UserPromptSubmit"
 
 
 class ModeTrackerTests(unittest.TestCase):
@@ -35,17 +37,20 @@ class ModeTrackerTests(unittest.TestCase):
     def tearDown(self):
         self._tmp.cleanup()
 
-    def send(self, prompt):
+    def send(self, prompt, extra_payload=None):
         env = os.environ.copy()
         env.pop("CAVEMAN_DEFAULT_MODE", None)
         env["HOME"] = self._tmp.name
         env["USERPROFILE"] = self._tmp.name
         env["CLAUDE_CONFIG_DIR"] = str(self.claude_dir)
+        payload = {"prompt": prompt}
+        if extra_payload:
+            payload.update(extra_payload)
         return subprocess.run(
             ["node", str(TRACKER)],
             cwd=REPO_ROOT,
             env=env,
-            input=json.dumps({"prompt": prompt}),
+            input=json.dumps(payload),
             text=True,
             capture_output=True,
             check=True,
@@ -176,6 +181,22 @@ class ModeTrackerTests(unittest.TestCase):
         self.send("next prompt")  # restore
         self.send("/caveman:caveman-review")
         self.assertEqual(self.flag_value(), "review")
+
+    def test_stats_uses_additional_context_instead_of_block_reason(self):
+        transcript = self.claude_dir / "session.jsonl"
+        transcript.write_text("")
+        result = self.send(STATS_COMMAND, {"transcript_path": str(transcript)})
+        payload = json.loads(result.stdout)
+
+        self.assertNotEqual(payload.get("decision"), "block")
+        output = payload["hookSpecificOutput"]
+        self.assertEqual(output["hookEventName"], HOOK_EVENT_NAME)
+        self.assertIn("The user ran /caveman-stats.", output["additionalContext"])
+        self.assertIn("inside a code block", output["additionalContext"])
+        self.assertIn(
+            "with no summary, reformatting, or commentary",
+            output["additionalContext"],
+        )
 
     def test_no_reinforcement_during_independent_turn(self):
         self.flag.write_text("full")


### PR DESCRIPTION
Fixes #618

## Summary

- Return `/caveman-stats` output through `hookSpecificOutput.additionalContext` instead of `decision: "block"` / `reason`.
- Include a strong render instruction so Claude Code desktop prints the stats in a code block verbatim, without summary or reformatting.
- Update stats skill docs and mirrored plugin skill text to match the new hook contract.

## RED -> GREEN

RED before the hook change:

```text
$ python3 -m unittest tests.test_mode_tracker
FAIL: test_stats_uses_additional_context_instead_of_block_reason
AssertionError: 'block' == 'block'
Ran 24 tests
FAILED (failures=1)
```

GREEN after the fix:

```text
$ python3 -m unittest tests.test_mode_tracker
Ran 24 tests in 1.565s
OK

$ node tests/test_caveman_stats.js
37 passed, 0 failed

$ npm test
tests 112
pass 112
fail 0

$ python3 tests/verify_repo.py
All local verification checks passed
```

Revert proof from review gate:

```text
Source fix reverted in a temp worktree:
- node tests failed the 2 stats additionalContext assertions
- Python failed test_stats_uses_additional_context_instead_of_block_reason
```

## Review gates

- contribute-code gate: GREEN
- pr-check gate: GREEN
