### PR TITLE
(first PR, may have done wrong) fix(hooks): match /caveman-stats when wrapped in <command-name> tags

### DIFF
--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -73,7 +73,35 @@ process.stdin.on('end', () => {
     // /caveman-stats [--share] — block the prompt and inject stats output as
     // the hook's reason. The script reads the active session log, so we pass
     // transcript_path through when Claude Code provides it.
-    const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
+    // The desktop app and SDK entrypoints do not pass the raw typed text: a
+    // slash command arrives as "<command-name>/caveman:caveman-stats</command-name>",
+    // with any arguments in a separate ',
+      transcript_path: sess,
+    }),
+  });
+  const parsed = JSON.parse(out);
+  assert.strictEqual(parsed.decision, 'block');
+  assert.match(parsed.reason, /^🪨 Saved 650 output tokens/);
+});
+
+// A wrapped invocation of any OTHER command must not be mistaken for
+// /caveman-stats — no stats block, reinforcement branch as usual.
+test('mode tracker ignores unrelated wrapped commands', (tmp) => {
+  const claudeDir = path.join(tmp, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, '.caveman-active'), 'full');
+  const out = execFileSync(process.execPath, [TRACKER], {
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir, HOME: tmp },
+    input: JSON.stringify({
+      prompt: '<command-name>/caveman:caveman-help</command-name>',
+      transcript_path: '',
+    }),
+  });
+  const parsed = JSON.parse(out);
+  assert.ok(!parsed.decision, 'must not block on an unrelated command');
+  assert.ok(parsed.hookSpecificOutput, 'expected the reinforcement branch');
+});
     if (statsMatch) {
       const tailArgs = (statsMatch[1] || '').trim().split(/\s+/).filter(Boolean);
       try {


### PR DESCRIPTION
### Problem

`/caveman-stats` produces no output at all in the Claude Code desktop app (and via the Agent SDK entrypoint). Nothing renders — no stats, no error. Verified against `main` at `0d95a81`.

Those entrypoints do not pass the raw typed text to the `UserPromptSubmit` hook. A slash command arrives as:

```xml
<command-message>caveman:caveman-stats</command-message>
<command-name>/caveman:caveman-stats</command-name>
```

with any arguments in a separate `<command-args>` tag. 

Because of this, the anchored match in `src/hooks/caveman-mode-tracker.js:76`:

```javascript
const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
```

never matches — after the #598 whitespace collapse the prompt is a single line, but it still starts with `<`, not `/`. The stats branch is skipped and control falls through to the per-turn reinforcement branch at the bottom of the hook.

#### Why this failure mode is confusing
* The hook still emits its reinforcement line, so it looks alive rather than broken.
* `skills/caveman-stats/SKILL.md` tells the model the hook returns `decision: "block"` with the numbers, and *"The user sees the numbers immediately."*
* The model therefore reports that the stats are on screen and that it cannot read them — a plausible, wrong answer, on both sides. It took me a second session to work out that nothing had rendered because nothing had generated it.

`src/hooks/caveman-stats.js` is not at fault. Run directly it produces correct output; only the dispatcher misses.

#### Reproduction
Reproduce on `main` — the input has to be built as valid JSON, since a literal newline inside a JSON string makes the hook's own `JSON.parse` throw and silently emit nothing:

```bash
node -e "
const {execFileSync} = require('child_process');
for (const p of ['<command-name>/caveman:caveman-stats</command-name>', '/caveman-stats']) {
  const out = execFileSync(process.execPath, ['src/hooks/caveman-mode-tracker.js'],
    { input: JSON.stringify({ prompt: p, transcript_path: '' }), encoding: 'utf8' });
  console.log(JSON.stringify(p), '=>', out || '(empty)');
}"
```

On `main`, the wrapped form returns no stats block; the raw form does.

---

### Fix

Unwrap `<command-name>` and `<command-args>` before matching. Terminal invocations pass the raw text, hit `cmdTag === null`, and take exactly the same path as before — no behavior change there.

> **Scope note:** This fixes the stats dispatch only. The `/caveman` mode-switch branch below it (`prompt.startsWith('/caveman')`) has the same blind spot, so `/caveman lite` in the desktop app does not switch levels either — the flag stays at whatever it was:
> * **Raw:** `/caveman lite` -> `flag = lite`
> * **Wrapped:** `/caveman:caveman + args lite` -> `flag = full` *(unchanged)*
> 
> I left that alone rather than widen the diff. Happy to send it as a follow-up, or to fold it in here if you would rather have one change — it is the same unwrap applied to the `startsWith` check.

---

### Tests

Three tests appended to `tests/test_caveman_stats.js`:
1. The wrapped invocation returns a stats block.
2. `<command-args>--share</command-args>` forwards the flag (mirrors the existing mode tracker forwards `--share` test, same 650-token fixture).
3. A wrapped unrelated command (`/caveman:caveman-help`) is not mistaken for `/caveman-stats`.

The first two fail on `main`, pass with the fix.

#### Test Results

| Test Suite | Result |
| :--- | :--- |
| `test_caveman_stats.js` | 40 passed, 0 failed |
| `test_caveman_init.js` | 8 passed, 0 failed |
| `test_mcp_shrink.js` | 18 passed, 0 failed |
| `test_repo_local_config.js` | 12 passed, 0 failed |
| `test_mode_tracker_stdin.js` | 2 passed, 0 failed |
| `test_cavecrew_model_overrides.js` | 24 passed |

*Note on un-run suites:* 
* `test_symlink_flag.js` fails identically on unmodified `main` (`EPERM: operation not permitted, symlink` — Windows requires elevation or Developer Mode).
* Python suites (including `test_mode_tracker.py`) have no interpreter on this machine.

---

### Environment

* **Client:** Claude Code 2.1.219 (Desktop App entrypoint)
* **OS:** Windows 11

*The wrapper format is entrypoint-specific rather than version-specific, so anyone running caveman outside the terminal is affected.*

---

### Separate Gap (Not Fixed Here)

Needs a rate-card decision rather than a code one: `MODEL_OUTPUT_PRICE_PER_M` in `caveman-stats.js` has no entry for the Claude 5 family, so `priceForModel('claude-opus-5')` returns `null` and the `Est. saved (USD)` line is silently omitted. Token counts stay correct. Glad to send that as a second PR if you say which rates you want listed.