### PR TITLE
fix(hooks): make caveman-statusline.sh always exit 0

### DIFF
--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -215,5 +215,50 @@ class HookScriptTests(unittest.TestCase):
             self.assertIn("PLUGIN ROOT MARKER RULESET", result.stdout)
 
 
+class StatuslineExitCodeTests(unittest.TestCase):
+    def run_statusline(self, config_dir, extra_env=None):
+        env = os.environ.copy()
+        env["CLAUDE_CONFIG_DIR"] = str(config_dir)
+        if extra_env:
+            env.update(extra_env)
+        return subprocess.run(
+            ["bash", str(REPO_ROOT / "src" / "hooks" / "caveman-statusline.sh")],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_exits_zero_with_empty_savings_suffix_file(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-statusline-empty-suffix-") as tmp:
+            config_dir = Path(tmp)
+            (config_dir / ".caveman-active").write_text("full")
+            (config_dir / ".caveman-statusline-suffix").write_text("")
+
+            result = self.run_statusline(config_dir)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("CAVEMAN", result.stdout)
+
+    def test_exits_zero_with_no_savings_suffix_file(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-statusline-no-suffix-") as tmp:
+            config_dir = Path(tmp)
+            (config_dir / ".caveman-active").write_text("full")
+
+            result = self.run_statusline(config_dir)
+
+            self.assertEqual(result.returncode, 0)
+
+    def test_exits_zero_with_populated_savings_suffix_file(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-statusline-suffix-") as tmp:
+            config_dir = Path(tmp)
+            (config_dir / ".caveman-active").write_text("full")
+            (config_dir / ".caveman-statusline-suffix").write_text("42.1K saved")
+
+            result = self.run_statusline(config_dir)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("42.1K saved", result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refs #711.

## Update: superseded by 7693a04, narrowed to regression tests

This PR originally added the same fix independently. Rebasing onto current
`main` showed that `7693a04` already shipped the identical fix upstream
(an explicit `exit 0` after the savings-suffix block in
`caveman-statusline.sh`, for the same reason described below), so that part
of this PR is now redundant and has been dropped in the rebase. The
`caveman-statusline.sh` diff here is empty; it now matches `main` exactly.

What remains is `StatuslineExitCodeTests` in `tests/test_hooks.py`, which
`main` does not have. It pins the behavior in place: empty suffix file,
missing suffix file, and populated suffix file must all exit 0.

Entirely your call whether these tests are worth merging as-is, folding
into another PR, or just closing this one.

## Original root cause (for context, already fixed on main by 7693a04)

`caveman-statusline.sh`'s last statement is:

```sh
[ -n "$SAVINGS" ] && printf ' \033[38;5;172m%s\033[0m' "$SAVINGS"
```

When `.caveman-statusline-suffix` exists but is empty (interrupted write, or
a fresh install before `caveman-stats` has produced its first value),
`$SAVINGS` is empty, the test fails, and since this is the last command in
the script its exit status (1) becomes the script's exit status, even
though the badge itself already printed correctly. Claude Code hides the
whole statusline on a non-zero exit, so the badge disappears entirely
instead of just dropping the optional suffix.

## Verification

Rebased onto current `main` (`fcf7663`) and ran the full `tests/test_hooks.py`
and `npm test` suites in a `node:22-slim` + `python3` container: 10/10 and
125/125 (121 pass, 4 pre-existing skips) green, no regressions. The three
new `StatuslineExitCodeTests` pass against `main`'s already-fixed script.
