### PR TITLE
fix: remove command files that duplicate same-named skills

### DIFF
--- a/commands/caveman-commit.md
+++ b/commands/caveman-commit.md
@@ -1,5 +1,0 @@
----
-description: Generate terse caveman-style commit message
----
-
-Generate a terse commit message for the current staged changes. Conventional Commits format. Subject: ≤50 chars, imperative, lowercase after type. Body: only when 'why' isn't obvious from subject. Why over what. No period on subject.

--- a/commands/caveman-review.md
+++ b/commands/caveman-review.md
@@ -1,5 +1,0 @@
----
-description: One-line code review comments
----
-
-Review the current code changes. One-line per finding. Format: L<line>: <severity> <problem>. <fix>. Severity: bug, risk, nit, q. Skip praise. Skip obvious. If code look good, say 'LGTM' and stop.

--- a/commands/caveman-stats.md
+++ b/commands/caveman-stats.md
@@ -1,6 +1,0 @@
----
-description: Real session token usage + lifetime savings + USD. Tweetable line via --share.
-argument-hint: "[--share|--all|--since 7d]"
----
-
-/caveman-stats $ARGUMENTS

--- a/commands/caveman.md
+++ b/commands/caveman.md
@@ -1,6 +1,0 @@
----
-description: Switch caveman intensity level (lite/full/ultra/wenyan)
-argument-hint: "[lite|full|ultra|wenyan]"
----
-
-Switch to caveman $ARGUMENTS mode. If no level specified, use full. Respond terse like smart caveman — drop articles, filler, pleasantries. Fragments OK. Technical terms exact. Code unchanged. Pattern: [thing] [action] [reason]. [next step].


### PR DESCRIPTION
## Problem

Claude Code registers both `commands/*.md` and `skills/*/SKILL.md`. Since the plugin ships both for `caveman`, `caveman-commit`, `caveman-review`, and `caveman-stats`, each appears **twice** in every session's available-skills listing (once with the short command description, once with the long skill description) — roughly 500 wasted context tokens per session for every plugin user, which runs against the plugin's whole purpose.

## Fix

Delete the four shadowed command `.md` files. The skills are already user-invocable as `/caveman`, `/caveman-commit`, `/caveman-review`, `/caveman-stats`, so no functionality is lost.

- `commands/caveman-init.md` kept — it has no skill counterpart.
- `.toml` command variants (other runtimes) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSexBNDnKmWe64ARv5r1wv