### PR TITLE
ci: add npm publish workflow with provenance (OIDC trusted publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish to npm
+
+# Publishes the npm packages with build provenance using npm Trusted Publishing
+# (OIDC) — no long-lived NPM_TOKEN secret.
+#
+# ONE-TIME SETUP (per package, on npmjs.com):
+#   Package settings → "Trusted Publisher" → GitHub Actions →
+#     repository: JuliusBrussee/caveman, workflow: publish.yml
+#   Do this for `caveman-shrink` (and `caveman-installer` if/when it's published).
+# Until a package has a trusted publisher configured, its matrix leg will fail —
+# that's expected; configure it first, then re-run.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish ${{ matrix.pkg.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write   # required for OIDC trusted publishing + provenance
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg:
+          - { name: caveman-shrink, dir: src/mcp-servers/caveman-shrink }
+          # Uncomment once caveman-installer is published + has a trusted publisher:
+          # - { name: caveman-installer, dir: . }
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      # Trusted Publishing (OIDC) needs a recent npm.
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Publish with provenance
+        working-directory: ${{ matrix.pkg.dir }}
+        run: npm publish --provenance --access public


### PR DESCRIPTION
Adds `publish.yml` to publish on release using npm Trusted Publishing (OIDC) +
`--provenance` — no long-lived `NPM_TOKEN`. Targets `caveman-shrink`;
`caveman-installer` is left commented out until/unless it's published to npm.

Requires a one-time Trusted Publisher setup on npmjs.com (this repo + `publish.yml`
as the trusted publisher for the package), documented in the workflow header. The
workflow is inert until a release is published and that setup is in place.
