### PR TITLE
fix(openclaw): stop stamping stale version, add --no-always opt-out

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -59,7 +59,7 @@ function parseArgs(argv) {
     withHooks: 'auto', withInit: false, withMcpShrink: false,
     all: false, minimal: false, listOnly: false, noColor: false,
     only: [], uninstall: false, nonInteractive: false,
-    configDir: null, help: false,
+    configDir: null, help: false, openclawAlways: true,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -102,6 +102,7 @@ function parseArgs(argv) {
         break;
       }
       case '--no-mcp-shrink': opts.withMcpShrink = false; break;
+      case '--no-always': opts.openclawAlways = false; break;
       case '--all': opts.all = true; break;
       case '--minimal': opts.minimal = true; break;
       case '--list': opts.listOnly = true; break;
@@ -882,8 +883,10 @@ function installOpencode(ctx) {
 // Drops skills/caveman/ into the OpenClaw workspace and appends a small
 // auto-injected bootstrap block to the workspace SOUL.md. Always-on behavior
 // comes from SOUL.md (auto-injected each turn); the skill folder makes
-// caveman discoverable via `openclaw skills list`. See bin/lib/openclaw.js
-// for the actual file writes.
+// caveman discoverable via `openclaw skills list`. Pass --no-always to skip
+// the SOUL.md write (and the `always: true` frontmatter stamp) and install
+// the skill as load-on-demand only. See bin/lib/openclaw.js for the actual
+// file writes.
 function installOpenclaw(ctx) {
   const { say, note, warn, opts, repoRoot, results } = ctx;
   results.detected++;
@@ -900,6 +903,8 @@ function installOpenclaw(ctx) {
     repoRoot,
     dryRun: opts.dryRun,
     force: opts.force,
+    version: PINNED_REF.replace(/^v/, ''),
+    always: opts.openclawAlways,
     log,
   });
 
@@ -1391,6 +1396,9 @@ FLAGS
                         is required. The value is whitespace-tokenized.
                         Example: --with-mcp-shrink="npx @modelcontextprotocol/server-filesystem /tmp"
   --no-mcp-shrink       Skip MCP shrink. (Default.)
+  --no-always           OpenClaw: install the skill as load-on-demand only —
+                        skip the SOUL.md bootstrap write and the
+                        \`always: true\` frontmatter stamp. (Default: always-on.)
   --uninstall, -u       Remove caveman from this machine.
   --config-dir <path>   Claude Code config dir for hook files + settings.json.
                         Default: \$CLAUDE_CONFIG_DIR or ~/.claude. Does NOT

--- a/bin/lib/openclaw.js
+++ b/bin/lib/openclaw.js
@@ -17,6 +17,17 @@
 //      pointing the agent at the skill. SOUL.md is auto-injected each turn,
 //      so this is what actually drives always-on behavior.
 //
+// Pass `always: false` (bin/install.js: --no-always) to opt out of both the
+// `always: true` frontmatter stamp and the SOUL.md write — the skill is then
+// only step 1: dropped into the workspace and discoverable via
+// `openclaw skills list`, loaded by the model on demand instead of injected
+// every turn.
+//
+// `version` defaults to SKILL_VERSION below (a static fallback) but should be
+// passed explicitly by callers that know the real release — bin/install.js
+// passes its PINNED_REF so `openclaw skills list` reports the version that
+// was actually installed instead of a stale constant.
+//
 // Idempotent on both writes. Uninstall removes the skill folder and strips
 // the marker block from SOUL.md while preserving any user-authored content.
 
@@ -27,6 +38,9 @@ const os = require('os');
 const path = require('path');
 
 const SKILL_NAME = 'caveman';
+// Fallback only — used when a caller doesn't pass an explicit `version`
+// (e.g. src/tools/caveman-init.js). bin/install.js's npx/CLI path always
+// passes its own PINNED_REF instead of relying on this.
 const SKILL_VERSION = '1.0.0';
 const MARK_BEGIN = '<!-- caveman-begin -->';
 const MARK_END = '<!-- caveman-end -->';
@@ -67,12 +81,12 @@ function frontmatterHasKey(fm, key) {
   return re.test(fm);
 }
 
-function mergeOpenclawFrontmatter(src) {
+function mergeOpenclawFrontmatter(src, { version = SKILL_VERSION, always = true } = {}) {
   const { frontmatter, body } = splitFrontmatter(src);
   const additions = [];
   if (!frontmatterHasKey(frontmatter, 'name')) additions.push(`name: ${SKILL_NAME}`);
-  if (!frontmatterHasKey(frontmatter, 'version')) additions.push(`version: ${SKILL_VERSION}`);
-  if (!frontmatterHasKey(frontmatter, 'always')) additions.push('always: true');
+  if (!frontmatterHasKey(frontmatter, 'version')) additions.push(`version: ${version}`);
+  if (always && !frontmatterHasKey(frontmatter, 'always')) additions.push('always: true');
   if (additions.length === 0 && frontmatter) return src;
   const fmBody = (frontmatter ? frontmatter.trimEnd() + '\n' : '') + additions.join('\n') + (additions.length ? '\n' : '');
   return '---\n' + fmBody + '---\n' + body;
@@ -198,7 +212,7 @@ function stripBootstrapFromSoul(soulPath) {
 }
 
 // ── Public API ────────────────────────────────────────────────────────────
-function installOpenclaw({ workspace, repoRoot, dryRun = false, force = false, log = noopLog() } = {}) {
+function installOpenclaw({ workspace, repoRoot, dryRun = false, force = false, version, always = true, log = noopLog() } = {}) {
   const ws = workspace || resolveWorkspace();
   const skillBody = loadSkillBody(repoRoot);
   if (!skillBody) {
@@ -206,7 +220,7 @@ function installOpenclaw({ workspace, repoRoot, dryRun = false, force = false, l
     log.note('  Re-run from a clone or via `npx -y github:JuliusBrussee/caveman -- --only openclaw`.');
     return { ok: false, reason: 'repo not available' };
   }
-  const snippet = loadBootstrapSnippet(repoRoot);
+  const snippet = always ? loadBootstrapSnippet(repoRoot) : null;
 
   if (!fs.existsSync(ws)) {
     if (!force) {
@@ -222,15 +236,24 @@ function installOpenclaw({ workspace, repoRoot, dryRun = false, force = false, l
   const soulFile = path.join(ws, SOUL_FILE);
 
   if (dryRun) {
-    log.note(`  would write ${skillFile} (with version/always frontmatter)`);
-    log.note(`  would ${fs.existsSync(soulFile) ? 'append to' : 'create'} ${soulFile} (caveman bootstrap block)`);
+    log.note(`  would write ${skillFile} (with ${always ? 'version/always' : 'version-only'} frontmatter)`);
+    if (always) {
+      log.note(`  would ${fs.existsSync(soulFile) ? 'append to' : 'create'} ${soulFile} (caveman bootstrap block)`);
+    } else {
+      log.note(`  would NOT touch ${soulFile} (--no-always: skill installed on-demand only)`);
+    }
     return { ok: true, dryRun: true };
   }
 
   fs.mkdirSync(skillDir, { recursive: true });
-  const merged = mergeOpenclawFrontmatter(skillBody);
+  const merged = mergeOpenclawFrontmatter(skillBody, { version, always });
   fs.writeFileSync(skillFile, merged, { mode: 0o644 });
   log.write(`  installed: ${skillFile}\n`);
+
+  if (!always) {
+    log.note(`  skipped ${soulFile} (--no-always: skill discoverable via \`openclaw skills list\`, loaded on demand)`);
+    return { ok: true };
+  }
 
   const soul = appendBootstrapToSoul(soulFile, snippet);
   if (soul.changed) log.write(`  wrote bootstrap block to ${soulFile}\n`);

--- a/tests/installer/e2e.freshinstall.test.mjs
+++ b/tests/installer/e2e.freshinstall.test.mjs
@@ -281,6 +281,76 @@ test('openclaw install writes skill folder + SOUL.md bootstrap', () => {
   }
 });
 
+test('openclaw install stamps the pinned release version, not a stale constant', () => {
+  const dir = freshTmpDir();
+  const ws = path.join(dir, 'ws');
+  fs.mkdirSync(ws);
+  try {
+    const r = spawnSync('node', [INSTALLER, '--only', 'openclaw', '--non-interactive', '--no-mcp-shrink', '--config-dir', dir], {
+      // CAVEMAN_REF is the sanctioned test override for PINNED_REF (see
+      // bin/install.js). Using a value distinct from the real pinned release
+      // proves the frontmatter version is threaded through at install time,
+      // not hardcoded to bin/lib/openclaw.js's SKILL_VERSION fallback.
+      env: { ...process.env, OPENCLAW_WORKSPACE: ws, NO_COLOR: '1', CAVEMAN_REF: 'v9.9.9' },
+      encoding: 'utf8',
+    });
+    assert.notEqual(r.status, 2, `installer aborted on argv parse: ${r.stderr}`);
+
+    const skillRaw = fs.readFileSync(path.join(ws, 'skills', 'caveman', 'SKILL.md'), 'utf8');
+    assert.match(skillRaw, /\nversion:\s*9\.9\.9\b/, 'frontmatter version should match CAVEMAN_REF (9.9.9), not a stale fallback');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('openclaw install --no-always: skill installed load-on-demand, SOUL.md untouched', () => {
+  const dir = freshTmpDir();
+  const ws = path.join(dir, 'ws');
+  fs.mkdirSync(ws);
+  try {
+    const r = spawnSync('node', [INSTALLER, '--only', 'openclaw', '--non-interactive', '--no-mcp-shrink', '--no-always', '--config-dir', dir], {
+      env: { ...process.env, OPENCLAW_WORKSPACE: ws, NO_COLOR: '1' },
+      encoding: 'utf8',
+    });
+    assert.notEqual(r.status, 2, `installer aborted on argv parse: ${r.stderr}`);
+
+    // Skill still written, still versioned, but no `always: true` stamp.
+    const skillFile = path.join(ws, 'skills', 'caveman', 'SKILL.md');
+    assert.ok(fs.existsSync(skillFile), 'skill SKILL.md missing');
+    const skillRaw = fs.readFileSync(skillFile, 'utf8');
+    assert.match(skillRaw, /\nversion:\s*\d+\.\d+\.\d+/, 'skill missing version frontmatter');
+    assert.doesNotMatch(skillRaw, /\nalways:\s*true/, '--no-always should not stamp always: true');
+
+    // SOUL.md is what drives always-on injection — --no-always must not write it.
+    const soul = path.join(ws, 'SOUL.md');
+    assert.equal(fs.existsSync(soul), false, '--no-always should not create SOUL.md');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('openclaw install --no-always is idempotent and does not retroactively strip an existing SOUL.md block', () => {
+  const dir = freshTmpDir();
+  const ws = path.join(dir, 'ws');
+  fs.mkdirSync(ws);
+  try {
+    const env = { ...process.env, OPENCLAW_WORKSPACE: ws, NO_COLOR: '1' };
+    const base = ['--only', 'openclaw', '--non-interactive', '--no-mcp-shrink', '--config-dir', dir];
+
+    // First install always-on (writes SOUL.md), then re-run with --no-always.
+    // --no-always should not touch an already-present bootstrap block — it
+    // only controls whether a NEW install writes one.
+    spawnSync('node', [INSTALLER, ...base], { env, encoding: 'utf8' });
+    const r = spawnSync('node', [INSTALLER, ...base, '--force', '--no-always'], { env, encoding: 'utf8' });
+    assert.notEqual(r.status, 2, `installer aborted on argv parse: ${r.stderr}`);
+
+    const soulRaw = fs.readFileSync(path.join(ws, 'SOUL.md'), 'utf8');
+    assert.match(soulRaw, /<!-- caveman-begin -->/, '--no-always on a re-run should not strip an existing bootstrap block');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('openclaw install is idempotent: skill frontmatter not double-prepended, SOUL.md has one marker block', () => {
   const dir = freshTmpDir();
   const ws = path.join(dir, 'ws');


### PR DESCRIPTION
## Problem

Found while integrating caveman into an OpenClaw deployment and reading `bin/lib/openclaw.js`:

1. **Stale version stamp.** `SKILL_VERSION = '1.0.0'` is hardcoded and gets written into every installed skill's frontmatter regardless of the actual release — currently v1.9.1. `openclaw skills list` reports a version that's never been accurate since the constant was introduced.
2. **No opt-out for always-on.** `installOpenclaw()` unconditionally stamps `always: true` and writes the SOUL.md bootstrap block. There's no flag to install caveman as a discoverable, load-on-demand skill only (which the module's own top-of-file comment describes as a supported mode — "Skills there... are loaded on-demand by the model" — but nothing in the installer actually lets you land in that mode).

## Fix

Both scoped narrowly, no default-behavior change:

- **Version**: `mergeOpenclawFrontmatter()` / `installOpenclaw()` accept an explicit `version` override. `bin/install.js`'s `--only openclaw` path now passes `PINNED_REF` (already bumped on every release for hook-integrity pinning — this reuses that existing, maintained value instead of introducing a second version source). `SKILL_VERSION` stays as the fallback for callers that don't pass one explicitly.
- **`--no-always`**: new flag. Skips the `always: true` frontmatter stamp and the SOUL.md write; only the skill file is installed. Re-running `--no-always` over an already always-on install does **not** retroactively strip the existing SOUL.md block — it only changes what a *new* install does (covered by a test).

## Before / after

```diff
- version: 1.0.0
+ version: 1.9.1
```

```bash
# new: install caveman for OpenClaw without forcing always-on
npx -y github:JuliusBrussee/caveman -- --only openclaw --no-always
```

## Tests

4 new cases in `tests/installer/e2e.freshinstall.test.mjs`:
- version threading (`CAVEMAN_REF` override → frontmatter reflects it, not the fallback)
- `--no-always`: skill written, versioned, no `always:` key, SOUL.md not created
- `--no-always` idempotency: doesn't strip a SOUL.md block from a prior always-on install

Existing openclaw suite (always-on default, idempotent re-run, uninstall, marker damage-tolerance from #596) is unmodified and still green — confirms the default install path is unchanged.

`npm test`: 113/115 pass locally, including all 4 new tests. The 2 failures are **pre-existing** — they reproduce on an unmodified checkout of `main` in this sandbox, caused by a real `claude` CLI + `~/.openclaw` present in the environment (tests documented as "skipped without `claude` CLI" detect it and take a different path). Unrelated to this change; not touched here.

## Scope note

`src/tools/caveman-init.js` (the per-repo rule-file installer) also calls `helper.installOpenclaw()` for its `openclaw` target, and is left unchanged — it's a differently-scoped tool (drops rule files for many editors into a target repo, explicitly documented as installing an "always-on caveman rule") and extending it is a separate concern per the one-PR-one-concern guidance in CONTRIBUTING.md. Happy to follow up there if useful.