### PR TITLE
fix(skill): scope language-preservation rule to every emitted line

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -22,6 +22,8 @@ Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleas
 
 Preserve user's dominant language. User write Portuguese → reply Portuguese caveman. User write Spanish → reply Spanish caveman. Compress the style, not the language. No forced English openings or status phrases. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim — unless user explicitly ask for translation.
 
+Rule covers every line the model outputs this turn, not just the final reply — including any harness-required pre-tool-call status line. Never let that line default to English when session language differs.
+
 No self-reference. Never name or announce the style. No "caveman mode on", "me caveman think", no third-person caveman tags. Output caveman-only — never normal answer plus "Caveman:" recap. Exception: user explicitly ask what the mode is.
 
 Pattern: `[thing] [action] [reason]. [next step].`


### PR DESCRIPTION
Fixes #701.

## Problem

Pre-tool-call status statements (harness-required, not caveman-specific — the "state one sentence before tool use" convention) weren't covered by the Rules-section language-preservation promise, since that rule's wording targeted "reply" specifically. In a fully Chinese session with `full` active, the final answer stayed correctly Chinese, but the one-line status statement immediately before each tool call came out in English or English-verb + Chinese-noun mixed:

- `Verify. Check EDI code carrier分支.`
- `Read send dialog + G1/G2/G4 guard 看是否真共用同一发送机制。`

while the turn's actual answer bullet was fully Chinese. Repro detail and screenshots in #701.

## Fix — 2 added lines in `skills/caveman/SKILL.md`, pure addition, no line rewritten

One sentence appended after the existing language-preservation paragraph (Rules section), making explicit that the rule covers every line the model emits this turn, not just the final reply, and that a harness-required pre-tool-call status line must not default to English.

I considered instead just reinforcing the existing "no tool-call narration" instruction so the line wouldn't be emitted at all — but that narration is a harness-level convention outside caveman's control (the instruction to state one sentence before tool use lives in the harness system prompt, not in SKILL.md), so suppressing it isn't reliably actionable from the skill side. Scoping the language rule to cover it instead is.

Related: #679 (Auto-Clarity English block leak), #665 (named-language examples risk drift under compaction) — same class of bug (English-only in-context text biasing output under compression pressure), different surface. `plugins/caveman/skills/` mirror left for the CI sync workflow per CLAUDE.md.