### PR TITLE
fix(compress): reject compression output that is not smaller than input

### DIFF
--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -293,6 +293,18 @@ def compress_file(filepath: Path) -> bool:
         print("   already in caveman form. Original file is untouched (no backup created).")
         return False
 
+    # The whole point of the skill is token reduction, but validate() only
+    # checks structural invariants (headings/code blocks/URLs/paths/bullets/
+    # inline code) — it never compares length. A rewrite that is structurally
+    # faithful but LONGER therefore passes every check and gets written and
+    # reported as a successful "compression". Gate on length here, beside the
+    # identical-output guard, so we abort before any backup or write.
+    if len(compressed_body) >= len(body):
+        print("❌ Compression aborted: output is not smaller than input "
+              f"({len(compressed_body)} >= {len(body)} chars).")
+        print("   Original file is untouched (no backup created).")
+        return False
+
     # Reassemble: frontmatter (verbatim) + compressed body
     compressed = frontmatter + compressed_body
 

--- a/tests/test_compress_safety.py
+++ b/tests/test_compress_safety.py
@@ -67,6 +67,25 @@ class CompressSafetyTests(unittest.TestCase):
             self.assertEqual(path.read_text(), original)
             self.assertFalse((Path(tmp) / "task.original.md").exists())
 
+    def test_expanded_compressed_output_does_not_touch_disk(self):
+        # A structurally faithful but LONGER rewrite passes every validate()
+        # check (same heading, no URLs/code/inline code lost), so without a
+        # length gate it was written and reported as a successful compression.
+        # Isolate the backup data dir so no backup lands in the real home dir.
+        with tempfile.TemporaryDirectory() as tmp, \
+             tempfile.TemporaryDirectory() as data_home, \
+             mock.patch.dict(os.environ, {"XDG_DATA_HOME": data_home, "LOCALAPPDATA": data_home}):
+            original = "# Heading\n\nFox jump dog.\n"
+            expanded = "# Heading\n\nThe quick brown fox jumps over the lazy dog, repeatedly.\n"
+            self.assertGreater(len(expanded), len(original))
+            path = self._file_with(Path(tmp), original)
+            with mock.patch.object(compress_mod, "call_claude", return_value=expanded):
+                ok = compress_mod.compress_file(path)
+            self.assertFalse(ok)
+            self.assertEqual(path.read_text(), original)
+            backup = compress_mod.backup_dir_for(path.resolve()) / "task.original.md"
+            self.assertFalse(backup.exists())
+
     def test_real_compression_writes_backup_and_target(self):
         # Isolate the backup data dir to a temp location so the out-of-tree
         # backup (issue #420) never lands in the developer's real home dir.


### PR DESCRIPTION
Fixes #776

## What

`validate()` checks structure only — headings, code blocks, URLs, paths, bullets, inline code. None of it compares length, and `compress_file()` rejected only an exactly-identical body. A rewrite that keeps every heading and code block but is **longer** passed all checks, overwrote the original, and was reported as a successful compression.

This adds a length gate right beside the existing identical-output guard, before any backup or write, so the original is never touched.

```python
if len(compressed_body) >= len(body):
    print("❌ Compression aborted: output is not smaller than input "
          f"({len(compressed_body)} >= {len(body)} chars).")
    print("   Original file is untouched (no backup created).")
    return False
```

Comparing bodies is the same as comparing files here — `compressed = frontmatter + compressed_body` and the frontmatter is byte-identical on both sides.

## Why here and not in `validate.py`

An error raised inside `validate()` feeds the `MAX_RETRIES` loop, which spends a Claude fix-call that `build_fix_prompt` explicitly cannot satisfy ("DO NOT recompress or rephrase the file") before restoring the original. Burning an API call to reject an expansion seemed wrong in a tool whose point is saving tokens. Aborting at this point creates no backup and never touches the input.

Trade-off, so it is on the record: a standalone `python validate.py <orig> <comp>` still will not report an expansion. `validate()` stays structure-only.

## Test

`tests/test_compress_safety.py` gains `test_expanded_compressed_output_does_not_touch_disk`, next to the existing identical-output test and using the same `XDG_DATA_HOME`/`LOCALAPPDATA` isolation as `test_real_compression_writes_backup_and_target`.

On pre-fix code it fails exactly as the bug describes — `compress_file()` prints `Validation passed` and returns `True` for an output 2.6x larger than the input:

```
AssertionError: True is not false
...
Validation attempt 1
Validation passed
```

```
$ python -m unittest tests.test_compress_safety
Ran 6 tests in 0.072s
OK
```

Note for anyone reproducing on Windows: this suite has 4 pre-existing errors from the `❌` status `print()`s hitting a cp1252 console (the same ones #619 mentions). `PYTHONIOENCODING=utf-8` clears them; I left that alone since several open PRs are already fixing the encoding layer.

## Scope

One concern only. No mirror files touched — `skills/caveman-compress/scripts/compress.py` is the source of truth and CI resyncs `plugins/caveman/skills/caveman-compress/` on merge.

<sub>Found while auditing the repo for functional bugs; diagnosis and patch drafted with Claude Code, then verified by hand against a checkout — the failing/passing output above is from real runs.</sub>