### PR TITLE
fix(shrink): stop corrupting multi-byte characters at chunk boundaries

### DIFF
--- a/src/mcp-servers/caveman-shrink/index.js
+++ b/src/mcp-servers/caveman-shrink/index.js
@@ -57,18 +57,8 @@ upstream.on('exit', (code, signal) => {
 // JSON-RPC framing over stdio: messages are separated by newlines (the
 // MCP stdio transport uses LSP-like content but most servers emit one JSON
 // object per line). We line-buffer in both directions and parse opportunistically.
-function makeLineBuffer(onLine) {
-  let buf = '';
-  return chunk => {
-    buf += chunk.toString('utf8');
-    let nl;
-    while ((nl = buf.indexOf('\n')) !== -1) {
-      const line = buf.slice(0, nl);
-      buf = buf.slice(nl + 1);
-      if (line.trim()) onLine(line);
-    }
-  };
-}
+// Lives in line-buffer.js so the chunk-boundary handling is unit-testable.
+const { makeLineBuffer } = require('./line-buffer');
 
 function transformResponse(msg) {
   // Compress description fields on list-style responses. Match by method

--- a/src/mcp-servers/caveman-shrink/line-buffer.js
+++ b/src/mcp-servers/caveman-shrink/line-buffer.js
@@ -1,0 +1,36 @@
+// Newline-delimited framing for the upstream MCP stdio stream.
+//
+// Node hands stdout to a 'data' listener in arbitrary byte-sized chunks with no
+// regard for character boundaries. Decoding each chunk independently with
+// Buffer#toString('utf8') therefore destroys any multi-byte character that
+// happens to straddle a chunk boundary: the trailing bytes of the split
+// character decode to U+FFFD in one chunk and the leading bytes to U+FFFD in
+// the next. The resulting line is still valid JSON, so nothing downstream
+// notices — the model just receives a corrupted tool description.
+//
+// StringDecoder exists for exactly this: it retains an incomplete trailing
+// sequence and emits it once the continuation bytes arrive.
+//
+// Exported standalone so the framing is unit-testable without re-running the
+// CLI entry point (index.js spawns the upstream as soon as it is required),
+// mirroring spawn-options.js.
+
+'use strict';
+
+const { StringDecoder } = require('string_decoder');
+
+function makeLineBuffer(onLine) {
+  const decoder = new StringDecoder('utf8');
+  let buf = '';
+  return chunk => {
+    buf += typeof chunk === 'string' ? chunk : decoder.write(chunk);
+    let nl;
+    while ((nl = buf.indexOf('\n')) !== -1) {
+      const line = buf.slice(0, nl);
+      buf = buf.slice(nl + 1);
+      if (line.trim()) onLine(line);
+    }
+  };
+}
+
+module.exports = { makeLineBuffer };

--- a/src/mcp-servers/caveman-shrink/package.json
+++ b/src/mcp-servers/caveman-shrink/package.json
@@ -26,6 +26,7 @@
     "index.js",
     "compress.js",
     "spawn-options.js",
+    "line-buffer.js",
     "README.md"
   ]
 }

--- a/tests/test_mcp_shrink.js
+++ b/tests/test_mcp_shrink.js
@@ -13,6 +13,9 @@ const { compress, compressDescriptionsInPlace } = require(
 const { getSpawnOptions } = require(
   path.join(ROOT, 'src', 'mcp-servers', 'caveman-shrink', 'spawn-options.js')
 );
+const { makeLineBuffer } = require(
+  path.join(ROOT, 'src', 'mcp-servers', 'caveman-shrink', 'line-buffer.js')
+);
 
 let passed = 0;
 let failed = 0;
@@ -216,6 +219,60 @@ test('package.json "files" ships every module the entry points require (#597)', 
       queue.push(dep);
     }
   }
+});
+
+// ── Line framing across chunk boundaries ────────────────────────────────────
+// Node delivers stdout to a 'data' listener in arbitrary byte-sized chunks. A
+// per-chunk Buffer#toString('utf8') mangles any multi-byte character split
+// across two chunks into U+FFFD, and because the line still parses as JSON the
+// corruption reaches the model silently as a mangled tool description.
+
+test('reassembles a multi-byte character split across chunks', () => {
+  const payload = JSON.stringify({
+    jsonrpc: '2.0', id: 1,
+    result: { tools: [{ name: 't', description: '读取文件 — reads a file 🎉' }] }
+  }) + '\n';
+  const full = Buffer.from(payload, 'utf8');
+  // Cut one byte into the 3-byte '读' so its sequence straddles the boundary.
+  const cut = full.indexOf(Buffer.from('读', 'utf8')) + 1;
+
+  const lines = [];
+  const feed = makeLineBuffer(l => lines.push(l));
+  feed(full.subarray(0, cut));
+  feed(full.subarray(cut));
+
+  assert.equal(lines.length, 1, 'expected exactly one framed line');
+  assert.ok(!lines[0].includes('�'),
+    `replacement character in reassembled line: ${lines[0]}`);
+  assert.equal(JSON.parse(lines[0]).result.tools[0].description,
+    '读取文件 — reads a file 🎉');
+});
+
+test('survives a byte-at-a-time stream', () => {
+  const payload = JSON.stringify({ result: { tools: [{ description: '日本語 ✅ café' }] } }) + '\n';
+  const full = Buffer.from(payload, 'utf8');
+  const lines = [];
+  const feed = makeLineBuffer(l => lines.push(l));
+  for (const byte of full) feed(Buffer.from([byte]));
+
+  assert.equal(lines.length, 1);
+  assert.equal(JSON.parse(lines[0]).result.tools[0].description, '日本語 ✅ café');
+});
+
+test('emits one line per newline-delimited message and drops blanks', () => {
+  const lines = [];
+  const feed = makeLineBuffer(l => lines.push(l));
+  feed(Buffer.from('{"a":1}\n\n  \n{"b":2}\n', 'utf8'));
+  assert.deepStrictEqual(lines, ['{"a":1}', '{"b":2}']);
+});
+
+test('withholds a trailing partial line until its newline arrives', () => {
+  const lines = [];
+  const feed = makeLineBuffer(l => lines.push(l));
+  feed(Buffer.from('{"a":', 'utf8'));
+  assert.deepStrictEqual(lines, [], 'partial line must not be emitted');
+  feed(Buffer.from('1}\n', 'utf8'));
+  assert.deepStrictEqual(lines, ['{"a":1}']);
 });
 
 console.log(`\n${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## What

`makeLineBuffer` decoded each stdout chunk on its own with `Buffer#toString('utf8')`. Node picks those chunk boundaries by byte count, not by character, so any multi-byte character split across two chunks gets destroyed — the trailing bytes decode to U+FFFD in one chunk and the leading bytes to U+FFFD in the next.

The damaged line is still valid JSON, so nothing downstream errors. The model just receives a mangled tool description. Whether a given description survives depends on where the boundaries happen to land, which makes it look intermittent.

No issue filed for this one — found it while reading the proxy.

## Repro

Feeding a `tools/list` response through the current framing, split one byte into the 3-byte `读`:

```
chunks: 71 and 39 bytes
parsed OK  : true
description: ���取文件 — reads a file 🎉
```

End to end through the proxy against a server that writes its response a byte at a time:

```
before   "Sends alert ��� make channel is valid ✅"
after    "Sends alert — make channel is valid ✅"
```

Compression still applies as before — `读取文件的内容。The function will basically just return the contents.` comes out as `读取文件的内容。function will return contents.`

## Fix

`StringDecoder` holds an incomplete trailing sequence until its continuation bytes arrive. That is exactly the case here.

Framing moves to `line-buffer.js` for the same reason `spawn-options.js` was split out — `index.js` spawns the upstream at require time, so nothing in it can be unit-tested in place.

## Tests

Four framing tests. Two of them fail on `main`:

```
✗ reassembles a multi-byte character split across chunks
  replacement character in reassembled line: ...\"description\":\"���取文件 — reads a file 🎉\"...
✗ survives a byte-at-a-time stream
  '��������� ��� caf��' == '日本語 ✅ café'
```

The other two cover the framing behaviour I did not want to regress while moving it: blank-line dropping, and withholding a partial line until its newline arrives.

`line-buffer.js` is added to `files` in the package manifest, which the existing #597 packaging test checks.

## Note on running these

`npm test` only runs `tests/installer/*.test.mjs`, so `tests/test_mcp_shrink.js` is not picked up by it. Ran directly:

```
node tests/test_mcp_shrink.js
22 passed, 0 failed
```

Worth mentioning since CONTRIBUTING says CI runs the suite on every PR — as far as I can tell the only workflow is `sync-skill.yml`, and nothing runs tests. #695 looks like it is addressing that.
