### PR TITLE
Skip caveman reinforcement on scheduled-task (unattended) runs

### DIFF
--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -31,6 +31,14 @@ process.stdin.on('end', () => {
     // every regex below sees a single-line prompt (#598).
     const prompt = (data.prompt || '').trim().toLowerCase().replace(/\s+/g, ' ');
 
+    // Unattended scheduled-task runs must not receive caveman styling. The
+    // per-turn reinforcement hijacks the task prompt, so a lightweight scheduled
+    // task answers with a caveman greeting ("Yo. What need?") instead of doing
+    // its job. Claude Code wraps scheduled runs in a <scheduled-task ...> marker;
+    // when present, skip all flag mutation and reinforcement. Interactive
+    // sessions are unaffected.
+    if (/<scheduled-task\b/.test(prompt)) return;
+
     // Deactivation intent — computed FIRST so "turn caveman mode off" never
     // falls through to the activation patterns (#598: the old contiguous
     // "turn off" phrasing missed the "turn X off" word order entirely, and

--- a/tests/test_mode_tracker_stdin.js
+++ b/tests/test_mode_tracker_stdin.js
@@ -81,5 +81,50 @@ test('normal stdin (valid JSON + clean EOF) still exits 0', () => {
   }
 });
 
+// Guard: unattended scheduled-task runs must NOT receive caveman reinforcement,
+// even when caveman is active — otherwise the injection hijacks the task prompt
+// and a lightweight scheduled task greets ("Yo. What need?") instead of running.
+test('scheduled-task prompt emits no reinforcement while caveman active', () => {
+  const tmpConfig = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-tracker-sched-'));
+  try {
+    // Activate caveman by planting the flag file the hook reads.
+    fs.writeFileSync(path.join(tmpConfig, '.caveman-active'), 'full');
+
+    const scheduled = spawnSync(process.execPath, [HOOK_PATH], {
+      input: JSON.stringify({
+        prompt: '<scheduled-task name="trigger-runner" file="/x/SKILL.md">\nAutomated run.',
+      }),
+      env: { ...process.env, CLAUDE_CONFIG_DIR: tmpConfig },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf8',
+    });
+    assert.strictEqual(
+      scheduled.status,
+      CLEAN_EXIT,
+      `expected clean exit, got status=${scheduled.status}\nstderr: ${(scheduled.stderr || '').trim()}`
+    );
+    assert.strictEqual(
+      (scheduled.stdout || '').trim(),
+      '',
+      `scheduled-task run must emit no reinforcement, got: ${(scheduled.stdout || '').trim()}`
+    );
+
+    // Control: an ordinary prompt with the SAME active flag IS reinforced —
+    // proving the empty output above is the guard, not an inactive flag.
+    const normal = spawnSync(process.execPath, [HOOK_PATH], {
+      input: JSON.stringify({ prompt: 'fix the auth bug' }),
+      env: { ...process.env, CLAUDE_CONFIG_DIR: tmpConfig },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf8',
+    });
+    assert.ok(
+      /CAVEMAN MODE ACTIVE/.test(normal.stdout || ''),
+      `control prompt should be reinforced, got: ${(normal.stdout || '').trim()}`
+    );
+  } finally {
+    fs.rmSync(tmpConfig, { recursive: true, force: true });
+  }
+});
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Problem

The `caveman-mode-tracker.js` UserPromptSubmit hook injects the per-turn "CAVEMAN MODE ACTIVE" reinforcement on **every** session, including Claude Code scheduled-task (cron) runs, which are unattended.

On a lightweight scheduled task the caveman persona overrides the task prompt and the model responds with a greeting like **"Yo. What need?"** instead of doing the task. In my setup this silently broke a scheduled `trigger-runner` that fires due follow-up actions: it greeted every hour instead of polling. SessionStart activation alone is (by design) too weak to cause this; the per-turn reinforcement is what flips the model into caveman voice.

## Fix

Claude Code wraps scheduled runs in a `<scheduled-task name=... file=...>` marker at the start of the prompt. When that marker is present, return early, before any flag mutation or reinforcement. Interactive chat is unaffected.

```js
if (/<scheduled-task\b/.test(prompt)) return;
```

## Test

Added a regression test to `tests/test_mode_tracker_stdin.js`:

- active flag + scheduled-task prompt -> **no** output (the guard)
- same active flag + ordinary prompt -> reinforced (control, proves it is the guard and not an inactive flag)

```
3 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
