### PR TITLE
ci: automate dependency + action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+# Dependabot — automated dependency + action updates.
+#
+# NOTE: this repo ships BOTH a dependabot.yml and a renovate.json as part of the
+# security donation. They do the same job — pick ONE and delete the other.
+# Recommendation: Renovate (renovate.json) for its cross-ecosystem cooldown and
+# grouping; Dependabot here is the zero-extra-setup alternative if you'd rather
+# stay fully GitHub-native. Do not run both at once (duplicate PRs).
+version: 2
+updates:
+  # ── GitHub Actions (all workflows) ──
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # ── npm: root installer (caveman-installer) ──
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+
+  # ── npm: bundled MCP server (caveman-shrink) ──
+  - package-ecosystem: "npm"
+    directory: "/src/mcp-servers/caveman-shrink"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(caveman-shrink)"
+
+  # ── npm: opencode plugin ──
+  - package-ecosystem: "npm"
+    directory: "/src/plugins/opencode"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(opencode)"
+
+  # ── pip: benchmarks (anthropic) ──
+  - package-ecosystem: "pip"
+    directory: "/benchmarks"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(benchmarks)"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits"
+  ],
+  "_comment": "Recommended over dependabot.yml for this repo: one config covers npm + pip + github-actions with a shared cooldown, groups actions together, and SHA-pins actions with an inline version comment. Pick ONE (renovate.json OR dependabot.yml) and delete the other. Enable by installing the Renovate GitHub App on the repo.",
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "prConcurrentLimit": 5,
+  "npm": {
+    "minimumReleaseAge": "7 days"
+  },
+  "github-actions": {
+    "pinDigests": true
+  },
+  "packageRules": [
+    {
+      "description": "Pin all GitHub Actions to a commit SHA with a version comment.",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "pinDigests": true
+    },
+    {
+      "description": "Group non-major npm updates to reduce PR noise.",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm (non-major)"
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "minimumReleaseAge": "0 days"
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  }
+}


### PR DESCRIPTION
Adds Dependabot and Renovate configs covering npm (root, `caveman-shrink`, opencode
plugin), GitHub Actions, and pip (`benchmarks/`), each with a 7-day cooldown.

**Pick one, delete the other** — running both creates duplicate PRs. Renovate is
recommended for this repo (one config across all three ecosystems, cross-ecosystem
cooldown, and it SHA-pins Actions with a version comment). `dependabot.yml` is the
zero-extra-setup GitHub-native alternative if you'd rather not install the Renovate
app.