### PR TITLE
chore(cavecrew-builder): pin model to haiku

### DIFF
--- a/agents/cavecrew-builder.md
+++ b/agents/cavecrew-builder.md
@@ -7,6 +7,7 @@ description: >
   obvious; do NOT use for new features, new files (unless asked), or
   cross-file refactors.
 tools: Read, Edit, Write, Grep, Glob
+model: haiku
 ---
 
 Caveman-ultra. Drop articles/filler. Code/paths exact, backticked. No narration.

--- a/plugins/caveman/agents/cavecrew-builder.md
+++ b/plugins/caveman/agents/cavecrew-builder.md
@@ -7,6 +7,7 @@ description: >
   obvious; do NOT use for new features, new files (unless asked), or
   cross-file refactors.
 tools: Read, Edit, Write, Grep, Glob
+model: haiku
 ---
 
 Caveman-ultra. Drop articles/filler. Code/paths exact, backticked. No narration.


### PR DESCRIPTION
## Problem

`cavecrew-builder` is the only one of the three cavecrew agents without a `model:` field in its frontmatter. Without it the agent inherits the main thread's model, so on an Opus-configured session the builder runs on Opus.

Its siblings are both pinned:

- `agents/cavecrew-investigator.md` — `model: haiku`
- `agents/cavecrew-reviewer.md` — `model: haiku`
- `agents/cavecrew-builder.md` — *(no model field)*

That looks unintended given the agent's own description scopes it to "surgical 1-2 file edit… typo fixes, single-function rewrites, mechanical renames, comment removal, format-preserving tweaks" and it hard-refuses 3+ file scope. It also has no `Bash` tool. That is squarely haiku-tier work, and it fits the plugin's stated goal of cutting token cost.

## Change

Adds `model: haiku` to the `cavecrew-builder` frontmatter, matching its two siblings.

Applied to both synced copies, consistent with how the other agent files are duplicated in this repo:

- `agents/cavecrew-builder.md`
- `plugins/caveman/agents/cavecrew-builder.md`

One line each, no behavior or prompt-body changes.

## Note

If the omission was deliberate — e.g. builder is meant to inherit so it can ride a stronger model when the user configures one — feel free to close this. In that case a comment in the frontmatter would help, since the asymmetry with the other two agents reads as an oversight.