### PR TITLE
Resolve OS command injection in /app/caveman/bin/install.js

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -394,7 +394,7 @@ const IS_WIN = process.platform === 'win32';
 
 function quoteWinArg(a) {
   if (!IS_WIN) return a;
-  if (a === '' || /[\s"]/.test(a)) {
+  if (a === '' || /[\s"&|^<>%()]/.test(a)) {
     // Standard CommandLineToArgvW escaping
     return '"' + String(a).replace(/\\(?=\\*"|$)/g, '\\\\').replace(/"/g, '\\"') + '"';
   }


### PR DESCRIPTION
**Title**: Command Injection via Malicious Directory Name or MCP Command (Windows)
**Vulnerability Type**: OS command injection
**File Path**: `/app/caveman/bin/install.js`

#### Analysis
The `spawnXplat` function in `bin/install.js` is used to execute commands on Windows with `shell: true`. When joining arguments to form the command string, it uses a `quoteWinArg` helper that only adds double quotes if the argument contains a space or a double quote. It does not escape or quote other shell meta-characters such as `&`, `|`, `(`, `)`, `<`, `>`, `^`, or `%`. 

An attacker can exploit this by:
1. Trick a user into running the installer (e.g., via `npx`) from a directory whose name contains a meta-character (e.g., `C:\projects\repo&calc&`). The `runInit` function passes `process.cwd()` as an argument to `runSpawn`, which calls `spawnXplat`.
2. Providing a malicious string to the `--with-mcp-shrink` flag (e.g., `--with-mcp-shrink="npx & calc"`). The installer will then execute a command string containing the unquoted `&`, leading to arbitrary command execution by `cmd.exe`.