### PR TITLE
fix(opencode): record mode changes

### DIFF
--- a/src/plugins/opencode/plugin.js
+++ b/src/plugins/opencode/plugin.js
@@ -74,7 +74,7 @@ function loadConfig() {
 }
 const config = loadConfig();
 
-const { getDefaultMode, safeWriteFlag, readFlag } = config;
+const { getDefaultMode, safeWriteFlag, readFlag, recordModeChange } = config;
 
 // Load the shared mode-change parser (#602) the same way loadConfig() loads
 // caveman-config.js — see the doc comment above loadConfig() for why this
@@ -103,7 +103,8 @@ function opencodeConfigDir() {
   return path.join(os.homedir(), '.config', 'opencode');
 }
 
-const flagPath = path.join(opencodeConfigDir(), '.caveman-active');
+const opencodeDir = opencodeConfigDir();
+const flagPath = path.join(opencodeDir, '.caveman-active');
 
 function removeFlag() {
   try {
@@ -170,10 +171,12 @@ function reinforcementLine(mode) {
 function applyModeChange(change) {
   if (!change) return;
   if (change.action === 'clear') {
+    recordModeChange(opencodeDir, null);
     removeFlag();
     return;
   }
   if (change.action === 'set' && change.mode) {
+    recordModeChange(opencodeDir, change.mode);
     safeWriteFlag(flagPath, change.mode);
   }
 }
@@ -184,9 +187,11 @@ function applyModeChange(change) {
 function handleSessionCreated() {
   const mode = getDefaultMode();
   if (mode === 'off') {
+    recordModeChange(opencodeDir, null);
     removeFlag();
     return;
   }
+  recordModeChange(opencodeDir, mode);
   safeWriteFlag(flagPath, mode);
 }
 

--- a/tests/installer/opencode.test.mjs
+++ b/tests/installer/opencode.test.mjs
@@ -19,6 +19,7 @@ const REPO_ROOT = path.resolve(HERE, '..', '..');
 const INSTALLER = path.join(REPO_ROOT, 'bin', 'install.js');
 const requireCjs = createRequire(import.meta.url);
 const SETTINGS = requireCjs(path.join(REPO_ROOT, 'bin', 'lib', 'settings.js'));
+const MODE_LOG_BASENAME = '.caveman-mode-log.jsonl';
 
 const IS_WIN = process.platform === 'win32';
 
@@ -357,6 +358,7 @@ test('opencode plugin handles /caveman ultra, stop caveman, and session init via
 
     const pluginPath = path.join(xdg, 'opencode', 'plugins', 'caveman', 'plugin.js');
     const flagPath = path.join(xdg, 'opencode', '.caveman-active');
+    const modeLogPath = path.join(xdg, 'opencode', MODE_LOG_BASENAME);
 
     // Set XDG_CONFIG_HOME so the plugin's flagPath resolves to our temp dir,
     // and pin the default mode so session-init is deterministic regardless of
@@ -379,6 +381,9 @@ test('opencode plugin handles /caveman ultra, stop caveman, and session init via
     // Slash command in a chat.message text part activates ultra.
     await handlers['chat.message']({}, { parts: [{ type: 'text', text: '/caveman ultra' }] });
     assert.equal(fs.readFileSync(flagPath, 'utf8'), 'ultra');
+    assert.ok(fs.existsSync(modeLogPath), 'mode log missing after slash activation');
+    const activationRows = fs.readFileSync(modeLogPath, 'utf8').trim().split('\n').map(JSON.parse);
+    assert.equal(activationRows.at(-1).mode, 'ultra');
 
     // opencode expands "/caveman <level>" into the command template before
     // chat.message fires — the level must be recovered from the expanded text.
@@ -430,6 +435,8 @@ test('opencode plugin handles /caveman ultra, stop caveman, and session init via
     // Natural-language deactivation removes the flag.
     await handlers['chat.message']({}, { parts: [{ type: 'text', text: 'stop caveman please' }] });
     assert.equal(fs.existsSync(flagPath), false, 'flag should be deleted after deactivation');
+    const deactivationRows = fs.readFileSync(modeLogPath, 'utf8').trim().split('\n').map(JSON.parse);
+    assert.equal(deactivationRows.at(-1).mode, null);
 
     // No reinforcement injected when inactive.
     const sys2 = { system: [] };

--- a/tests/installer/opencode.test.mjs
+++ b/tests/installer/opencode.test.mjs
@@ -449,6 +449,23 @@ test('opencode plugin handles /caveman ultra, stop caveman, and session init via
     assert.equal(fs.existsSync(flagPath), false, 'non-session.created event must not write the flag');
     await handlers.event({ event: { type: 'session.created' } });
     assert.equal(fs.readFileSync(flagPath, 'utf8'), 'full');
+    const sessionInitRows = fs.readFileSync(modeLogPath, 'utf8').trim().split('\n').map(JSON.parse);
+    assert.deepEqual(
+      { mode: sessionInitRows.at(-1).mode, prev: sessionInitRows.at(-1).prev },
+      { mode: 'full', prev: null },
+    );
+
+    // A session starting with the default resolved to "off" turns caveman off,
+    // and that transition is a mode change like any other — stats must be able
+    // to attribute the messages that follow to caveman being inactive.
+    process.env.CAVEMAN_DEFAULT_MODE = 'off';
+    await handlers.event({ event: { type: 'session.created' } });
+    assert.equal(fs.existsSync(flagPath), false, 'session init with default off should delete the flag');
+    const sessionOffRows = fs.readFileSync(modeLogPath, 'utf8').trim().split('\n').map(JSON.parse);
+    assert.deepEqual(
+      { mode: sessionOffRows.at(-1).mode, prev: sessionOffRows.at(-1).prev },
+      { mode: null, prev: 'full' },
+    );
   } finally {
     if (origDefault === undefined) delete process.env.CAVEMAN_DEFAULT_MODE;
     else process.env.CAVEMAN_DEFAULT_MODE = origDefault;


### PR DESCRIPTION
Fixes #734

## Summary

The opencode plugin imported `getDefaultMode`, `safeWriteFlag` and `readFlag` from
`caveman-config`, but never `recordModeChange` — so every caveman mode transition in
opencode wrote the flag file and nothing else. `.caveman-mode-log.jsonl` was never
created, and `caveman-stats` had no transitions to attribute messages to.

This wires `recordModeChange` into all four transition sites the plugin owns:

- `applyModeChange` — slash/natural-language activation (`set`) and deactivation (`clear`)
- `handleSessionCreated` — session start, both the resolved-mode path and the
  `off` path

`opencodeConfigDir()` is hoisted to a module-level `opencodeDir` so the log lands
beside the flag it describes, instead of recomputing the directory per call.

Ordering matters and is deliberate: `recordModeChange` reads the *current* flag to
fill the row's `prev` field, so it runs before `safeWriteFlag`/`removeFlag`, never
after. Writes go through the existing symlink-safe `appendFlag` helper and inherit
its silent-fail contract, so a bad log path can never break session start.

## Test verification (RED → GREEN)

RED — unmodified upstream `main` (`a42ef76`) with **only** the test changes applied,
production `plugin.js` untouched:

```text
$ git status --porcelain
 M tests/installer/opencode.test.mjs

$ node --test --test-force-exit tests/installer/opencode.test.mjs
not ok 11 - opencode plugin handles /caveman ultra, stop caveman, and session init via real hooks
  error: 'mode log missing after slash activation'
  code: 'ERR_ASSERTION'
  expected: true
  actual: false
# tests 12
# pass 11
# fail 1
```

GREEN — same tests with the fix:

```text
$ node --test --test-force-exit tests/installer/opencode.test.mjs
# tests 12
# pass 12
# fail 0
```

Every `recordModeChange` call site the fix adds is asserted, not merely executed:
activation asserts the row's `mode`, deactivation asserts `mode: null`, and both
`handleSessionCreated` branches assert `{mode, prev}` so the session-start
transition is pinned in both directions.

## Scope note

`src/plugins/opencode/commands/caveman-stats.md` still points the model at
`~/.config/caveman/.caveman-history.jsonl`. That is the lifetime-savings file, a
different artifact from the mode log, and nothing on the opencode side writes it
today — it was already stale before this change. Deciding what opencode's
`/caveman-stats` should read is a separate call, so it is left out of a PR titled
"record mode changes" rather than folded in silently.
