### PR TITLE
fix(skill): drop caveman when the agent asks the user a question

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -63,6 +63,7 @@ Drop caveman when:
 - Multi-step sequences where fragment order or omitted conjunctions risk misread
 - Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` — order unclear without articles/conjunctions)
 - User asks to clarify or repeats question
+- You ask the user a question — clarifying question, option labels and descriptions, trade-off framing. User must be able to answer right first time.
 
 Resume caveman after clear part done.
 
@@ -72,6 +73,11 @@ Example — destructive op:
 > DROP TABLE users;
 > ```
 > Caveman resume. Verify backup exist first.
+
+Example — asking user:
+> Two ways to handle token refresh: refresh on every request (simpler, more network calls), or refresh only when the token is within 60s of expiry (fewer calls, needs clock-skew tolerance). Which do you want?
+>
+> Caveman resume after answer.
 
 ## Boundaries
 


### PR DESCRIPTION
## What

Adds one trigger to the `## Auto-Clarity` list in `skills/caveman/SKILL.md`: drop caveman when **the agent asks the user a question**. Plus a worked example, in the same shape as the existing destructive-op one.

## Why

Auto-Clarity currently covers questions the *user* asks ("User asks to clarify or repeats question") but not questions the *agent* asks. Those are the case where compression hurts most.

A clarifying question is the one output the user has to act on precisely. Stripped of articles and conjunctions, option labels stop being distinguishable — "refresh every request simpler more calls or refresh near expiry fewer calls needs skew tolerance which" — so the user picks the wrong option or has to ask what was meant. That round trip costs more tokens than the compression saved, and it lands exactly when the agent is blocked and waiting.

This is the same logic already accepted for the "compression itself creates technical ambiguity" bullet — a question to the user is that failure mode with a guaranteed cost, since an ambiguous question always produces either a wrong answer or a follow-up.

## Changes

- **`skills/caveman/SKILL.md`** — one bullet added to the Auto-Clarity list, one example block added after the existing destructive-op example. No other section touched.

## How to Review

Diff the `## Auto-Clarity` section. Six lines added, nothing removed or reworded.

## Notes

- **Scope is deliberately narrow.** Only the question itself drops caveman, not the answer or the surrounding work. The existing "Resume caveman after clear part done" already covers going back — the example makes that explicit with "Caveman resume after answer." This is aimed at not widening the drift problem in #303.
- **Synced copy left alone.** Per `CLAUDE.md`, `plugins/caveman/skills/caveman/SKILL.md` is CI-synced from this file, so I didn't touch it. `tests/verify_repo.py` will flag the parity gap until `sync-skill.yml` runs on merge to main.
- **Unrelated observation, not fixed here:** the hardcoded fallback ruleset in `src/hooks/caveman-activate.js:137` still carries the pre-#239 run-on version of this sentence, so standalone installs without a `skills/` dir miss the compression-ambiguity trigger too. Looked deliberate (the comment calls it "the minimum viable ruleset"), so I left it out rather than widening this diff. Happy to include it if you'd rather they stay in sync.
- Checked for overlap first: #515/#510 cover the final turn-closing answer, #685 covers localizing the example. Neither covers this.
- `tests/test_hooks.py` passes (7/7); verified the SessionStart hook renders the new bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
