### PR TITLE
ci: force Node 24 for JS actions

### DIFF
--- a/.github/workflows/sync-skill.yml
+++ b/.github/workflows/sync-skill.yml
@@ -1,5 +1,8 @@
 name: Sync SKILL.md and rules
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Adds top-level env FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true so JS actions run on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)