### PR TITLE
fix(compress): pin utf-8 and newline on file I/O

### DIFF
--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -39,6 +39,38 @@ def split_frontmatter(text: str):
         return m.group(1), m.group(2)
     return "", text
 
+
+def read_exact(path: Path) -> str:
+    """Read text as UTF-8 with no newline translation.
+
+    ``Path.read_text`` grew a ``newline`` parameter only in 3.13 and the skill
+    supports 3.10+, so go through ``open`` to keep older interpreters working.
+    """
+    with path.open(encoding="utf-8", errors="ignore", newline="") as fh:
+        return fh.read()
+
+
+def _lf(text: str) -> str:
+    """Normalize to LF so CRLF and LF copies of the same text compare equal."""
+    return text.replace("\r\n", "\n")
+
+
+def match_line_endings(text: str, reference: str) -> str:
+    """Rewrite text's line endings to match the reference document's.
+
+    Every read and write here pins ``newline=""`` so Python performs no
+    translation of its own — otherwise ``write_text`` emits CRLF on Windows and
+    silently rewrites every line of the user's file. Claude always returns LF,
+    so a CRLF source still needs its endings restored explicitly.
+    """
+    crlf = reference.count("\r\n")
+    lf = reference.count("\n") - crlf
+    normalized = _lf(text)
+    if crlf > lf:
+        return normalized.replace("\n", "\r\n")
+    return normalized
+
+
 # Filenames and paths that almost certainly hold secrets or PII. Compressing
 # them ships raw bytes to the Anthropic API — a third-party data boundary that
 # developers on sensitive codebases cannot cross. detect.py already skips .env
@@ -246,7 +278,7 @@ def compress_file(filepath: Path) -> bool:
         print("Skipping (not natural language)")
         return False
 
-    original_text = filepath.read_text(errors="ignore")
+    original_text = read_exact(filepath)
     # Store backup outside the source directory so skill auto-loaders don't
     # re-ingest the `.original.md` copy as a live file. Mirror the source's
     # parent-dir name + stem under a platform-aware base to reduce collisions.
@@ -287,21 +319,25 @@ def compress_file(filepath: Path) -> bool:
 
     # Compare the BODY (not the whole file) — frontmatter is preserved verbatim
     # and would never change, so identity must be judged on the compressible part.
-    if compressed_body.strip() == body.strip():
+    # Normalize line endings first: the body keeps the source file's CRLF while
+    # Claude always answers in LF, so a raw compare would never match on a CRLF
+    # file and the no-op guard below would stop firing entirely.
+    if _lf(compressed_body).strip() == _lf(body).strip():
         print("❌ Compression aborted: output is identical to input.")
         print("   Likely causes: Claude refused, returned the prompt verbatim, or the file is")
         print("   already in caveman form. Original file is untouched (no backup created).")
         return False
 
-    # Reassemble: frontmatter (verbatim) + compressed body
-    compressed = frontmatter + compressed_body
+    # Reassemble: frontmatter (verbatim) + compressed body, then restore the
+    # source file's line endings — Claude always answers in LF.
+    compressed = match_line_endings(frontmatter + compressed_body, original_text)
 
     # Save original as backup, then verify the backup readback before
     # touching the input file. If the filesystem dropped bytes (encoding,
     # antivirus, disk full), unlink the bad backup and abort instead of
     # leaving the user with a corrupt backup + compressed primary.
-    backup_path.write_text(original_text)
-    backup_readback = backup_path.read_text(errors="ignore")
+    backup_path.write_text(original_text, encoding="utf-8", newline="")
+    backup_readback = read_exact(backup_path)
     if backup_readback != original_text:
         print(f"❌ Backup write verification failed: {backup_path}")
         print("   In-memory original differs from on-disk backup. Aborting before touching the input file.")
@@ -310,7 +346,7 @@ def compress_file(filepath: Path) -> bool:
         except OSError:
             pass
         return False
-    filepath.write_text(compressed)
+    filepath.write_text(compressed, encoding="utf-8", newline="")
 
     # Step 2: Validate + Retry
     for attempt in range(MAX_RETRIES):
@@ -328,15 +364,16 @@ def compress_file(filepath: Path) -> bool:
 
         if attempt == MAX_RETRIES - 1:
             # Restore original on failure
-            filepath.write_text(original_text)
+            filepath.write_text(original_text, encoding="utf-8", newline="")
             backup_path.unlink(missing_ok=True)
             print("❌ Failed after retries — original restored")
             return False
 
         print("Fixing with Claude...")
-        compressed = call_claude(
-            build_fix_prompt(original_text, compressed, result.errors)
+        compressed = match_line_endings(
+            call_claude(build_fix_prompt(original_text, compressed, result.errors)),
+            original_text,
         )
-        filepath.write_text(compressed)
+        filepath.write_text(compressed, encoding="utf-8", newline="")
 
     return True

--- a/skills/caveman-compress/scripts/detect.py
+++ b/skills/caveman-compress/scripts/detect.py
@@ -90,7 +90,7 @@ def detect_file_type(filepath: Path) -> str:
     # Extensionless files (like CLAUDE.md, TODO) — check content
     if not ext:
         try:
-            text = filepath.read_text(errors="ignore")
+            text = filepath.read_text(encoding="utf-8", errors="ignore")
         except (OSError, PermissionError):
             return "unknown"
 

--- a/skills/caveman-compress/scripts/validate.py
+++ b/skills/caveman-compress/scripts/validate.py
@@ -28,7 +28,7 @@ class ValidationResult:
 
 
 def read_file(path: Path) -> str:
-    return path.read_text(errors="ignore")
+    return path.read_text(encoding="utf-8", errors="ignore")
 
 
 # ---------- Extractors ----------

--- a/tests/test_compress_encoding.py
+++ b/tests/test_compress_encoding.py
@@ -1,0 +1,146 @@
+"""Tests for the Windows text-mode file I/O guards in `compress_file` (issue #762).
+
+`Path.read_text` / `Path.write_text` default to the locale encoding and to CRLF
+translation on Windows. That corrupted every non-ASCII character the model
+emitted (issue #686 and friends) and silently rewrote the line endings of every
+file the compressor touched. These tests pin the fix: output is always UTF-8,
+the source file's line endings survive the round-trip, and the backup stays a
+byte-for-byte copy of the input.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "skills" / "caveman-compress"))
+
+from scripts import compress as compress_mod  # noqa: E402
+
+# Claude answers in LF and reaches for typographic punctuation unprompted. An
+# em dash is exactly the character that lands as a bare 0x97 under cp1252.
+COMPRESSED_LF = "# Heading\n\nFox jump dog — done.\n"
+EM_DASH_UTF8 = b"\xe2\x80\x94"
+SOURCE_LF = "# Heading\n\nThe quick brown fox jumps over the lazy dog.\n"
+
+
+class MatchLineEndingsTests(unittest.TestCase):
+    def test_lf_reference_yields_lf(self):
+        self.assertEqual(
+            compress_mod.match_line_endings("a\r\nb\r\n", "x\ny\n"), "a\nb\n"
+        )
+
+    def test_crlf_reference_yields_crlf(self):
+        self.assertEqual(
+            compress_mod.match_line_endings("a\nb\n", "x\r\ny\r\n"), "a\r\nb\r\n"
+        )
+
+    def test_reference_without_newlines_defaults_to_lf(self):
+        self.assertEqual(compress_mod.match_line_endings("a\nb\n", "x"), "a\nb\n")
+
+    def test_is_idempotent(self):
+        once = compress_mod.match_line_endings("a\nb\n", "x\r\ny\r\n")
+        twice = compress_mod.match_line_endings(once, "x\r\ny\r\n")
+        self.assertEqual(once, twice)
+
+
+class ReadExactTests(unittest.TestCase):
+    def _written(self, tmp: str, raw: bytes) -> Path:
+        path = Path(tmp) / "sample.md"
+        path.write_bytes(raw)
+        return path
+
+    def test_preserves_crlf(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._written(tmp, b"one\r\ntwo\r\n")
+            self.assertEqual(compress_mod.read_exact(path), "one\r\ntwo\r\n")
+
+    def test_preserves_lf(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._written(tmp, b"one\ntwo\n")
+            self.assertEqual(compress_mod.read_exact(path), "one\ntwo\n")
+
+    def test_decodes_utf8_regardless_of_locale(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._written(tmp, "dash — here".encode("utf-8"))
+            self.assertEqual(compress_mod.read_exact(path), "dash — here")
+
+
+class CompressTextModeTests(unittest.TestCase):
+    """End-to-end through `compress_file` with the model call stubbed out."""
+
+    def _compress(self, raw: bytes):
+        """Run the real orchestrator over `raw`; return (output, backup) bytes.
+
+        The backup data dir is redirected into the temp tree so the out-of-tree
+        backup (issue #420) never lands in the developer's real home dir.
+        """
+        with tempfile.TemporaryDirectory() as tmp, \
+             tempfile.TemporaryDirectory() as data_home, \
+             mock.patch.dict(os.environ, {"XDG_DATA_HOME": data_home,
+                                          "LOCALAPPDATA": data_home}):
+            path = Path(tmp) / "task.md"
+            path.write_bytes(raw)
+            with mock.patch.object(compress_mod, "call_claude",
+                                   return_value=COMPRESSED_LF), \
+                 mock.patch.object(compress_mod, "validate") as v:
+                v.return_value = mock.Mock(is_valid=True, errors=[], warnings=[])
+                ok = compress_mod.compress_file(path)
+            self.assertTrue(ok)
+            backup = compress_mod.backup_dir_for(path.resolve()) / "task.original.md"
+            return path.read_bytes(), backup.read_bytes()
+
+    def test_non_ascii_output_is_utf8(self):
+        out, _ = self._compress(SOURCE_LF.encode("utf-8"))
+        self.assertIn(EM_DASH_UTF8, out)
+        self.assertNotIn(b"\x97", out)
+        out.decode("utf-8")  # raises if the locale codec leaked through
+
+    def test_lf_source_stays_lf(self):
+        out, _ = self._compress(SOURCE_LF.encode("utf-8"))
+        self.assertNotIn(b"\r", out)
+
+    def test_crlf_source_stays_crlf(self):
+        raw = SOURCE_LF.replace("\n", "\r\n").encode("utf-8")
+        out, _ = self._compress(raw)
+        self.assertIn(b"\r\n", out)
+        self.assertNotIn(b"\n", out.replace(b"\r\n", b""))
+
+    def test_backup_is_byte_identical_for_lf_source(self):
+        raw = SOURCE_LF.encode("utf-8")
+        _, backup = self._compress(raw)
+        self.assertEqual(backup, raw)
+
+    def test_backup_is_byte_identical_for_crlf_source(self):
+        raw = SOURCE_LF.replace("\n", "\r\n").encode("utf-8")
+        _, backup = self._compress(raw)
+        self.assertEqual(backup, raw)
+
+    def test_no_op_guard_still_fires_on_crlf_source(self):
+        """A CRLF file whose body Claude echoes back in LF must not be touched.
+
+        The body carries the source's CRLF while Claude always answers LF, so
+        the no-op comparison has to normalize before matching — otherwise the
+        guard silently stops firing on every CRLF file.
+        """
+        raw = SOURCE_LF.replace("\n", "\r\n").encode("utf-8")
+        with tempfile.TemporaryDirectory() as tmp, \
+             tempfile.TemporaryDirectory() as data_home, \
+             mock.patch.dict(os.environ, {"XDG_DATA_HOME": data_home,
+                                          "LOCALAPPDATA": data_home}):
+            path = Path(tmp) / "task.md"
+            path.write_bytes(raw)
+            with mock.patch.object(compress_mod, "call_claude",
+                                   return_value=SOURCE_LF):
+                ok = compress_mod.compress_file(path)
+            self.assertFalse(ok)
+            self.assertEqual(path.read_bytes(), raw)
+            backup = compress_mod.backup_dir_for(path.resolve()) / "task.original.md"
+            self.assertFalse(backup.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #762. Also covers #686 (and #652, #655, #533).

## What

`Path.read_text` / `Path.write_text` default to the locale encoding **and** to CRLF translation on Windows. Both defaults mutate the user's file.

**Encoding.** Non-ASCII output goes out in the locale codec. An em dash becomes a bare `0x97` under cp1252, so the file stops being valid UTF-8. `validate.py` then read it back through the same default, saw a correct em dash, and printed `Validation passed` — the round-trip is self-consistent and wrong, so the corruption ships silently.

**Line endings.** Every processed file comes back CRLF. Measured on a real run: a 67-line LF file restored from backup at +67 bytes, one CR per line. `git diff` then reports every line changed.

## Overlap with #683

#683 already fixes the encoding half, and this PR contains that same change — the two touch identical call sites, so splitting them would just conflict. What this adds on top:

- `detect.py:93`, which #686's body lists as needing the fix but #683 misses
- the newline half, which #683 does not touch; after it merges the CRLF rewrite is still there
- regression tests

Happy to rebase down to newline-only if #683 lands first. No claim on that work intended.

## Notes

- Reads go through `open()` rather than `read_text(newline=...)`. That parameter is 3.13+ and `CLAUDE.md` states the skill supports Python 3.10+.
- `validate.py` deliberately does **not** get `newline=""`. The validator needs universal-newline normalization so a CRLF original and an LF candidate still compare equal — pinning it there would make `validate_code_blocks` fail on every CRLF file.
- The no-op comparison needed normalizing too. The body now carries the source's CRLF while Claude always answers LF, so `compressed_body.strip() == body.strip()` would never match and the "output identical to input" guard would stop firing on CRLF files entirely. The existing `test_identical_compressed_output_does_not_touch_disk` caught this — it is green again.

## Tests

New `tests/test_compress_encoding.py`, 13 cases: `match_line_endings` unit tests, `read_exact` round-trips, and end-to-end through `compress_file` with `call_claude` stubbed, so no API key is needed.

```
python3 -m unittest tests.test_compress_encoding   # Ran 13 tests, OK
python3 -m unittest tests.test_compress_safety     # Ran 5 tests, OK
```

`tests.test_hooks` reports 3 errors and `npm test` 2 failures on my Windows box. Both are identical on a clean checkout of `main` and unrelated to this change.

CI will resync `plugins/caveman/skills/caveman-compress/scripts/` on merge.
