### PR TITLE
stats: surface the net-negative regime (#145), not just gross savings

### DIFF
--- a/src/hooks/caveman-stats.js
+++ b/src/hooks/caveman-stats.js
@@ -18,6 +18,18 @@ const { readFlag, appendFlag, readHistory, safeWriteFlag, VALID_MODES, MODE_LOG_
 // run is committed.
 const COMPRESSION = { 'full': 0.65 };
 
+// Per-turn INPUT cost the skill adds: the SKILL.md rules (~5 KB ≈ ~1,250 tokens
+// at the ~4-chars/token approximation used elsewhere here) are injected into
+// context every turn, plus the per-turn reinforcement the mode tracker emits.
+// A real "net" must subtract this from the output savings — caveman is
+// net-negative when it saves less output than the rules cost (docs/HONEST-NUMBERS.md).
+// Override with CAVEMAN_RULE_OVERHEAD_TOKENS if you've measured your own setup.
+const DEFAULT_RULE_OVERHEAD_TOKENS_PER_TURN = 1250;
+function ruleOverheadPerTurn() {
+  const env = parseInt(process.env.CAVEMAN_RULE_OVERHEAD_TOKENS, 10);
+  return Number.isFinite(env) && env >= 0 ? env : DEFAULT_RULE_OVERHEAD_TOKENS_PER_TURN;
+}
+
 // Approximate Anthropic public output-token pricing, USD per million.
 // Match by model id prefix so this stays correct across point releases
 // (e.g. claude-sonnet-4-20250514, claude-sonnet-4-7). Update from
@@ -250,6 +262,26 @@ function deriveSavings({ byMode, model }) {
   return { estSavedTokens, estSavedUsd };
 }
 
+// Net token effect = output tokens saved − input tokens the rules cost. Savings
+// are OUTPUT tokens; overhead is INPUT tokens; their sum is the honest
+// whole-budget delta (docs/HONEST-NUMBERS.md frames break-even exactly so).
+function deriveNet({ estSavedTokens, turns }) {
+  const overheadTokens = Math.max(0, turns || 0) * ruleOverheadPerTurn();
+  return { overheadTokens, netTokens: (estSavedTokens || 0) - overheadTokens };
+}
+
+// Shared "rule overhead" + "net" lines for the session and lifetime views.
+function netLines({ estSavedTokens, turns }) {
+  const perTurn = ruleOverheadPerTurn();
+  const { overheadTokens, netTokens } = deriveNet({ estSavedTokens, turns });
+  const overhead = `Est. rule overhead:    ${overheadTokens.toLocaleString()} ` +
+    `(input, ~${perTurn.toLocaleString()}/turn over ${turns} turn${turns === 1 ? '' : 's'})`;
+  const net = netTokens >= 0
+    ? `Est. net:              +${netTokens.toLocaleString()} (net saving after rule overhead)`
+    : `Est. net:              ${netTokens.toLocaleString()} (caveman cost more than it saved — turn it off for this workload)`;
+  return `${overhead}\n${net}`;
+}
+
 // Parse "7d", "12h" etc. to milliseconds. Returns null on invalid input.
 function parseDuration(spec) {
   if (!spec) return null;
@@ -274,13 +306,14 @@ function aggregateHistory(historyPath, sinceMs) {
     const prev = latestPerSession.get(id);
     if (!prev || (entry.ts || 0) >= (prev.ts || 0)) latestPerSession.set(id, entry);
   }
-  let outputTokens = 0, estSavedTokens = 0, estSavedUsd = 0;
+  let outputTokens = 0, estSavedTokens = 0, estSavedUsd = 0, turns = 0;
   for (const e of latestPerSession.values()) {
     outputTokens   += e.output_tokens     || 0;
     estSavedTokens += e.est_saved_tokens  || 0;
     estSavedUsd    += e.est_saved_usd     || 0;
+    turns          += e.turns             || 0;   // older rows lack turns → 0 (overhead uncounted until re-logged)
   }
-  return { sessions: latestPerSession.size, outputTokens, estSavedTokens, estSavedUsd };
+  return { sessions: latestPerSession.size, outputTokens, estSavedTokens, estSavedUsd, turns };
 }
 
 // Output-reduction share: saved / (saved + used) = the fraction of the
@@ -306,7 +339,7 @@ function humanizeTokens(n) {
   return String(Math.round(n));
 }
 
-function formatHistory({ sessions, outputTokens, estSavedTokens, estSavedUsd, since }) {
+function formatHistory({ sessions, outputTokens, estSavedTokens, estSavedUsd, turns, since }) {
   const sep = '──────────────────────────────────';
   const window = since ? ` (last ${since})` : '';
   if (sessions === 0) {
@@ -317,11 +350,12 @@ function formatHistory({ sessions, outputTokens, estSavedTokens, estSavedUsd, si
   const budgetLine = pct !== null
     ? `Est. output reduction: ~${pct}% (output tokens only, est.)\n`
     : '';
+  const netBlock = turns > 0 ? netLines({ estSavedTokens, turns }) + '\n' : '';
   return `\nCaveman Stats — Lifetime${window}\n${sep}\n` +
     `Sessions:   ${sessions.toLocaleString()}\n${sep}\n` +
     `Output tokens:         ${outputTokens.toLocaleString()}\n` +
     `Est. tokens saved:     ${estSavedTokens.toLocaleString()}\n` +
-    budgetLine + usdLine + sep + '\n';
+    netBlock + budgetLine + usdLine + sep + '\n';
 }
 
 // Single-line tweetable summary. Stays human-friendly when no ratio is known.
@@ -414,9 +448,11 @@ function formatStats({ outputTokens, cacheReadTokens, turns, mode, model, sessio
     // any session-usage % would overstate real limit relief. See
     // docs/HONEST-NUMBERS.md.
     footer += ' Reduction is of output tokens only; input/cache usage is unchanged.';
+    footer += ` Net subtracts the rules' est. input cost (~${ruleOverheadPerTurn().toLocaleString()}/turn, docs/HONEST-NUMBERS.md).`;
     savings = (`Est. without caveman:  ${estNormal.toLocaleString()}\n` +
               `Est. tokens saved:     ${estSaved.toLocaleString()} (~${Math.round(ratio * 100)}% of output)\n` +
               usdLine).replace(/\n$/, '');
+    savings += '\n' + netLines({ estSavedTokens: estSaved, turns });
   } else if (mode && mode !== 'off') {
     savings = `No savings estimate for '${mode}' mode — only 'full' has benchmark data.`;
   } else {
@@ -501,6 +537,7 @@ function main() {
       mode: mode || null,
       model: parsed.model || null,
       output_tokens: parsed.outputTokens,
+      turns: parsed.turns,
       est_saved_tokens: estSavedTokens,
       est_saved_usd: estSavedUsd,
     }));
@@ -527,7 +564,7 @@ if (require.main === module) main();
 
 module.exports = {
   formatStats, formatShare, formatHistory, aggregateHistory, parseDuration, deriveSavings,
-  parseSession, priceForModel, formatUsd, COMPRESSION, MODEL_OUTPUT_PRICE_PER_M,
-  findCompressedPairs, summarizeCompressed, humanizeTokens, outputReductionPct,
-  readModeLog, attributeByMode,
+  deriveNet, ruleOverheadPerTurn, parseSession, priceForModel, formatUsd, COMPRESSION,
+  MODEL_OUTPUT_PRICE_PER_M, findCompressedPairs, summarizeCompressed, humanizeTokens,
+  outputReductionPct, readModeLog, attributeByMode,
 };

--- a/tests/test_caveman_stats.js
+++ b/tests/test_caveman_stats.js
@@ -221,6 +221,7 @@ test('appends to lifetime history on each run', (tmp) => {
   const entry = JSON.parse(lines[0]);
   assert.strictEqual(entry.session_id, 's');
   assert.strictEqual(entry.output_tokens, 350);
+  assert.strictEqual(entry.turns, 1);
   assert.strictEqual(entry.est_saved_tokens, 650);
   assert.strictEqual(entry.mode, 'full');
   assert.strictEqual(entry.model, 'claude-sonnet-4-7');
@@ -631,6 +632,119 @@ test('excludes tokens that predate a mid-session flag write with no log (#601)',
   assert.match(out, /unattributed:\s+350 tokens/);
   assert.match(out, /excluded/);
   assert.doesNotMatch(out, /Est\. without caveman/);
+});
+
+// ── Rule-injection overhead + net (reveals the net-negative regime, #145) ──
+// Gross output savings alone can never show when caveman costs more than it
+// saves. Net subtracts the per-turn rule-injection input cost.
+
+test('session shows rule overhead and a positive net on a large reply', (tmp) => {
+  const sess = makeSession(tmp, [
+    { type: 'assistant', message: { usage: { output_tokens: 1500 } } },
+  ]);
+  const claudeDir = path.join(tmp, '.claude');
+  fs.writeFileSync(path.join(claudeDir, '.caveman-active'), 'full');
+  const out = execFileSync(process.execPath, [STATS, '--session-file', sess], {
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir },
+  });
+  // 1500/0.35 = 4286, saved 2786; overhead 1250×1; net = +1536.
+  assert.match(out, /Est\. rule overhead:\s+1,250 \(input, ~1,250\/turn over 1 turn\)/);
+  assert.match(out, /Est\. net:\s+\+1,536 \(net saving after rule overhead\)/);
+});
+
+test('session shows a NEGATIVE net and says turn it off on a small reply (#145)', (tmp) => {
+  const sess = makeSession(tmp, [
+    { type: 'assistant', message: { usage: { output_tokens: 100 } } },
+  ]);
+  const claudeDir = path.join(tmp, '.claude');
+  fs.writeFileSync(path.join(claudeDir, '.caveman-active'), 'full');
+  const out = execFileSync(process.execPath, [STATS, '--session-file', sess], {
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir },
+  });
+  // 100/0.35 = 286, saved 186; overhead 1250; net = -1064.
+  assert.match(out, /Est\. net:\s+-1,064/);
+  assert.match(out, /caveman cost more than it saved/);
+  assert.match(out, /turn it off for this workload/);
+});
+
+test('overhead scales with CAVEMAN_RULE_OVERHEAD_TOKENS override', (tmp) => {
+  const sess = makeSession(tmp, [
+    { type: 'assistant', message: { usage: { output_tokens: 1500 } } },
+  ]);
+  const claudeDir = path.join(tmp, '.claude');
+  fs.writeFileSync(path.join(claudeDir, '.caveman-active'), 'full');
+  const out = execFileSync(process.execPath, [STATS, '--session-file', sess], {
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir, CAVEMAN_RULE_OVERHEAD_TOKENS: '500' },
+  });
+  // overhead 500×1; net = 2786 - 500 = +2286.
+  assert.match(out, /Est\. rule overhead:\s+500 \(input, ~500\/turn over 1 turn\)/);
+  assert.match(out, /Est\. net:\s+\+2,286/);
+});
+
+test('does not fabricate a net when tokens are unattributed (no guessing)', (tmp) => {
+  const now = Date.now();
+  const sess = makeSession(tmp, [
+    { type: 'assistant', timestamp: new Date(now - 60 * 60_000).toISOString(), message: { usage: { output_tokens: 350 } } },
+  ]);
+  const claudeDir = path.join(tmp, '.claude');
+  // Flag written now, no transition log → mode during the message is unknown.
+  fs.writeFileSync(path.join(claudeDir, '.caveman-active'), 'full');
+  const out = execFileSync(process.execPath, [STATS, '--session-file', sess], {
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir },
+  });
+  assert.match(out, /unattributed:\s+350 tokens/);
+  assert.doesNotMatch(out, /Est\. net:/);   // no savings basis → no net claim
+});
+
+test('lifetime view nets aggregated turns against savings', (tmp) => {
+  const claudeDir = path.join(tmp, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  const histPath = path.join(claudeDir, '.caveman-history.jsonl');
+  fs.writeFileSync(histPath, [
+    { ts: 1000, session_id: 'a', mode: 'full', output_tokens: 1500, est_saved_tokens: 2786, est_saved_usd: 0, turns: 1 },
+    { ts: 2000, session_id: 'b', mode: 'full', output_tokens: 100,  est_saved_tokens: 186,  est_saved_usd: 0, turns: 1 },
+  ].map(o => JSON.stringify(o)).join('\n') + '\n');
+  const out = execFileSync(process.execPath, [STATS, '--all'], {
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir },
+  });
+  // saved 2972, overhead 1250×2 = 2500, net = +472.
+  assert.match(out, /Est\. tokens saved:\s+2,972/);
+  assert.match(out, /Est\. rule overhead:\s+2,500 \(input, ~1,250\/turn over 2 turns\)/);
+  assert.match(out, /Est\. net:\s+\+472/);
+});
+
+test('lifetime view omits net for legacy rows without turn data', (tmp) => {
+  const claudeDir = path.join(tmp, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, '.caveman-history.jsonl'),
+    JSON.stringify({ ts: 1000, session_id: 'a', mode: 'full', output_tokens: 350, est_saved_tokens: 650, est_saved_usd: 0 }) + '\n');
+  const out = execFileSync(process.execPath, [STATS, '--all'], {
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir },
+  });
+  assert.doesNotMatch(out, /Est\. net:/);   // no turns logged → can't compute overhead honestly
+});
+
+test('deriveNet and ruleOverheadPerTurn: default and env override', () => {
+  const { deriveNet, ruleOverheadPerTurn } = require(STATS);
+  const saved = process.env.CAVEMAN_RULE_OVERHEAD_TOKENS;
+  try {
+    delete process.env.CAVEMAN_RULE_OVERHEAD_TOKENS;
+    assert.strictEqual(ruleOverheadPerTurn(), 1250);
+    assert.deepStrictEqual(deriveNet({ estSavedTokens: 2786, turns: 1 }), { overheadTokens: 1250, netTokens: 1536 });
+    process.env.CAVEMAN_RULE_OVERHEAD_TOKENS = '500';
+    assert.strictEqual(ruleOverheadPerTurn(), 500);
+    process.env.CAVEMAN_RULE_OVERHEAD_TOKENS = 'garbage';
+    assert.strictEqual(ruleOverheadPerTurn(), 1250);
+  } finally {
+    if (saved === undefined) delete process.env.CAVEMAN_RULE_OVERHEAD_TOKENS;
+    else process.env.CAVEMAN_RULE_OVERHEAD_TOKENS = saved;
+  }
 });
 
 console.log(`\n${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## The pain

`docs/HONEST-NUMBERS.md` is blunt about when caveman loses:

> the skill costs ~1–1.5k input tokens every turn. If it saves less output than that, you are paying to use it.

#145 measured exactly that. But the tool the docs point users to — `/caveman-stats` — can't show it. `deriveSavings` only computes gross output savings, so `Est. tokens saved` is always positive and the net-negative case is invisible in the one instrument meant to reveal it. The page's own creed — *"If caveman lose for your workload, this page tell you to turn it off"* — isn't wired into the page.

## The change

Adds the missing half:

- **`Est. rule overhead`** — the per-turn input cost of the injected rules (default `1250` tokens ≈ the ~5 KB `SKILL.md` at the ~4-chars/token approximation already used here; override with `CAVEMAN_RULE_OVERHEAD_TOKENS` if you've measured your own setup).
- **`Est. net`** = output saved − rule input. Negative → it says so and tells you to turn caveman off for that workload.

Shown in the single-mode session view and the lifetime `--all` view.

Before / after on a short reply (120 output tokens, 1 turn, `full`):

```
Est. tokens saved:     223 (~65% of output)          # previously the whole story
Est. rule overhead:    1,250 (input, ~1,250/turn over 1 turn)
Est. net:              -1,027 (caveman cost more than it saved — turn it off for this workload)
```

## Honesty guardrails

- Net is shown only where savings can actually be estimated (full-mode spans). Unattributed spans get **no** net line — no guessing, consistent with the #601 attribution logic.
- Overhead is an estimate, labeled as such, cited to `HONEST-NUMBERS.md`; it's a named constant, env-overridable.
- No new output-token claims; the reduction line still says output-only. Lifetime net only counts sessions logged since this change (older rows carry no turn count, so they're left out rather than guessed).

## Tests

`node tests/test_caveman_stats.js` — **44 pass** (37 existing + 7 new: positive net, the negative-net #145 case, the env override, the no-guessing unattributed path, lifetime aggregation, and the legacy-row omission).
