### PR TITLE
fix(install): remove stale state on uninstall

### DIFF
--- a/cli/install.js
+++ b/cli/install.js
@@ -56,6 +56,14 @@ const HOOK_FILES = [
   'caveman-statusline.ps1',
   'cavecrew-model-overrides.js',
 ];
+const CLAUDE_EPHEMERAL_STATE_FILES = [
+  '.caveman-active',
+  '.caveman-active.prev',
+  '.caveman-mode-log.jsonl',
+  '.caveman-statusline-suffix',
+  '.caveman-nudge-shown',
+];
+const CLAUDE_HISTORY_FILE = '.caveman-history.jsonl';
 
 // ── Argv ───────────────────────────────────────────────────────────────────
 function parseArgs(argv) {
@@ -1201,7 +1209,8 @@ function uninstall(ctx) {
       }
       SETTINGS.validateHookFields(settings);
       if (!opts.dryRun) SETTINGS.writeSettings(settingsPath, settings);
-      ok(`  removed ${removed} caveman hook entr${removed === 1 ? 'y' : 'ies'} from settings.json`);
+      const action = opts.dryRun ? 'would remove' : 'removed';
+      ok(`  ${action} ${removed} caveman hook entr${removed === 1 ? 'y' : 'ies'} from settings.json`);
     }
   }
 
@@ -1211,9 +1220,13 @@ function uninstall(ctx) {
       if (!fs.existsSync(p)) continue;
       if (opts.dryRun) {
         note(`  would remove ${p}`);
-      } else {
-        try { fs.unlinkSync(p); } catch (_) {}
+        continue;
+      }
+      try {
+        fs.unlinkSync(p);
         note(`  removed ${p}`);
+      } catch (err) {
+        warn(`  failed to remove ${p}: ${err.message || err}`);
       }
     }
     // Don't rmdir hooksDir — other plugins may use it.
@@ -1340,44 +1353,46 @@ function uninstall(ctx) {
   // Honors HERMES_HOME via hermesConfigDir(); probed by the dirs we own.
   const hermesRoot = path.join(hermesConfigDir(), 'productivity');
   if (fs.existsSync(hermesRoot)) {
-    let prunedHermes = false;
+    let hermesDirsFound = false;
+    let hermesDirsRemoved = 0;
     for (const name of HERMES_SKILL_DIRS) {
       const p = path.join(hermesRoot, name);
       if (fs.existsSync(p)) {
-        if (!opts.dryRun) { try { fs.rmSync(p, { recursive: true, force: true }); } catch (_) {} }
-        note(`  removed ${p}`);
-        prunedHermes = true;
+        hermesDirsFound = true;
+        if (opts.dryRun) {
+          note(`  would remove ${p}`);
+        } else {
+          try {
+            fs.rmSync(p, { recursive: true, force: true });
+            note(`  removed ${p}`);
+            hermesDirsRemoved += 1;
+          } catch (err) {
+            warn(`  failed to remove ${p}: ${err.message || err}`);
+          }
+        }
       }
     }
-    if (prunedHermes) ok('  pruned caveman skills from Hermes');
+    if (opts.dryRun && hermesDirsFound) ok('  would prune caveman skills from Hermes');
+    if (!opts.dryRun && hermesDirsRemoved > 0) ok('  pruned caveman skills from Hermes');
   }
 
-  // Flag + per-session state files. `.caveman-active` is the live mode flag;
-  // the rest are cumulative state the mode-tracker/stats/activate hooks write
-  // (issue #635 — uninstall only ever cleaned the flag, leaving these behind
-  // forever). `.caveman-history.jsonl` is the user's lifetime savings ledger —
-  // deliberately KEPT, not stale state; note it so the user knows it's there.
-  const STATE_FILES_TO_REMOVE = [
-    '.caveman-active',
-    '.caveman-active.prev',
-    '.caveman-mode-log.jsonl',
-    '.caveman-statusline-suffix',
-    '.caveman-nudge-shown',
-  ];
-  for (const f of STATE_FILES_TO_REMOVE) {
-    const p = path.join(configDir, f);
-    if (!fs.existsSync(p)) continue;
+  // Ephemeral Claude state. Keep lifetime history: it is user data.
+  for (const file of CLAUDE_EPHEMERAL_STATE_FILES) {
+    const statePath = path.join(configDir, file);
+    if (!fs.existsSync(statePath)) continue;
     if (opts.dryRun) {
-      note(`  would remove ${p}`);
-    } else {
-      try { fs.unlinkSync(p); } catch (_) {}
-      note(`  removed ${p}`);
+      note(`  would remove ${statePath}`);
+      continue;
+    }
+    try {
+      fs.unlinkSync(statePath);
+      note(`  removed ${statePath}`);
+    } catch (err) {
+      warn(`  failed to remove ${statePath}: ${err.message || err}`);
     }
   }
-  const historyPath = path.join(configDir, '.caveman-history.jsonl');
-  if (fs.existsSync(historyPath)) {
-    note(`  kept ${historyPath} (lifetime history — delete manually if unwanted)`);
-  }
+  const historyPath = path.join(configDir, CLAUDE_HISTORY_FILE);
+  if (fs.existsSync(historyPath)) note(`  kept ${historyPath} (lifetime history)`);
 
   process.stdout.write('\n');
   ok('uninstall done.');

--- a/tests/installer/e2e.dryrun.test.mjs
+++ b/tests/installer/e2e.dryrun.test.mjs
@@ -67,4 +67,84 @@ test('dry-run --uninstall does not delete files', () => {
   // File still present, settings unchanged.
   assert.equal(fs.existsSync(fake), true);
   assert.equal(fs.readFileSync(path.join(cfg, 'settings.json'), 'utf8'), before);
+  assert.match(r.stdout, /would remove 1 caveman hook entry from settings\.json/);
+  assert.doesNotMatch(r.stdout, /removed .*settings\.json/);
+});
+
+const CLAUDE_EPHEMERAL_STATE_FILES = [
+  '.caveman-active',
+  '.caveman-active.prev',
+  '.caveman-mode-log.jsonl',
+  '.caveman-statusline-suffix',
+];
+const CLAUDE_HISTORY_FILE = '.caveman-history.jsonl';
+
+test('dry-run --uninstall reports state cleanup without deleting state files', () => {
+  const cfg = freshTmpDir();
+  for (const file of [...CLAUDE_EPHEMERAL_STATE_FILES, CLAUDE_HISTORY_FILE]) {
+    fs.writeFileSync(path.join(cfg, file), 'seed\n');
+  }
+
+  const r = spawnSync(process.execPath, [INSTALLER, '--uninstall', '--dry-run', '--non-interactive', '--config-dir', cfg],
+    { encoding: 'utf8', env: { ...process.env, CLAUDE_CONFIG_DIR: cfg, PATH: '' } });
+  assert.equal(r.status, 0, r.stderr);
+
+  for (const file of CLAUDE_EPHEMERAL_STATE_FILES) {
+    assert.equal(fs.existsSync(path.join(cfg, file)), true, `${file} should survive dry-run`);
+    assert.match(r.stdout, new RegExp(`would remove .*${file.replaceAll('.', '\\.')}`));
+  }
+  assert.equal(fs.existsSync(path.join(cfg, CLAUDE_HISTORY_FILE)), true, 'history should survive dry-run');
+  assert.match(r.stdout, /kept .*\.caveman-history\.jsonl/);
+});
+
+test('uninstall removes ephemeral Claude state but keeps lifetime history', () => {
+  const cfg = freshTmpDir();
+
+  for (const file of [...CLAUDE_EPHEMERAL_STATE_FILES, CLAUDE_HISTORY_FILE]) {
+    fs.writeFileSync(path.join(cfg, file), 'seed\n');
+  }
+
+  const r = spawnSync(process.execPath, [INSTALLER, '--uninstall', '--non-interactive', '--config-dir', cfg],
+    { encoding: 'utf8', env: { ...process.env, CLAUDE_CONFIG_DIR: cfg, PATH: '' } });
+  assert.equal(r.status, 0, r.stderr);
+
+  for (const file of CLAUDE_EPHEMERAL_STATE_FILES) {
+    assert.equal(fs.existsSync(path.join(cfg, file)), false, `${file} should be removed`);
+    assert.match(r.stdout, new RegExp(`removed .*${file.replaceAll('.', '\\.')}`));
+  }
+  assert.equal(fs.existsSync(path.join(cfg, CLAUDE_HISTORY_FILE)), true, 'lifetime history should be preserved');
+  assert.match(r.stdout, /kept .*\.caveman-history\.jsonl/);
+});
+
+test('uninstall warns when an ephemeral state file cannot be removed', () => {
+  const cfg = freshTmpDir();
+  const blockedState = '.caveman-active';
+  const blockedPath = path.join(cfg, blockedState);
+  fs.mkdirSync(blockedPath);
+  fs.writeFileSync(path.join(cfg, CLAUDE_HISTORY_FILE), 'seed\n');
+
+  const r = spawnSync(process.execPath, [INSTALLER, '--uninstall', '--non-interactive', '--config-dir', cfg],
+    { encoding: 'utf8', env: { ...process.env, CLAUDE_CONFIG_DIR: cfg, PATH: '' } });
+  assert.equal(r.status, 0, r.stderr);
+
+  const combinedOutput = r.stdout + r.stderr;
+  assert.match(combinedOutput, /failed to remove .*\.caveman-active/);
+  assert.doesNotMatch(combinedOutput, /removed .*\.caveman-active/);
+  assert.equal(fs.existsSync(blockedPath), true, `${blockedState} directory should remain after unlink failure`);
+  assert.equal(fs.existsSync(path.join(cfg, CLAUDE_HISTORY_FILE)), true, 'history should survive failed cleanup');
+});
+
+test('uninstall warns when a managed hook file cannot be removed', () => {
+  const cfg = freshTmpDir();
+  const blockedHook = path.join(cfg, 'hooks', 'caveman-activate.js');
+  fs.mkdirSync(blockedHook, { recursive: true });
+
+  const r = spawnSync(process.execPath, [INSTALLER, '--uninstall', '--non-interactive', '--config-dir', cfg],
+    { encoding: 'utf8', env: { ...process.env, CLAUDE_CONFIG_DIR: cfg, PATH: '' } });
+  assert.equal(r.status, 0, r.stderr);
+
+  const combinedOutput = r.stdout + r.stderr;
+  assert.match(combinedOutput, /failed to remove .*caveman-activate\.js/);
+  assert.doesNotMatch(combinedOutput, /removed .*caveman-activate\.js/);
+  assert.equal(fs.existsSync(blockedHook), true, 'hook directory should remain after unlink failure');
 });

--- a/tests/installer/hermes.test.mjs
+++ b/tests/installer/hermes.test.mjs
@@ -86,12 +86,36 @@ test('hermes dry-run uninstall leaves skills in place', () => {
     runInstaller(['--only', 'hermes'], home);
     const r = runInstaller(['--uninstall', '--dry-run'], home);
     assert.notEqual(r.status, 2);
+    assert.match(r.stdout, /would remove .*skills[/\\]productivity[/\\]caveman/);
+    assert.match(r.stdout, /would prune caveman skills from Hermes/);
+    assert.doesNotMatch(r.stdout, /removed .*skills[/\\]productivity[/\\]caveman/);
+    assert.doesNotMatch(r.stdout, /pruned caveman skills from Hermes/);
 
     const prod = productivityDir(home);
     for (const name of SKILLS) {
       assert.ok(fs.existsSync(path.join(prod, name)), `${name} was deleted by a dry-run uninstall`);
     }
   } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('hermes uninstall warns when a skill folder cannot be removed', () => {
+  const home = freshHome();
+  const prod = productivityDir(home);
+  try {
+    runInstaller(['--only', 'hermes'], home);
+    const blocked = path.join(prod, 'caveman');
+    fs.chmodSync(prod, 0o555);
+
+    const r = runInstaller(['--uninstall'], home);
+    assert.notEqual(r.status, 2);
+    const combinedOutput = r.stdout + r.stderr;
+    assert.match(combinedOutput, /failed to remove .*skills[/\\]productivity[/\\]caveman/);
+    assert.doesNotMatch(combinedOutput, /removed .*skills[/\\]productivity[/\\]caveman/);
+    assert.ok(fs.existsSync(blocked), 'blocked Hermes skill should remain after failed cleanup');
+  } finally {
+    try { fs.chmodSync(prod, 0o755); } catch {}
     fs.rmSync(home, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Fixes #635

## Summary

- Remove Claude-owned ephemeral state during uninstall:
  - `.caveman-active`
  - `.caveman-active.prev`
  - `.caveman-mode-log.jsonl`
  - `.caveman-statusline-suffix`
- Preserve `.caveman-history.jsonl` as lifetime/user data and print a note when it is kept.
- Make uninstall dry-run messages truthful (`would remove` / `would prune`) for settings, hook files, Claude state, and Hermes skill folders.
- Warn on failed hook/state/Hermes removals instead of printing false `removed` messages.

## RED -> GREEN

RED before the fix:

```text
$ node --test tests/installer/e2e.dryrun.test.mjs
not ok 3 - uninstall removes ephemeral Claude state but keeps lifetime history
error: .caveman-active.prev should be removed
true !== false
```

GREEN after the fix:

```text
$ node --test tests/installer/e2e.dryrun.test.mjs
tests 6
pass 6
fail 0

$ node --test tests/installer/hermes.test.mjs
tests 4
pass 4
fail 0

$ npm test
tests 117
pass 117
fail 0

$ python3 tests/verify_repo.py
All local verification checks passed
```

## Review gates

- contribute-code gate: GREEN
- pr-check gate: GREEN
