### PR TITLE
fix: strip Claude-schema tools frontmatter so cavecrew agents load on Gemini/Antigravity

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -24,7 +24,7 @@ const crypto = require('crypto');
 
 const SETTINGS = require('./lib/settings');
 const OPENCLAW = require('./lib/openclaw');
-const { stripOpencodeAgentTools } = require('./lib/opencode-agent');
+const { stripAgentTools, stripOpencodeAgentTools } = require('./lib/opencode-agent');
 
 const REPO = 'JuliusBrussee/caveman';
 // Pin remote fetches to an immutable release tag, not the moving `main`
@@ -51,6 +51,7 @@ const HOOK_FILES = [
   'caveman-statusline.ps1',
   'cavecrew-model-overrides.js',
 ];
+const CAVECREW_AGENT_FILES = ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md'];
 
 // ── Argv ───────────────────────────────────────────────────────────────────
 function parseArgs(argv) {
@@ -448,6 +449,17 @@ function absoluteNodePath() {
   return process.execPath;
 }
 
+function stripInstalledAgentTools(agentsDir) {
+  for (const file of CAVECREW_AGENT_FILES) {
+    const agentPath = path.join(agentsDir, file);
+    try {
+      const content = fs.readFileSync(agentPath, 'utf8');
+      const stripped = stripAgentTools(content);
+      if (stripped !== content) fs.writeFileSync(agentPath, stripped);
+    } catch (_) {}
+  }
+}
+
 // ── Per-provider installers ────────────────────────────────────────────────
 async function installClaude(ctx) {
   const { say, note, warn, ok, opts, results, configDir } = ctx;
@@ -566,8 +578,14 @@ function installGemini(ctx) {
     }
   }
   const r = runSpawn('gemini', ['extensions', 'install', `https://github.com/${REPO}`], null, opts.dryRun);
-  if (spawnOk(r)) results.installed.push('gemini');
-  else results.failed.push(['gemini', 'gemini extensions install failed']);
+  if (spawnOk(r)) {
+    results.installed.push('gemini');
+    if (!opts.dryRun) {
+      stripInstalledAgentTools(path.join(os.homedir(), '.gemini', 'extensions', 'caveman', 'agents'));
+    }
+  } else {
+    results.failed.push(['gemini', 'gemini extensions install failed']);
+  }
   process.stdout.write('\n');
 }
 
@@ -587,8 +605,16 @@ function installViaSkills(ctx, prov) {
   // documented form for "install every skill into a specific agent".
   const args = ['-y', 'skills', 'add', REPO, '--skill', '*', '-a', prov.profile, '--yes'];
   const r = runSpawn('npx', args, null, opts.dryRun);
-  if (spawnOk(r)) results.installed.push(prov.id);
-  else results.failed.push([prov.id, `npx skills add (${prov.profile}) failed`]);
+  if (spawnOk(r)) {
+    results.installed.push(prov.id);
+    if (!opts.dryRun && prov.id === 'antigravity') {
+      stripInstalledAgentTools(path.join(
+        os.homedir(), '.gemini', 'antigravity', 'skills', 'cavecrew', 'agents',
+      ));
+    }
+  } else {
+    results.failed.push([prov.id, `npx skills add (${prov.profile}) failed`]);
+  }
   process.stdout.write('\n');
 }
 
@@ -656,7 +682,7 @@ function installHermes(ctx) {
 // architecture as closely as opencode allows — only the statusline is missing
 // (opencode's TUI exposes no plugin-writable badge).
 const OPENCODE_SKILL_DIRS  = ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'cavecrew'];
-const OPENCODE_AGENT_FILES = ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md'];
+const OPENCODE_AGENT_FILES = CAVECREW_AGENT_FILES;
 const OPENCODE_COMMAND_FILES = ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-compress.md', 'caveman-stats.md', 'caveman-help.md'];
 const OPENCODE_PLUGIN_REL = './plugins/caveman/plugin.js';
 const OPENCODE_AGENTS_MD_SENTINEL = 'Respond terse like smart caveman';

--- a/bin/install.js
+++ b/bin/install.js
@@ -25,7 +25,7 @@ const crypto = require('crypto');
 const SETTINGS = require('./lib/settings');
 const OPENCLAW = require('./lib/openclaw');
 const OWNED = require('./lib/owned-install');
-const { stripOpencodeAgentTools } = require('./lib/opencode-agent');
+const { stripAgentTools, stripOpencodeAgentTools } = require('./lib/opencode-agent');
 const PORTABLE = require('./lib/portable-process');
 const PLATFORM_PATHS = require('./lib/platform-paths');
 
@@ -58,6 +58,7 @@ const HOOK_FILES = [
   'caveman-statusline.ps1',
   'cavecrew-model-overrides.js',
 ];
+const CAVECREW_AGENT_FILES = ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md'];
 
 // ── Argv ───────────────────────────────────────────────────────────────────
 function parseArgs(argv) {
@@ -444,6 +445,17 @@ function absoluteNodePath() {
   return process.execPath;
 }
 
+function stripInstalledAgentTools(agentsDir) {
+  for (const file of CAVECREW_AGENT_FILES) {
+    const agentPath = path.join(agentsDir, file);
+    try {
+      const content = fs.readFileSync(agentPath, 'utf8');
+      const stripped = stripAgentTools(content);
+      if (stripped !== content) fs.writeFileSync(agentPath, stripped);
+    } catch (_) {}
+  }
+}
+
 // ── Per-provider installers ────────────────────────────────────────────────
 async function installClaude(ctx) {
   const { say, note, warn, ok, opts, results, configDir } = ctx;
@@ -562,8 +574,14 @@ function installGemini(ctx) {
     }
   }
   const r = runSpawn('gemini', ['extensions', 'install', `https://github.com/${REPO}`], null, opts.dryRun);
-  if (spawnOk(r)) results.installed.push('gemini');
-  else results.failed.push(['gemini', 'gemini extensions install failed']);
+  if (spawnOk(r)) {
+    results.installed.push('gemini');
+    if (!opts.dryRun) {
+      stripInstalledAgentTools(path.join(os.homedir(), '.gemini', 'extensions', 'caveman', 'agents'));
+    }
+  } else {
+    results.failed.push(['gemini', 'gemini extensions install failed']);
+  }
   process.stdout.write('\n');
 }
 
@@ -583,8 +601,16 @@ function installViaSkills(ctx, prov) {
   // documented form for "install every skill into a specific agent".
   const args = ['-y', 'skills', 'add', REPO, '--skill', '*', '-a', prov.profile, '--yes'];
   const r = runSpawn('npx', args, null, opts.dryRun);
-  if (spawnOk(r)) results.installed.push(prov.id);
-  else results.failed.push([prov.id, `npx skills add (${prov.profile}) failed`]);
+  if (spawnOk(r)) {
+    results.installed.push(prov.id);
+    if (!opts.dryRun && prov.id === 'antigravity') {
+      stripInstalledAgentTools(path.join(
+        os.homedir(), '.gemini', 'antigravity', 'skills', 'cavecrew', 'agents',
+      ));
+    }
+  } else {
+    results.failed.push([prov.id, `npx skills add (${prov.profile}) failed`]);
+  }
   process.stdout.write('\n');
 }
 
@@ -657,7 +683,7 @@ function installHermes(ctx) {
 // architecture as closely as opencode allows — only the statusline is missing
 // (opencode's TUI exposes no plugin-writable badge).
 const OPENCODE_SKILL_DIRS  = ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'cavecrew'];
-const OPENCODE_AGENT_FILES = ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md'];
+const OPENCODE_AGENT_FILES = CAVECREW_AGENT_FILES;
 const OPENCODE_COMMAND_FILES = ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-compress.md', 'caveman-stats.md', 'caveman-help.md'];
 const OPENCODE_PLUGIN_REL = './plugins/caveman/plugin.js';
 const OPENCODE_AGENTS_MD_SENTINEL = 'Respond terse like smart caveman';

--- a/bin/lib/opencode-agent.js
+++ b/bin/lib/opencode-agent.js
@@ -1,23 +1,24 @@
 'use strict';
 
-// Strip the `tools:` field from a Claude-Code-style subagent frontmatter so
-// the file is valid for opencode, whose schema rejects the YAML array form
-// (`tools: [Read, Grep, Bash]`) with:
+// Strip the `tools:` field from Claude-Code-style subagent frontmatter so the
+// file can be loaded by agents whose schemas reject Claude's tool names or
+// YAML array form (`tools: [Read, Grep, Bash]`). opencode reports:
 //
 //   Configuration is invalid at .../agents/cavecrew-reviewer.md
 //   ↳ Expected object | undefined, got ["Read","Grep","Bash"] tools
 //
-// opencode allows `tools` to be a map (`{read: true, grep: true}`) or
-// omitted entirely. Omitting falls back to opencode's default tool set,
-// which is what the cavecrew subagent prompts already self-restrict against
-// in their body ("Read-only locator", "No `Bash` available", etc.), so
-// dropping the array form is safe.
+// Gemini rejects the same frontmatter earlier with `tools.0: Invalid tool
+// name` because Claude's tool vocabulary does not match Gemini's.
+//
+// Omitting the field falls back to the target agent's default tool set. The
+// cavecrew prompts already self-restrict in their bodies ("Read-only locator",
+// "No `Bash` available", etc.), so dropping the Claude-specific field is safe.
 
 const TOOLS_FIELD_RE = /^tools[ \t]*:/;
 const CONTINUATION_RE = /^[ \t]/;
 const FRONTMATTER_FENCE = '---\n';
 
-function stripOpencodeAgentTools(content) {
+function stripAgentTools(content) {
   if (typeof content !== 'string' || !content.startsWith(FRONTMATTER_FENCE)) return content;
   const fmEnd = content.indexOf('\n---', FRONTMATTER_FENCE.length);
   if (fmEnd < 0) return content;
@@ -39,4 +40,6 @@ function stripOpencodeAgentTools(content) {
   return FRONTMATTER_FENCE + out.join('\n') + rest;
 }
 
-module.exports = { stripOpencodeAgentTools };
+const stripOpencodeAgentTools = stripAgentTools;
+
+module.exports = { stripAgentTools, stripOpencodeAgentTools };

--- a/tests/installer/gemini-agents.test.mjs
+++ b/tests/installer/gemini-agents.test.mjs
@@ -1,0 +1,214 @@
+// Gemini/Antigravity agent frontmatter compatibility (issue #497).
+//
+// The shipped cavecrew agents use Claude Code tool names in `tools: [...]`.
+// Gemini rejects those names before loading the agents, so provider installs
+// must remove only that frontmatter key from their on-disk copies.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const INSTALLER = path.join(REPO_ROOT, 'bin', 'install.js');
+const requireCjs = createRequire(import.meta.url);
+const { stripAgentTools, stripOpencodeAgentTools } = requireCjs(
+  path.join(REPO_ROOT, 'bin', 'lib', 'opencode-agent.js'),
+);
+
+const AGENT_FILES = ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md'];
+
+function agentFixture(name) {
+  return `---
+name: ${name.replace(/\.md$/, '')}
+description: >
+  Test agent with a folded description.
+tools: [Read, Edit, Write, Grep, Glob]
+model: haiku
+---
+
+## Tools
+
+No \`Bash\` available. Keep this prose untouched.
+`;
+}
+
+function frontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n/);
+  assert.ok(match, 'frontmatter present');
+  return match[1];
+}
+
+function assertSanitized(agentPath) {
+  const content = fs.readFileSync(agentPath, 'utf8');
+  const fm = frontmatter(content);
+  assert.doesNotMatch(fm, /^tools:/m, `${agentPath}: tools field survived`);
+  const expectedName = path.basename(agentPath, '.md');
+  assert.match(fm, new RegExp(`^name: ${expectedName}$`, 'm'), `${agentPath}: name field changed`);
+  assert.match(fm, /^description:/m, `${agentPath}: description field missing`);
+  assert.match(content, /^## Tools$/m, `${agentPath}: body heading changed`);
+  assert.match(content, /No \`Bash\` available/, `${agentPath}: body prose changed`);
+}
+
+function writeFakeCommand(binDir, name) {
+  const scriptPath = path.join(binDir, `${name}.js`);
+  fs.writeFileSync(scriptPath, `
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+if (process.argv.includes('list')) process.exit(0);
+const files = JSON.parse(process.env.CAVEMAN_TEST_AGENT_FILES);
+for (const file of files) {
+  if (file === process.env.CAVEMAN_TEST_MISSING_AGENT) continue;
+  const dest = path.join(process.env.CAVEMAN_TEST_AGENT_DIR, file);
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  if (!fs.existsSync(dest)) {
+    fs.writeFileSync(
+      dest,
+      process.env.CAVEMAN_TEST_AGENT_FIXTURE.replaceAll('__FILE__', file.replace(/\\.md$/, '')),
+    );
+  }
+}
+`);
+
+  const posixPath = path.join(binDir, name);
+  fs.writeFileSync(
+    posixPath,
+    `#!/bin/sh\nexec "${process.execPath}" "${scriptPath}" "$@"\n`,
+    { mode: 0o755 },
+  );
+  fs.writeFileSync(
+    path.join(binDir, `${name}.cmd`),
+    `@echo off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`,
+  );
+}
+
+function makeHarness() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-gemini-agents-'));
+  const home = path.join(root, 'home');
+  const bin = path.join(root, 'bin');
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(bin, { recursive: true });
+  writeFakeCommand(bin, 'gemini');
+  writeFakeCommand(bin, 'npx');
+
+  // Keep provider tests isolated from installer modules they do not exercise.
+  const preload = path.join(root, 'preload.cjs');
+  fs.writeFileSync(preload, `
+'use strict';
+const Module = require('node:module');
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  const fromInstaller = parent && /bin[\\\\/]install\\.js$/.test(parent.filename);
+  if (fromInstaller && (request === './lib/settings' || request === './lib/openclaw')) return {};
+  return originalLoad.call(this, request, parent, isMain);
+};
+`);
+
+  return {
+    root,
+    home,
+    run(provider, agentDir, missingAgent) {
+      const nodeOptions = [process.env.NODE_OPTIONS, '--require', JSON.stringify(preload)]
+        .filter(Boolean)
+        .join(' ');
+      return spawnSync(process.execPath, [
+        INSTALLER,
+        '--only', provider,
+        '--force',
+        '--skip-skills',
+        '--non-interactive',
+        '--no-mcp-shrink',
+        '--config-dir', path.join(root, 'claude'),
+      ], {
+        env: {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+          PATH: bin + path.delimiter + (process.env.PATH || ''),
+          NODE_OPTIONS: nodeOptions,
+          CAVEMAN_TEST_AGENT_DIR: agentDir,
+          CAVEMAN_TEST_AGENT_FILES: JSON.stringify(AGENT_FILES),
+          CAVEMAN_TEST_AGENT_FIXTURE: agentFixture('__FILE__'),
+          CAVEMAN_TEST_MISSING_AGENT: missingAgent || '',
+        },
+        encoding: 'utf8',
+      });
+    },
+    cleanup() {
+      fs.rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+test('stripAgentTools removes only the frontmatter tools key', () => {
+  const src = agentFixture('cavecrew-builder.md');
+  const out = stripAgentTools(src);
+  const fm = frontmatter(out);
+  assert.doesNotMatch(fm, /^tools:/m);
+  assert.match(fm, /^name: cavecrew-builder$/m);
+  assert.match(fm, /^description:/m);
+  assert.match(out, /^## Tools$/m, 'inline body tools heading preserved');
+  assert.match(out, /No \`Bash\` available/, 'inline body tools prose preserved');
+});
+
+test('opencode compatibility alias stays equivalent and stripping is idempotent', () => {
+  const src = agentFixture('cavecrew-reviewer.md');
+  const once = stripAgentTools(src);
+  assert.equal(stripAgentTools(once), once);
+  assert.equal(stripOpencodeAgentTools(src), once);
+});
+
+test('Gemini extension install strips tools from every distributed cavecrew agent', () => {
+  const harness = makeHarness();
+  const agentDir = path.join(harness.home, '.gemini', 'extensions', 'caveman', 'agents');
+  try {
+    const result = harness.run('gemini', agentDir);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    for (const file of AGENT_FILES) assertSanitized(path.join(agentDir, file));
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('Gemini force re-run is idempotent and skips a missing installed agent', () => {
+  const harness = makeHarness();
+  const agentDir = path.join(harness.home, '.gemini', 'extensions', 'caveman', 'agents');
+  const missing = 'cavecrew-reviewer.md';
+  try {
+    const first = harness.run('gemini', agentDir, missing);
+    assert.equal(first.status, 0, first.stderr || first.stdout);
+    const second = harness.run('gemini', agentDir, missing);
+    assert.equal(second.status, 0, second.stderr || second.stdout);
+    for (const file of AGENT_FILES.filter(name => name !== missing)) {
+      assertSanitized(path.join(agentDir, file));
+    }
+    assert.equal(fs.existsSync(path.join(agentDir, missing)), false);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('Antigravity install strips tools from npx-skills cavecrew agent copies', () => {
+  const harness = makeHarness();
+  const agentDir = path.join(
+    harness.home,
+    '.gemini',
+    'antigravity',
+    'skills',
+    'cavecrew',
+    'agents',
+  );
+  try {
+    const result = harness.run('antigravity', agentDir);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    for (const file of AGENT_FILES) assertSanitized(path.join(agentDir, file));
+  } finally {
+    harness.cleanup();
+  }
+});


### PR DESCRIPTION
## What

Fixes #497 - caveman fails to load on Google Antigravity / Gemini CLI.

## Why

Installing the extension with `gemini extensions install https://github.com/JuliusBrussee/caveman` makes Gemini's ExtensionManager reject all three cavecrew agents:

```
Validation failed: Agent Definition: tools.0: Invalid tool name
```

The `agents/cavecrew-*.md` files carry Claude Code schema frontmatter (`tools: [Read, Edit, Write, Grep, Glob]`). Gemini validates each entry against its own tool vocabulary and refuses the Claude names, so the cavecrew subagents never load and the extension is broken on Antigravity. This is the same class of schema mismatch already fixed for opencode in #386 via `stripOpencodeAgentTools()`.

## How

Mirror the opencode #386 fix on the Gemini/Antigravity distribution path, reusing the proven transform:

- `bin/lib/opencode-agent.js`: generalize the existing helper into a schema-agnostic `stripAgentTools()` that removes the frontmatter `tools:` key (and its wrapped continuation lines), keeping `stripOpencodeAgentTools` as a thin alias so the existing opencode call site and test stay unchanged.
- `bin/install.js`: after `gemini extensions install` lands the extension at `~/.gemini/extensions/caveman/agents/`, rewrite the three installed cavecrew agent files in place with the `tools:` line stripped (Gemini then falls back to its default tool set; the subagent prompts already self-restrict scope in their bodies). The same strip is applied to the Antigravity `npx skills` agent copies. Missing files are skipped silently, honoring the installer's fail-soft-on-filesystem-error invariant.

Top-level source-of-truth agents are untouched, so the Claude plugin mirror still ships the full `tools:` schema via CI. Only the Gemini/Antigravity on-disk copies are rewritten.

## Tests

Adds `tests/installer/gemini-agents.test.mjs` (5 cases): only the frontmatter `tools:` key is stripped (inline body prose preserved), opencode-alias equivalence and idempotency, end-to-end Gemini install strips every distributed agent, `--force` re-run idempotency + missing-file skip, and the Antigravity path. The existing `tests/installer/opencode-agent.test.mjs` continues to pass unchanged.

```
$ node --test tests/installer/gemini-agents.test.mjs
# tests 5 | pass 5 | fail 0
$ node --test tests/installer/opencode-agent.test.mjs
# tests 9 | pass 9 | fail 0
```

---

AI was used for assistance.
