### PR TITLE
fix: make caveman hooks robust to non-standard or absent interpreters

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-activate.js\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/src/hooks/run-hook.sh\" \"${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-activate.js\"",
             "timeout": 5,
             "statusMessage": "Loading caveman mode..."
           }
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-mode-tracker.js\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/src/hooks/run-hook.sh\" \"${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-mode-tracker.js\"",
             "timeout": 5,
             "statusMessage": "Tracking caveman mode..."
           }

--- a/src/hooks/caveman-statusline.sh
+++ b/src/hooks/caveman-statusline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # caveman — statusline badge script for Claude Code
 # Reads the caveman mode flag file and outputs a colored badge.
 #

--- a/src/hooks/install.sh
+++ b/src/hooks/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # caveman — one-command hook installer for Claude Code
 # Installs: SessionStart hook (auto-load rules) + UserPromptSubmit hook (mode tracking)
 # Usage: bash src/hooks/install.sh

--- a/src/hooks/run-hook.sh
+++ b/src/hooks/run-hook.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+command -v node >/dev/null 2>&1 || exit 0
+exec node "$@"

--- a/src/hooks/uninstall.sh
+++ b/src/hooks/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # caveman — uninstaller for the SessionStart + UserPromptSubmit hooks
 # Removes: hook files in ~/.claude/hooks, settings.json entries, and the flag file
 # Usage: bash src/hooks/uninstall.sh

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -27,6 +27,71 @@ class HookScriptTests(unittest.TestCase):
             check=True,
         )
 
+    def test_run_hook_executes_node_with_all_arguments(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hook-runner-") as tmp:
+            home = Path(tmp)
+            script = home / "print-arguments.js"
+            script.write_text(
+                "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n"
+            )
+
+            result = self.run_cmd(
+                [
+                    str(REPO_ROOT / "src" / "hooks" / "run-hook.sh"),
+                    str(script),
+                    "first argument",
+                    "second",
+                ],
+                home,
+            )
+
+            self.assertEqual(result.stdout, '["first argument","second"]')
+
+    def test_run_hook_silently_succeeds_without_node(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hook-no-node-") as tmp:
+            home = Path(tmp)
+            empty_path = home / "empty-path"
+            empty_path.mkdir()
+
+            result = self.run_cmd(
+                ["/bin/sh", "src/hooks/run-hook.sh", "unused.js"],
+                home,
+                extra_env={"PATH": str(empty_path)},
+            )
+
+            self.assertEqual(result.stdout, "")
+            self.assertEqual(result.stderr, "")
+
+    def test_plugin_hooks_use_node_wrapper(self):
+        plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
+        expected_scripts = {
+            "SessionStart": "caveman-activate.js",
+            "UserPromptSubmit": "caveman-mode-tracker.js",
+        }
+
+        for event, script in expected_scripts.items():
+            with self.subTest(event=event):
+                command = plugin["hooks"][event][0]["hooks"][0]["command"]
+                self.assertEqual(
+                    command,
+                    'sh "${CLAUDE_PLUGIN_ROOT}/src/hooks/run-hook.sh" '
+                    f'"${{CLAUDE_PLUGIN_ROOT}}/src/hooks/{script}"',
+                )
+
+    def test_hook_shell_scripts_use_env_shebangs(self):
+        expected_interpreters = {
+            "run-hook.sh": "sh",
+            "caveman-statusline.sh": "bash",
+            "install.sh": "bash",
+            "uninstall.sh": "bash",
+        }
+
+        for name, interpreter in expected_interpreters.items():
+            with self.subTest(script=name):
+                script_path = REPO_ROOT / "src" / "hooks" / name
+                first_line = script_path.read_text().splitlines()[0]
+                self.assertEqual(first_line, f"#!/usr/bin/env {interpreter}")
+
     def test_install_upgrades_old_two_file_install(self):
         with tempfile.TemporaryDirectory(prefix="caveman-hooks-upgrade-") as tmp:
             home = Path(tmp)


### PR DESCRIPTION
## Summary
Two coordinated changes that both serve issue #65's theme. (1) Portable shebangs: change `src/hooks/caveman-statusline.sh`, `src/hooks/install.sh`, and `src/hooks/uninstall.sh` from hardcoded `#!/bin/bash` to `#!/usr/bin/env bash` (keep `bash` where the scripts use bash-isms; downgrade `caveman-statusline.sh` to `#!/usr/bin/env sh` only if it is verified POSIX-clean).

## Why this matters
Installing the caveman plugin emits `Plugin hook error: /bin/sh: line 1: node: command not found` (SessionStart) and `UserPromptSubmit hook error` for users whose environment does not expose `node` on the hook runner's PATH, or who have no Node at all. Three distinct reporters confirmed it: a NixOS user (`sh` not at the usual path), a Bun-only user (no `node`), and a Debian user who intentionally runs without Node. The literal ask in the title is to use portable `#!/usr/bin/env` shebangs; the thread's most detailed comment (cgty, 2026-07-13) clarifies the real failure: `.claude-plugin/plugin.json` launches the hooks as bare `node "${CLAUDE_PLUGIN_ROOT}/src/hooks/*.js"`, so a shebang change alone cannot help when Node is absent. The single concern is: caveman's hooks must not hard-fail the Claude Code session when the interpreter is at a non-standard path or missing.

## Testing
- Happy path: with `node` on PATH, `run-hook.sh <script.js>` execs Node and the hook runs exactly as before (existing `tests/test_hooks.py` behavior preserved).
- Node absent: with a PATH that has no `node`, `run-hook.sh` exits 0 and produces no error, so the session start / prompt submit degrades gracefully.
- Structural: `.claude-plugin/plugin.json` SessionStart and UserPromptSubmit commands route through `run-hook.sh` (no bare `node` invocation remains).
- Shebang assertions: `src/hooks/caveman-statusline.sh`, `install.sh`, `uninstall.sh` start with a `#!/usr/bin/env` shebang, not a hardcoded `#!/bin/bash`.
- Regression: `bash src/hooks/install.sh` still installs the statusline hook and writes settings.json correctly (existing `HookScriptTests` continue to pass).

Fixes #65

AI was used for assistance.