### PR TITLE
fix(config): read POSIX fallback on Windows

### DIFF
--- a/src/hooks/caveman-config.js
+++ b/src/hooks/caveman-config.js
@@ -24,12 +24,14 @@ const VALID_MODES = [
   'wenyan-lite', 'wenyan', 'wenyan-full', 'wenyan-ultra',
   'commit', 'review', 'compress'
 ];
+const CONFIG_FILE_NAME = 'config.json';
+const WINDOWS_PLATFORM = 'win32';
 
 function getConfigDir() {
   if (process.env.XDG_CONFIG_HOME) {
     return path.join(process.env.XDG_CONFIG_HOME, 'caveman');
   }
-  if (process.platform === 'win32') {
+  if (process.platform === WINDOWS_PLATFORM) {
     return path.join(
       process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'),
       'caveman'
@@ -39,7 +41,11 @@ function getConfigDir() {
 }
 
 function getConfigPath() {
-  return path.join(getConfigDir(), 'config.json');
+  return path.join(getConfigDir(), CONFIG_FILE_NAME);
+}
+
+function getPosixHomeConfigPath() {
+  return path.join(os.homedir(), '.config', 'caveman', CONFIG_FILE_NAME);
 }
 
 // Walk up from `start` looking for a repo-local caveman config. Returns the
@@ -110,6 +116,10 @@ function getDefaultMode(startDir) {
   // 3. User config file
   const userMode = readModeFromConfigFile(getConfigPath());
   if (userMode) return userMode;
+  if (process.platform === WINDOWS_PLATFORM && !process.env.XDG_CONFIG_HOME) {
+    const posixHomeMode = readModeFromConfigFile(getPosixHomeConfigPath());
+    if (posixHomeMode) return posixHomeMode;
+  }
 
   // 4. Default
   return 'full';

--- a/tests/test_repo_local_config.js
+++ b/tests/test_repo_local_config.js
@@ -17,8 +17,11 @@ const assert = require('assert');
 const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-userhome-'));
 process.env.XDG_CONFIG_HOME = tmpHome;
 delete process.env.CAVEMAN_DEFAULT_MODE;
+const APPDATA_SEGMENT = /AppData/;
+const CONFIG_FILE_NAME = 'config.json';
+const WINDOWS_PLATFORM = 'win32';
 
-const { getDefaultMode, findRepoConfigPath } = require('../src/hooks/caveman-config');
+const { getDefaultMode, findRepoConfigPath, getConfigPath } = require('../src/hooks/caveman-config');
 
 let passed = 0;
 let failed = 0;
@@ -120,6 +123,33 @@ test('falls through to user config when repo config absent', (tmp) => {
     assert.strictEqual(getDefaultMode(), 'review');
   } finally {
     fs.rmSync(path.join(tmpHome, 'caveman'), { recursive: true, force: true });
+  }
+});
+
+test('win32 without APPDATA falls back to ~/.config/caveman/config.json', (tmp) => {
+  const origXdg = process.env.XDG_CONFIG_HOME;
+  const origAppData = process.env.APPDATA;
+  const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+  const origHomedir = os.homedir;
+  const posixConfigDir = path.join(tmp, '.config', 'caveman');
+  try {
+    delete process.env.XDG_CONFIG_HOME;
+    delete process.env.APPDATA;
+    Object.defineProperty(process, 'platform', { value: WINDOWS_PLATFORM });
+    os.homedir = () => tmp;
+    fs.mkdirSync(posixConfigDir, { recursive: true });
+    fs.writeFileSync(path.join(posixConfigDir, CONFIG_FILE_NAME),
+      JSON.stringify({ defaultMode: 'lite' }));
+
+    assert.match(getConfigPath(), APPDATA_SEGMENT);
+    assert.strictEqual(getDefaultMode(), 'lite');
+  } finally {
+    if (origXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = origXdg;
+    if (origAppData === undefined) delete process.env.APPDATA;
+    else process.env.APPDATA = origAppData;
+    Object.defineProperty(process, 'platform', origPlatform);
+    os.homedir = origHomedir;
   }
 });
 


### PR DESCRIPTION
Fixes #723

## Summary

- Add a Windows-only fallback from `%APPDATA%\caveman\config.json` to `~/.config/caveman/config.json` when `XDG_CONFIG_HOME` is unset.

- Cover the silent fallback case with a simulated win32 config-resolution regression test.

## Test verification (RED / GREEN)
RED before production fix:
```text
node tests/test_repo_local_config.js
'full' !== 'lite'

```
GREEN after fix:
```text
node tests/test_repo_local_config.js
13 passed, 0 failed

node tests/test_symlink_flag.js
12 passed, 0 failed

npm test
# tests 112
# pass 112
# fail 0
```