### PR TITLE
fix(evals): make llm_run.py fault-tolerant (save partial snapshot on failure)

### DIFF
--- a/evals/llm_run.py
+++ b/evals/llm_run.py
@@ -1,27 +1,20 @@
-"""
-Run each prompt through Claude Code in three conditions and snapshot the
+"""Run each prompt through Claude Code in three conditions and snapshot the
 real LLM outputs:
 
-  1. baseline      — no extra system prompt at all
-  2. terse         — system prompt: "Answer concisely."
-  3. terse+skill   — system prompt: "Answer concisely.\n\n{SKILL.md}"
+  1. baseline      - no extra system prompt at all
+  2. terse         - system prompt: "Answer concisely."
+  3. terse+skill   - system prompt: "Answer concisely.\n\n{SKILL.md}"
 
-The honest delta is (3) vs (2): how much does the SKILL itself add on top
-of a plain "be terse" instruction? Comparing (3) vs (1) conflates the
-skill with the generic terseness ask, which is what the previous version
-of this harness did.
-
-This is the source-of-truth generator. It calls a real LLM and produces
-evals/snapshots/results.json. Run it locally when SKILL.md files change.
-The CI-side `measure.py` only reads the snapshot and counts tokens.
-
-Requires:
-  - `claude` CLI on PATH (Claude Code), authenticated
+The honest delta is (3) vs (2). Run locally when SKILL.md files change.
+Requires: `claude` CLI on PATH (Claude Code), authenticated.
 
 Run: uv run python evals/llm_run.py
 
-Environment:
-  CAVEMAN_EVAL_MODEL  optional --model flag value passed through to claude
+Fault tolerance: a single failed `claude -p` call used to abort the whole
+multi-dollar run and write nothing. Now every call is isolated - a failure
+is recorded as an `__ERROR__:` marker and the run continues, saving a
+partial snapshot (results.partial.json) instead of throwing all progress
+away. Set CAVEMAN_EVAL_TIMEOUT to bound a single hung call.
 """
 
 from __future__ import annotations
@@ -30,6 +23,7 @@ import datetime as dt
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 EVALS = Path(__file__).parent
@@ -39,37 +33,59 @@ SNAPSHOT = EVALS / "snapshots" / "results.json"
 
 TERSE_PREFIX = "Answer concisely."
 
+# Cap a single `claude -p` call so a hang can't block the whole run forever.
+CALL_TIMEOUT = float(os.environ.get("CAVEMAN_EVAL_TIMEOUT", "300"))
 
-def run_claude(prompt: str, system: str | None = None) -> str:
+
+def run_claude(prompt: str, system: str | None = None, timeout: float = CALL_TIMEOUT) -> str:
     cmd = ["claude", "-p"]
     if system:
         cmd += ["--system-prompt", system]
     if model := os.environ.get("CAVEMAN_EVAL_MODEL"):
         cmd += ["--model", model]
     cmd.append(prompt)
-    out = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    out = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=timeout)
     return out.stdout.strip()
+
+
+def safe_run(prompt: str, system: str | None = None) -> str:
+    """run_claude that never raises. Returns the output, or an `__ERROR__:`
+    marker on any failure, so one bad call can't abort the entire run."""
+    try:
+        return run_claude(prompt, system)
+    except subprocess.TimeoutExpired as e:
+        return f"__ERROR__: timeout after {int(e.timeout)}s"
+    except subprocess.CalledProcessError as e:
+        return f"__ERROR__: claude exited {e.returncode}"
+    except Exception as e:  # noqa: BLE001 - survive any failure, record it
+        return f"__ERROR__: {type(e).__name__}: {e}"
 
 
 def claude_version() -> str:
     try:
-        out = subprocess.run(
-            ["claude", "--version"], capture_output=True, text=True, check=True
-        )
+        out = subprocess.run(["claude", "--version"], capture_output=True, text=True, check=True)
         return out.stdout.strip()
     except Exception:
         return "unknown"
+
+
+def _run_arm(prompts, system, errors, label):
+    out = []
+    for p in prompts:
+        r = safe_run(p, system)
+        out.append(r)
+        if isinstance(r, str) and r.startswith("__ERROR__"):
+            errors.append(f"{label}: {r}")
+    return out
 
 
 def main() -> None:
     prompts = [p.strip() for p in PROMPTS.read_text().splitlines() if p.strip()]
     skills = sorted(p.name for p in SKILLS.iterdir() if (p / "SKILL.md").exists())
 
-    print(
-        f"=== {len(prompts)} prompts × ({len(skills)} skills + 2 control arms) ===",
-        flush=True,
-    )
+    print(f"=== {len(prompts)} prompts x ({len(skills)} skills + 2 control arms) ===", flush=True)
 
+    errors: list[str] = []
     snapshot: dict = {
         "metadata": {
             "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
@@ -83,20 +99,28 @@ def main() -> None:
     }
 
     print("baseline (no system prompt)", flush=True)
-    snapshot["arms"]["__baseline__"] = [run_claude(p) for p in prompts]
+    snapshot["arms"]["__baseline__"] = _run_arm(prompts, None, errors, "baseline")
 
     print("terse (control: terse instruction only, no skill)", flush=True)
-    snapshot["arms"]["__terse__"] = [
-        run_claude(p, system=TERSE_PREFIX) for p in prompts
-    ]
+    snapshot["arms"]["__terse__"] = _run_arm(prompts, TERSE_PREFIX, errors, "terse")
 
     for skill in skills:
         skill_md = (SKILLS / skill / "SKILL.md").read_text()
         system = f"{TERSE_PREFIX}\n\n{skill_md}"
         print(f"  {skill}", flush=True)
-        snapshot["arms"][skill] = [run_claude(p, system=system) for p in prompts]
+        snapshot["arms"][skill] = _run_arm(prompts, system, errors, skill)
 
     SNAPSHOT.parent.mkdir(parents=True, exist_ok=True)
+
+    if errors:
+        # Save partial progress instead of discarding the whole run.
+        partial = SNAPSHOT.with_name("results.partial.json")
+        partial.write_text(json.dumps(snapshot, ensure_ascii=False, indent=2))
+        sys.stderr.write(f"\ncaveman-eval: {len(errors)} call(s) failed; wrote PARTIAL snapshot to {partial}\n")
+        for e in errors:
+            sys.stderr.write(f"  - {e}\n")
+        sys.exit(1)
+
     SNAPSHOT.write_text(json.dumps(snapshot, ensure_ascii=False, indent=2))
     print(f"\nWrote {SNAPSHOT}")
 

--- a/evals/test_llm_run.py
+++ b/evals/test_llm_run.py
@@ -1,0 +1,69 @@
+"""Tests for evals/llm_run.py fault tolerance (no `claude` CLI required)."""
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import llm_run  # noqa: E402
+
+
+def _tmp_env():
+    root = Path(tempfile.mkdtemp(prefix="caveman-eval-"))
+    (root / "skills" / "demo").mkdir(parents=True)
+    (root / "skills" / "demo" / "SKILL.md").write_text("Be terse.")
+    (root / "prompts").mkdir(parents=True)
+    (root / "prompts" / "en.txt").write_text("Q1\nQ2\n")
+    return root
+
+
+class EvalRunTest(unittest.TestCase):
+    def test_success_writes_canonical_snapshot(self):
+        env = _tmp_env()
+        llm_run.SKILLS = env / "skills"
+        llm_run.PROMPTS = env / "prompts" / "en.txt"
+        llm_run.SNAPSHOT = env / "evals" / "snapshots" / "results.json"
+        ok = subprocess.CompletedProcess("claude", 0, "out", "")
+        with mock.patch("subprocess.run", return_value=ok):
+            llm_run.main()
+        self.assertTrue(llm_run.SNAPSHOT.exists())
+        data = json.loads(llm_run.SNAPSHOT.read_text())
+        self.assertIn("__baseline__", data["arms"])
+        self.assertIn("__terse__", data["arms"])
+        self.assertIn("demo", data["arms"])
+        self.assertNotIn("__ERROR__", str(data["arms"]["__baseline__"]))
+
+    def test_midrun_failure_writes_partial_no_crash(self):
+        env = _tmp_env()
+        llm_run.SKILLS = env / "skills"
+        llm_run.PROMPTS = env / "prompts" / "en.txt"
+        llm_run.SNAPSHOT = env / "evals" / "snapshots" / "results.json"
+        calls = {"n": 0}
+
+        def fake(*a, **k):
+            calls["n"] += 1
+            if calls["n"] >= 2:  # transient claude failure mid-run
+                raise subprocess.CalledProcessError(1, "claude")
+            return subprocess.CompletedProcess("claude", 0, "out", "")
+
+        with mock.patch("subprocess.run", side_effect=fake):
+            with self.assertRaises(SystemExit) as cm:
+                llm_run.main()
+            self.assertEqual(cm.exception.code, 1)
+        # partial progress is saved ...
+        partial = llm_run.SNAPSHOT.with_name("results.partial.json")
+        self.assertTrue(partial.exists(), "partial snapshot must be saved on failure")
+        data = json.loads(partial.read_text())
+        # ... every arm was still attempted (no early abort) ...
+        self.assertEqual(len(data["arms"]["__baseline__"]), 2)
+        self.assertTrue(any("__ERROR__" in str(x) for x in data["arms"]["__baseline__"]))
+        # ... and the canonical snapshot is left untouched.
+        self.assertFalse(llm_run.SNAPSHOT.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
evals/llm_run.py ran every prompt x arm with no error handling and subprocess.run(check=True). A single failed claude -p call (auth expiry, rate limit, transient network, or a bad CAVEMAN_EVAL_MODEL) aborted the entire multi-dollar run and wrote nothing - SNAPSHOT.write_text(...) is the last statement in main().

Reproduced locally: mocking subprocess.run to fail on the 2nd call makes the real main() crash with CalledProcessError after 2 calls, with no results.json produced.

## Fix
- safe_run() wraps each claude call, catching CalledProcessError / TimeoutExpired / any exception and recording an __ERROR__: marker instead of crashing.
- run_claude now takes a timeout (via CAVEMAN_EVAL_TIMEOUT, default 300s) so a hung call cannot block the whole run forever.
- On any failure the run still writes results.partial.json (progress saved) and exits non-zero; the canonical results.json is left untouched, so CI measure.py stays correct.

## Test
- Add evals/test_llm_run.py (stdlib unittest, no claude CLI needed): the success path writes the canonical snapshot; a mid-run failure no longer crashes, writes the partial snapshot, and leaves the canonical untouched.

Verified locally: both cases pass.