### PR TITLE
docs: fix grammar in caveman-compress README

### DIFF
--- a/skills/caveman-compress/README.md
+++ b/skills/caveman-compress/README.md
@@ -71,7 +71,7 @@ All validations passed ✅ — headings, code blocks, URLs, file paths preserved
 
 ## Install
 
-Compress is built in with the `caveman` plugin. Install `caveman` once, then use `/caveman-compress`.
+Compress is built into the `caveman` plugin. Install `caveman` once, then use `/caveman-compress`.
 
 If you need local files, the compress skill lives at:
 


### PR DESCRIPTION
## Summary
- "built in with" conflates two idioms ("built in" and "bundled with"); "built into" is the correct construction.

## Test plan
- Docs-only change, no code/behavior affected.