### PR TITLE
fix(hooks): act on a complete payload instead of waiting for stdin EOF

### DIFF
--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -19,12 +19,22 @@ const flagPath = path.join(claudeDir, '.caveman-active');
 const prevPath = path.join(claudeDir, '.caveman-active.prev');
 
 let input = '';
-process.stdin.on('data', chunk => { input += chunk; });
+let handled = false;
 // Abnormal stdin close (broken pipe, parent crash) emits 'error'; without a
 // listener Node throws it as an uncaught exception and the hook exits
 // non-zero — a spurious hook failure (#538). Hooks must always exit 0.
 process.stdin.on('error', () => process.exit(0));
-process.stdin.on('end', () => {
+
+// Act on a COMPLETE payload rather than waiting for stdin to close. The whole
+// body used to live in the 'end' listener alone, so the hook did nothing until
+// the caller sent EOF — and Claude Code killed it at the 5s timeout whenever
+// that EOF was late. The sibling SessionStart hook never reads stdin and never
+// times out; this one did, on ~2% of runs. Destroying stdin (rather than
+// exiting) releases the only thing holding the event loop open, so Node drains
+// and flushes stdout on its own.
+function handlePayload() {
+  if (handled) return;
+  handled = true;
   try {
     const data = JSON.parse(input);
     // Collapse whitespace so phrase triggers still match multiline prompts —
@@ -203,4 +213,13 @@ process.stdin.on('end', () => {
   } catch (e) {
     // Silent fail
   }
+}
+
+process.stdin.on('data', chunk => {
+  input += chunk;
+  // A partial payload is not an error — keep reading until it parses.
+  try { JSON.parse(input); } catch (e) { return; }
+  handlePayload();
+  process.stdin.destroy();
 });
+process.stdin.on('end', handlePayload);

--- a/tests/test_mode_tracker_stdin.js
+++ b/tests/test_mode_tracker_stdin.js
@@ -81,5 +81,102 @@ test('normal stdin (valid JSON + clean EOF) still exits 0', () => {
   }
 });
 
+// --- Claude Code's 5s hook timeout -----------------------------------------
+// A complete payload can arrive well before the caller closes stdin. Doing the
+// work only in the 'end' listener meant the hook sat idle until EOF and was
+// killed at the timeout — silently, injecting nothing.
+//
+// Driven through a child so the assertions here stay synchronous: the driver
+// writes one complete payload, leaves stdin OPEN, and reports how long the hook
+// took to exit on its own plus whatever it managed to write.
+const HOOK_TIMEOUT_MS = 5000;
+
+function runWithStdinHeldOpen(configDir, prompt) {
+  const driver = `
+    const { spawn } = require('child_process');
+    const started = Date.now();
+    const p = spawn(process.execPath, [${JSON.stringify(HOOK_PATH)}], {
+      stdio: ['pipe', 'pipe', 'ignore'],
+      env: { ...process.env, CLAUDE_CONFIG_DIR: ${JSON.stringify(configDir)} },
+    });
+    let out = '';
+    p.stdout.on('data', c => { out += c; });
+    p.stdin.write(JSON.stringify({ prompt: ${JSON.stringify(prompt)} }));   // stdin stays open
+    const kill = setTimeout(() => { p.kill('SIGKILL'); }, ${HOOK_TIMEOUT_MS * 2});
+    p.on('exit', (code, signal) => {
+      clearTimeout(kill);
+      process.stdout.write(JSON.stringify({ ms: Date.now() - started, code, signal, out }));
+    });
+  `;
+  const res = spawnSync(process.execPath, ['-e', driver], { encoding: 'utf8' });
+  return JSON.parse(res.stdout);
+}
+
+test('a complete payload is acted on before the 5s hook timeout, without EOF', () => {
+  const tmpConfig = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-tracker-stdin-'));
+  try {
+    const r = runWithStdinHeldOpen(tmpConfig, 'hello there');
+    assert.ok(
+      r.signal === null && r.code === CLEAN_EXIT,
+      `hook did not exit on its own with stdin held open (code=${r.code} signal=${r.signal} ` +
+        `after ${r.ms}ms) — Claude Code kills it at ${HOOK_TIMEOUT_MS}ms`
+    );
+    assert.ok(
+      r.ms < HOOK_TIMEOUT_MS,
+      `hook took ${r.ms}ms with stdin held open; the hook timeout is ${HOOK_TIMEOUT_MS}ms`
+    );
+  } finally {
+    fs.rmSync(tmpConfig, { recursive: true, force: true });
+  }
+});
+
+test('the per-turn reinforcement is still emitted when stdin never closes', () => {
+  const tmpConfig = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-tracker-stdin-'));
+  try {
+    fs.writeFileSync(path.join(tmpConfig, '.caveman-active'), 'full');
+    const r = runWithStdinHeldOpen(tmpConfig, 'hello there');
+    assert.ok(
+      /CAVEMAN MODE ACTIVE/.test(r.out || ''),
+      `expected the additionalContext injection on stdout, got ${JSON.stringify(r.out)} ` +
+        `(exit code=${r.code} signal=${r.signal} after ${r.ms}ms)`
+    );
+  } finally {
+    fs.rmSync(tmpConfig, { recursive: true, force: true });
+  }
+});
+
+// The payload can also arrive split across chunks; a partial one must not be
+// mistaken for a broken one, and the body must still run exactly once.
+test('a payload split across chunks is handled once, and only once', () => {
+  const tmpConfig = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-tracker-stdin-'));
+  try {
+    fs.writeFileSync(path.join(tmpConfig, '.caveman-active'), 'full');
+    const driver = `
+      const { spawn } = require('child_process');
+      const p = spawn(process.execPath, [${JSON.stringify(HOOK_PATH)}], {
+        stdio: ['pipe', 'pipe', 'ignore'],
+        env: { ...process.env, CLAUDE_CONFIG_DIR: ${JSON.stringify(tmpConfig)} },
+      });
+      let out = '';
+      p.stdout.on('data', c => { out += c; });
+      const payload = JSON.stringify({ prompt: 'hello there' });
+      p.stdin.write(payload.slice(0, 8));
+      setTimeout(() => { p.stdin.write(payload.slice(8)); p.stdin.end(); }, 50);
+      p.on('exit', (code, signal) =>
+        process.stdout.write(JSON.stringify({ code, signal, out })));
+    `;
+    const r = JSON.parse(spawnSync(process.execPath, ['-e', driver], { encoding: 'utf8' }).stdout);
+    assert.strictEqual(r.code, CLEAN_EXIT, `expected clean exit, got code=${r.code} signal=${r.signal}`);
+    const injections = (r.out.match(/CAVEMAN MODE ACTIVE/g) || []).length;
+    assert.strictEqual(
+      injections,
+      1,
+      `expected exactly one injection for one payload, got ${injections}: ${JSON.stringify(r.out)}`
+    );
+  } finally {
+    fs.rmSync(tmpConfig, { recursive: true, force: true });
+  }
+});
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
Fixes #729

`caveman-mode-tracker.js` does all of its work inside `process.stdin.on('end', …)`, so the hook sits idle until the caller closes stdin. When that EOF is late, Claude Code kills the process at its 5000 ms timeout — before the flag file is written and before the per-turn reinforcement is injected. Silently: nothing is printed, and the only trace is a `hook_cancelled` attachment in the transcript.

Measured over 30 days of transcripts on one machine: **48 of 2076** `UserPromptSubmit` runs cancelled at the timeout (**2.3%**), some with a recorded `durationMs` of 25618 against `timeoutMs: 5000`. The sibling `SessionStart` hook — which never reads stdin — was cancelled once in 224 runs. Full numbers in the issue.

## The change

Parse on each `data` chunk and run the body as soon as the accumulated input is valid JSON, then destroy stdin. A partial payload is not an error, it just keeps reading; the `end` listener stays as the fallback for input that never parses, and a `handled` flag keeps the body from running twice when both fire.

**`process.stdin.destroy()` rather than `process.exit()`** — stdin is the only handle holding the event loop open, so releasing it lets Node drain and flush stdout on its own. Exiting outright races the write and can truncate the injection.

The diff is confined to the stdin wiring; the body is unchanged apart from being moved into a named function (the early `return` in the `/caveman-stats` branch behaves identically inside it).

## Tests

Three cases added to `tests/test_mode_tracker_stdin.js`, each verified to fail without the fix:

```
$ node tests/test_mode_tracker_stdin.js          # with the fix
  ✓ stdin "error" event does not crash the hook (exit 0)
  ✓ normal stdin (valid JSON + clean EOF) still exits 0
  ✓ a complete payload is acted on before the 5s hook timeout, without EOF
  ✓ the per-turn reinforcement is still emitted when stdin never closes
  ✓ a payload split across chunks is handled once, and only once
  5 passed, 0 failed
```

Reverting only the hook (keeping the tests):

```
  ✗ a complete payload is acted on before the 5s hook timeout, without EOF
    hook did not exit on its own with stdin held open
    (code=null signal=SIGKILL after 10006ms) — Claude Code kills it at 5000ms
  ✗ the per-turn reinforcement is still emitted when stdin never closes
    expected the additionalContext injection on stdout, got ""
  3 passed, 2 failed
```

The chunked case guards the new code path, so it is proven against a mutation of the fix instead — dropping the `handled` guard:

```
  ✗ a payload split across chunks is handled once, and only once
    expected exactly one injection for one payload, got 2
```

The driver spawns the hook through a child process so the assertions stay synchronous, matching the existing file's `spawnSync` style.

Also green, unchanged: `npm test` (112/112), `tests/test_mode_tracker.py` (23), `tests/test_hooks.py`, `tests/test_symlink_flag.js` (12), `tests/test_caveman_init.js` (8), `tests/test_repo_local_config.js` (12).