### PR TITLE
AB#00000: add caveman-test skill for terse test generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Six levels. Switch anytime with `/caveman <level>`. Level sticks until you chang
 | `/caveman-review` | One-line PR comments: `L42: 🔴 bug: user null. Add guard.` |
 | `/caveman-stats` | Real session token usage, lifetime savings, USD. Tweetable line with `--share`. |
 | `/caveman-compress <file>` | Rewrite a memory file (like `CLAUDE.md`) into caveman-speak. Cuts ~46% input tokens **every session after**. Code, URLs, paths byte-preserved. |
+| `/caveman-test` | Terse test cases. One behavior per test, matches repo's existing framework. |
 | `caveman-shrink` | MCP middleware. Wraps any MCP server, compresses its tool descriptions. [npm](https://www.npmjs.com/package/caveman-shrink). |
 | `cavecrew-*` | Caveman subagents (investigator, builder, reviewer). ~60% fewer tokens than vanilla, so main context lasts longer. |
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -594,7 +594,7 @@ function installViaSkills(ctx, prov) {
 
 // ── hermes native install ──────────────────────────────────────────────────
 // Drops the caveman skills into ~/.hermes/skills/productivity/ (or HERMES_HOME if set).
-const HERMES_SKILL_DIRS = ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'cavecrew'];
+const HERMES_SKILL_DIRS = ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'caveman-test', 'cavecrew'];
 
 function hermesConfigDir() {
   // Hermes uses ~/.hermes by default, or HERMES_HOME env var.
@@ -655,9 +655,9 @@ function installHermes(ctx) {
 // opencode.json with a "plugin" array entry. Mirrors the Claude Code hook
 // architecture as closely as opencode allows — only the statusline is missing
 // (opencode's TUI exposes no plugin-writable badge).
-const OPENCODE_SKILL_DIRS  = ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'cavecrew'];
+const OPENCODE_SKILL_DIRS  = ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'caveman-test', 'cavecrew'];
 const OPENCODE_AGENT_FILES = ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md'];
-const OPENCODE_COMMAND_FILES = ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-compress.md', 'caveman-stats.md', 'caveman-help.md'];
+const OPENCODE_COMMAND_FILES = ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-compress.md', 'caveman-stats.md', 'caveman-help.md', 'caveman-test.md'];
 const OPENCODE_PLUGIN_REL = './plugins/caveman/plugin.js';
 const OPENCODE_AGENTS_MD_SENTINEL = 'Respond terse like smart caveman';
 // Marker fence for the opencode AGENTS.md ruleset block. Same convention as

--- a/commands/caveman-test.md
+++ b/commands/caveman-test.md
@@ -1,0 +1,5 @@
+---
+description: Generate terse caveman-style test cases
+---
+
+Write test cases for the code in question. Match the repo's existing test framework and conventions. One logical behavior per test: happy path, boundary value, error case, or branch visible in the diff. Test names state condition and expected outcome. No redundant setup, no comments restating assertions, no debug prints. Reuse existing fixtures/mocks. Output test code only — do not modify the implementation or run the suite.

--- a/commands/caveman-test.toml
+++ b/commands/caveman-test.toml
@@ -1,0 +1,2 @@
+description = "Generate terse caveman-style test cases"
+prompt = "Write test cases for the code in question. Match the repo's existing test framework and conventions. One logical behavior per test: happy path, boundary value, error case, or branch visible in the diff. Test names state condition and expected outcome. No redundant setup, no comments restating assertions, no debug prints. Reuse existing fixtures/mocks. Output test code only — do not modify the implementation or run the suite."

--- a/skills/caveman-help/SKILL.md
+++ b/skills/caveman-help/SKILL.md
@@ -30,6 +30,7 @@ Mode stick until changed or session end.
 | **caveman-commit** | `/caveman-commit` | Terse commit messages. Conventional Commits. ≤50 char subject. |
 | **caveman-review** | `/caveman-review` | One-line PR comments: `L42: bug: user null. Add guard.` |
 | **caveman-compress** | `/caveman-compress <file>` | Compress .md files to caveman prose. Saves ~46% input tokens. |
+| **caveman-test** | `/caveman-test` | Terse test cases. One behavior per test, matches repo's framework. |
 | **caveman-help** | `/caveman-help` | This card. |
 
 ## Deactivate

--- a/skills/caveman-test/README.md
+++ b/skills/caveman-test/README.md
@@ -1,0 +1,35 @@
+# caveman-test
+
+Terse, high-coverage test generation. One behavior per test, no filler.
+
+## What it does
+
+Generates test cases matching the repo's existing test framework and conventions. Each test targets one logical behavior — happy path, boundary value, error case, or a branch visible in the diff. Test names state the condition and expected outcome directly. No redundant setup, no comments restating the assertion, no debug prints.
+
+Writes test code only. Does not modify the implementation, does not run the suite, does not install new test dependencies.
+
+## How to invoke
+
+```
+/caveman-test
+```
+
+Also triggers on phrases like "write tests", "add test coverage", "test this function".
+
+## Example output
+
+Function: `divide(a, b)` throws on `b === 0`.
+
+```python
+def test_divide_normal_returnsQuotient():
+    assert divide(10, 2) == 5
+
+def test_divide_byZero_raisesValueError():
+    with pytest.raises(ValueError):
+        divide(10, 0)
+```
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — full LLM-facing instructions
+- [Caveman README](../../README.md) — repo overview

--- a/skills/caveman-test/SKILL.md
+++ b/skills/caveman-test/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: caveman-test
+description: >
+  Ultra-compressed test-case generator. Cuts noise from test names and setup
+  while preserving full coverage intent. One assertion focus per test, terse
+  arrange/act/assert. Matches repo's existing test framework and style. Use
+  when user says "write tests", "add test coverage", "test this function",
+  "/test", or invokes /caveman-test. Auto-triggers when new function/module
+  lacks tests.
+---
+
+Write tests terse and exact. One behavior per test. No filler setup, no redundant assertions.
+
+## Rules
+
+**Test name:** `<unit>_<condition>_<expected>` or framework's native `describe/it` nesting — match whatever convention the repo already uses. State condition and expected outcome, nothing else.
+
+- ❌ `test_that_the_function_works_correctly()`
+- ✅ `parseAmount_negativeInput_throwsRangeError()`
+
+**Structure:** Arrange / Act / Assert, each on its own line(s), no blank-line ceremony beyond what improves readability. No comments labeling "// arrange" / "// act" / "// assert" unless repo convention already uses them.
+
+**Coverage, not padding:**
+- One logical assertion focus per test — split multi-behavior tests
+- Cover: happy path, boundary values, error/invalid input, and any branch visible in the diff
+- Skip redundant permutations that don't exercise new logic
+- Reuse existing fixtures/factories/mocks already in the repo — don't reinvent them
+
+**Drop:**
+- Explanatory comments restating the assertion ("// check that result is 5")
+- Mock setup for dependencies the test doesn't touch
+- `console.log` / debug prints
+- Snapshot tests for logic that has a clear expected value — assert the value directly
+
+**Keep:**
+- Exact expected values, not `toBeTruthy()` when the value is knowable
+- Edge cases implied by the code's own branches (null, empty, zero, max, off-by-one)
+- Async/error assertions in the framework's idiomatic form (`assertRaises`, `expect().rejects`, `try/fail/catch`)
+
+## Examples
+
+Function: `divide(a, b)` throws on `b === 0`.
+
+❌
+```python
+def test_divide():
+    # test that divide works
+    result = divide(10, 2)
+    assert result == 5
+    # test division by zero
+    try:
+        divide(10, 0)
+        assert False, "should have raised"
+    except Exception as e:
+        assert True
+```
+
+✅
+```python
+def test_divide_normal_returnsQuotient():
+    assert divide(10, 2) == 5
+
+def test_divide_byZero_raisesValueError():
+    with pytest.raises(ValueError):
+        divide(10, 0)
+```
+
+## Auto-Clarity
+
+Drop terse mode for: security-sensitive logic (auth, crypto, payment) — write full docstring explaining the threat model each test guards against; flaky-prone async/timing tests — explain the race being tested, not just assert it; and any test whose purpose isn't obvious from its name alone.
+
+## Boundaries
+
+Writes test code only — does not modify the implementation under test, does not run the test suite, does not install test frameworks or fixtures not already in the repo. Output the test file/block ready to paste. "stop caveman-test" or "normal mode": revert to verbose test-writing style.

--- a/src/hooks/caveman-config.js
+++ b/src/hooks/caveman-config.js
@@ -22,7 +22,7 @@ const os = require('os');
 const VALID_MODES = [
   'off', 'lite', 'full', 'ultra',
   'wenyan-lite', 'wenyan', 'wenyan-full', 'wenyan-ultra',
-  'commit', 'review', 'compress'
+  'commit', 'review', 'compress', 'test'
 ];
 
 function getConfigDir() {

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -10,7 +10,7 @@ const { getDefaultMode, safeWriteFlag, readFlag, recordModeChange, VALID_MODES }
 
 // Modes handled by their own slash commands (/caveman-commit, etc.) — not
 // selectable via /caveman <arg>.
-const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
+const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress', 'test']);
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');
@@ -118,6 +118,8 @@ process.stdin.on('end', () => {
         mode = 'review';
       } else if (cmd === '/caveman-compress' || cmd === '/caveman:caveman-compress') {
         mode = 'compress';
+      } else if (cmd === '/caveman-test' || cmd === '/caveman:caveman-test') {
+        mode = 'test';
       } else if (cmd === '/caveman' || cmd === '/caveman:caveman') {
         // Bare /caveman → activate at configured default
         if (!arg) {


### PR DESCRIPTION
Fixes AB#00000

## Summary
- Add `/caveman-test` skill: terse test-case generator mirroring `caveman-commit`/`caveman-review` structure

## AI Attribution
- AI-Generated (>=80% effort): Yes
- AI Contribution: 95%
- AI Tool(s): Claude Code
- AI review before human review: No
- AI review tool: N/A

## Changes
- New `skills/caveman-test/{SKILL.md,README.md}` — one behavior per test, matches repo's existing test framework, no filler setup
- New `commands/caveman-test.{toml,md}` — Codex/Gemini command stubs
- `src/hooks/caveman-mode-tracker.js` — added `test` as independent mode, wired `/caveman-test` command
- `src/hooks/caveman-config.js` — added `test` to `VALID_MODES`
- `bin/install.js` — added to `HERMES_SKILL_DIRS`, `OPENCODE_SKILL_DIRS`, `OPENCODE_COMMAND_FILES`
- `skills/caveman-help/SKILL.md`, `README.md` — added skill reference row

## Change Preview
N/A (not IaC)

## Blast Radius
- Services affected: N/A
- Environments: N/A
- Breaking change: No

## Testing
- [ ] Unit tests pass
- [ ] Tested manually via `/caveman-test` in a live session
