### PR TITLE
fix: add Claude 5 models to output-price table

### DIFF
--- a/src/hooks/caveman-stats.js
+++ b/src/hooks/caveman-stats.js
@@ -24,6 +24,11 @@ const COMPRESSION = { 'full': 0.65 };
 // https://www.anthropic.com/pricing if a release changes the tier.
 // Most-specific prefixes MUST come first — priceForModel returns the first match.
 const MODEL_OUTPUT_PRICE_PER_M = [
+  // Claude 5 generation.
+  ['claude-fable-5',     50.00],   // Fable 5  = $50/M output
+  ['claude-mythos-5',    50.00],   // Mythos 5 = same rate card as Fable 5
+  ['claude-opus-5',      25.00],   // Opus 5   = $25/M output (Opus tier unchanged since 4.5)
+  ['claude-sonnet-5',    15.00],   // Sonnet 5 = $15/M list ($10/M intro through 2026-08-31)
   // Legacy Opus 4.0 / 4.1 (pre-4.5) billed at the old $75/M output tier,
   // including the dated ids (e.g. claude-opus-4-20250514).
   ['claude-opus-4-0',    75.00],

--- a/tests/test_caveman_stats.js
+++ b/tests/test_caveman_stats.js
@@ -171,6 +171,18 @@ test('priceForModel matches by prefix across point releases', () => {
   assert.strictEqual(priceForModel('gpt-4'), null);
 });
 
+test('priceForModel covers the Claude 5 generation', () => {
+  const { priceForModel } = require(path.join(ROOT, 'src', 'hooks', 'caveman-stats.js'));
+  assert.strictEqual(priceForModel('claude-opus-5'), 25.00);
+  assert.strictEqual(priceForModel('claude-sonnet-5'), 15.00);
+  assert.strictEqual(priceForModel('claude-fable-5'), 50.00);
+  assert.strictEqual(priceForModel('claude-mythos-5'), 50.00);
+  // Claude Code reports the 1M-context variant with a bracket suffix.
+  assert.strictEqual(priceForModel('claude-opus-5[1m]'), 25.00);
+  // Claude 5 entries must not shadow the Claude 4 prefixes.
+  assert.strictEqual(priceForModel('claude-opus-4-8'), 25.00);
+});
+
 test('formatStats handles empty session gracefully', () => {
   const { formatStats } = require(path.join(ROOT, 'src', 'hooks', 'caveman-stats.js'));
   const out = formatStats({ outputTokens: 0, cacheReadTokens: 0, turns: 0, mode: 'full', model: null });


### PR DESCRIPTION
### Problem

`priceForModel()` matches by prefix against `claude-3*` and `claude-4*` only.
Every Claude 5 model id therefore falls through to `null`, which makes
`formatStats()` drop the `Est. saved (USD)` line and the statusline savings
suffix entirely.

Since `claude-opus-5` is the current Claude Code default, this means
`/caveman-stats` shows no dollar estimate at all for most users right now —
silently, with no error.

### Fix

Adds the four Claude 5 entries at the top of `MODEL_OUTPUT_PRICE_PER_M`:

| Model | Output $/M |
|---|---|
| Fable 5 / Mythos 5 | 50.00 |
| Opus 5 | 25.00 |
| Sonnet 5 | 15.00 |

Sonnet 5 is listed at its `$15/M` rate card; there is an introductory
`$10/M` price through 2026-08-31, noted in a comment rather than hard-coded
so the table doesn't silently expire.

The new prefixes do not overlap the existing `claude-*-4` entries, so Claude 4
pricing is untouched — pinned by an assertion in the new test.

### Tests

New case `priceForModel covers the Claude 5 generation` in
`tests/test_caveman_stats.js`, including the bracket-suffixed id Claude Code
actually reports for the 1M-context variant (`claude-opus-5[1m]`) — that
variant is what surfaced the bug.

- `node --test tests/*.js` → 7/7 files pass
- `npm test` (installer suite) → 112/112 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TUPyH44JsgchW1iJ5DZ6K
