### PR TITLE
ci: run the test suite in CI + harden the sync workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Least-privilege default: no job needs more than read to run tests/linters.
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Node ${{ matrix.node }} tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        # Matches package.json engines: node >=18.
+        node: ['18', '20', '22']
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node }}
+
+      # Zero runtime deps today (see package-lock.json). `npm ci` still validates
+      # the lockfile is in sync and gives us a reproducible, offline-safe install.
+      - name: Install (lockfile-verified)
+        run: npm ci --ignore-scripts
+
+      - name: Run installer test suite
+        run: npm test
+
+      # tests/test_*.js are standalone runners not covered by the npm test glob
+      # (tests/installer/*.test.mjs). CONTRIBUTING lists them as part of the suite.
+      - name: Run standalone node tests
+        run: |
+          for t in tests/test_*.js; do
+            echo "── $t"
+            node "$t"
+          done
+
+  python-tests:
+    name: Python tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      # Compress-safety etc. skip cleanly when the Claude CLI / API isn't present,
+      # per CONTRIBUTING ("must skip cleanly when the dependency is missing").
+      - name: Run Python unit tests
+        run: python3 -m unittest discover -s tests -p 'test_*.py'
+
+  lint-actions:
+    name: Lint workflows (actionlint + zizmor)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: actionlint
+        uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+        with:
+          args: -color
+
+      - name: zizmor (GitHub Actions static analysis)
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          # 'regular' persona; bump to 'pedantic' later for more hygiene findings.
+          persona: regular
+          # Annotations mode instead of SARIF upload, so this needs no GitHub
+          # Advanced Security / code-scanning setup to run on a fresh repo.
+          advanced-security: false
+
+  lint-shell:
+    name: Lint shell scripts (shellcheck)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: shellcheck
+        run: |
+          shellcheck --version
+          # Lint every tracked shell script. Fails the job on any warning.
+          find . -name '*.sh' -not -path './node_modules/*' -print0 \
+            | xargs -0 -r shellcheck --severity=warning

--- a/.github/workflows/sync-skill.yml
+++ b/.github/workflows/sync-skill.yml
@@ -10,6 +10,10 @@ on:
       - skills/caveman-compress/SKILL.md
       - skills/caveman-compress/scripts/**
 
+# Least-privilege default; the sync job below elevates to contents: write.
+permissions:
+  contents: read
+
 concurrency:
   group: sync-skill
   cancel-in-progress: false
@@ -17,10 +21,11 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "caveman-installer",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "caveman-installer",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "caveman": "bin/install.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/src/mcp-servers/caveman-shrink/package-lock.json
+++ b/src/mcp-servers/caveman-shrink/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "caveman-shrink",
+  "version": "0.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "caveman-shrink",
+      "version": "0.1.1",
+      "license": "MIT",
+      "bin": {
+        "caveman-shrink": "index.js"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a CI workflow that runs the existing test suite on every PR, and hardens the one
existing workflow.

- `ci.yml`: runs the full documented suite on Node 18/20/22 — `npm test` (installer
  unit/e2e), the standalone `tests/test_*.js` runners, and the Python `unittest`
  suite — plus `actionlint`, `zizmor`, and `shellcheck`.
- Commits `package-lock.json` for the root package and `caveman-shrink` (both
  zero-dep today) so CI can `npm ci` reproducibly.
- `sync-skill.yml`: pins `actions/checkout` to a commit SHA, adds a top-level
  `permissions: contents: read` default, and a `timeout-minutes`. Sync behavior is
  unchanged.

The tests already existed but weren't run on PRs. All actions are pinned to their
latest release SHA. Suite passes locally: `npm test` 117, standalone node 7/7,
python 52.
