### PR TITLE
adding support for npm12+ (uses the --allow-git=root flag where appropriate)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -69,7 +69,19 @@ caveman: Node.js (>=18) required. Install:
   # Do NOT pass `--` here — npm 7+ npx already forwards trailing args to the
   # package, and a literal `--` was tripping bin/install.js's parseArgs as an
   # unknown flag.
-  & npx -y "github:$Repo" @InstallerArgs
+  # npm 12 disables git package fetches by default. Allow only the root package
+  # requested here; older npm versions do not understand this config flag.
+  $npxVersion = [string](& npx --version)
+  $npxMajor = 0
+  if ($npxVersion -match '^(\d+)') {
+    $npxMajor = [int]$Matches[1]
+  }
+
+  if ($npxMajor -ge 12) {
+    & npx --allow-git=root -y "github:$Repo" @InstallerArgs
+  } else {
+    & npx -y "github:$Repo" @InstallerArgs
+  }
   exit $LASTEXITCODE
 }
 

--- a/install.sh
+++ b/install.sh
@@ -51,4 +51,18 @@ if ! command -v npx >/dev/null 2>&1; then
   exit 1
 fi
 
+# npm 12 disables git package fetches by default. Allow only the root package
+# requested here; keep the old invocation for npm versions that predate this
+# config flag.
+NPX_VERSION=""
+if NPX_VERSION=$(npx --version 2>/dev/null); then :; fi
+NPX_MAJOR=${NPX_VERSION%%.*}
+case "$NPX_MAJOR" in
+  ''|*[!0-9]*) NPX_MAJOR=0 ;;
+esac
+
+if [ "$NPX_MAJOR" -ge 12 ]; then
+  exec npx --allow-git=root -y "github:$REPO" "$@"
+fi
+
 exec npx -y "github:$REPO" "$@"

--- a/tests/installer/ps1-pipe.test.mjs
+++ b/tests/installer/ps1-pipe.test.mjs
@@ -56,3 +56,17 @@ test('#565 install.ps1 invokes its function at the bottom (script still does som
     'install.ps1 must actually invoke Install-Caveman after defining it',
   );
 });
+
+test('npm 12+ opts the root package into git fetching', () => {
+  assert.match(code, /\$npxVersion\s*=\s*\[string\]\(& npx --version\)/i);
+  assert.match(
+    code,
+    /if\s*\(\s*\$npxMajor\s+-ge\s+12\s*\)\s*\{[\s\S]*?& npx --allow-git=root -y/i,
+    'npm 12+ must pass --allow-git=root before the GitHub package spec',
+  );
+  assert.match(
+    code,
+    /else\s*\{\s*& npx -y/i,
+    'older npm versions must keep the legacy npx invocation',
+  );
+});

--- a/tests/installer/shim-npm-version.test.mjs
+++ b/tests/installer/shim-npm-version.test.mjs
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const SH = fs.readFileSync(path.join(REPO_ROOT, 'install.sh'), 'utf8');
+
+function writeExecutable(file, body) {
+  fs.writeFileSync(file, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+}
+
+function runShim(npxVersion) {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-shim-test-'));
+  const argsFile = path.join(temp, 'npx-args');
+
+  try {
+    writeExecutable(path.join(temp, 'node'), 'printf "20\\n"');
+    writeExecutable(path.join(temp, 'npx'), `
+if [ "$1" = "--version" ]; then
+  printf '${npxVersion}\\n'
+  exit 0
+fi
+printf '%s\\n' "$@" > "$NPX_ARGS_FILE"
+`);
+
+    const result = spawnSync('bash', ['-s', '--', '--only', 'claude'], {
+      cwd: temp,
+      input: SH,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${temp}${path.delimiter}${process.env.PATH || ''}`,
+        NPX_ARGS_FILE: argsFile,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    return fs.readFileSync(argsFile, 'utf8').trim().split('\n');
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+test('shell shim opts into root git fetching on npm 12+', {
+  skip: process.platform === 'win32',
+}, () => {
+  assert.deepEqual(runShim('12.0.1'), [
+    '--allow-git=root',
+    '-y',
+    'github:JuliusBrussee/caveman',
+    '--only',
+    'claude',
+  ]);
+});
+
+test('shell shim keeps legacy invocation before npm 12', {
+  skip: process.platform === 'win32',
+}, () => {
+  assert.deepEqual(runShim('11.15.0'), [
+    '-y',
+    'github:JuliusBrussee/caveman',
+    '--only',
+    'claude',
+  ]);
+});


### PR DESCRIPTION
npm 12 defaults git fetches off, causing `EALLOWGIT` errors. This modification adds Bash and PowerShell shims that now detect the presence of npm 12+ and add the `--allow-git=root` flag as appropriate, along with a test suite that independantly tests that the version detection is working. The changes have been tested locally on an intel silicon Mac + homebrew both full install and test-suite execution