### PR TITLE
fix(opencode): do not toggle caveman on "normal mode" mentions or questions

### DIFF
--- a/src/plugins/opencode/plugin.js
+++ b/src/plugins/opencode/plugin.js
@@ -106,11 +106,21 @@ function parseModeChange(promptRaw) {
   prompt = prompt.toLowerCase();
   if (!prompt) return null;
 
+  // Questions about caveman are not commands ("what is caveman mode?",
+  // "does caveman mode help?"). Mirrors caveman-mode-tracker.js (#598).
+  const isQuestion =
+    /^(what|whats|what's|how|why|when|where|who|does|do|did|is|are|can|could|would|should|tell me|explain)\b/.test(prompt);
+
   // Natural-language deactivation — checked before activation so "stop talking
   // like caveman" doesn't trip the activation regex.
   if (/\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/i.test(prompt) ||
       /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/i.test(prompt) ||
-      /\bnormal mode\b/i.test(prompt)) {
+      // "normal mode" only as a command (prompt-initial, optionally led by a
+      // switch-back verb) or with caveman context — never mid-sentence for
+      // e.g. vim's normal mode ("how do I exit vim normal mode"). This port
+      // kept the bare match after caveman-mode-tracker.js was fixed in #598.
+      /^(please\s+)?(go\s+|back\s+to\s+|switch\s+(back\s+)?to\s+|return\s+to\s+)?normal\s+mode\b/.test(prompt) ||
+      (/\bnormal\s+mode\b/.test(prompt) && /\bcaveman\b/.test(prompt))) {
     return 'off';
   }
 
@@ -129,9 +139,13 @@ function parseModeChange(promptRaw) {
     return getDefaultMode();
   }
 
-  // Natural-language activation
-  if (/\b(activate|enable|turn on|start|talk like)\b.*\bcaveman\b/i.test(prompt) ||
-      /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt)) {
+  // Natural-language activation. Gated on !isQuestion so "what is caveman
+  // mode?" asks about caveman instead of silently switching it on. The
+  // template branch above and the slash branch below stay ungated — neither
+  // can match the question regex, and gating them would break real commands.
+  if (!isQuestion &&
+      (/\b(activate|enable|turn on|start|talk like)\b.*\bcaveman\b/i.test(prompt) ||
+       /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt))) {
     const mode = getDefaultMode();
     return mode === 'off' ? null : mode;
   }
@@ -227,3 +241,6 @@ export const CavemanPlugin = async (_ctx) => {
 };
 
 export default CavemanPlugin;
+
+// Named export for unit tests only — opencode loads the default export.
+export { parseModeChange };

--- a/tests/test_opencode_plugin.mjs
+++ b/tests/test_opencode_plugin.mjs
@@ -1,0 +1,81 @@
+// Tests for parseModeChange() in src/plugins/opencode/plugin.js.
+//
+// The opencode port kept a bare /\bnormal mode\b/ deactivation test and had no
+// isQuestion guard on natural-language activation, so any prompt merely
+// mentioning "normal mode" (vim's, for instance) silently turned caveman off,
+// and "what is caveman mode?" silently turned it on. The canonical
+// src/hooks/caveman-mode-tracker.js guards both — it anchors "normal mode" to a
+// command position or caveman context, and skips activation on questions
+// (#598). These cases pin the port to the same behavior.
+//
+// Run: node --test tests/test_opencode_plugin.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Isolate config lookup before importing the plugin: the flag path is resolved
+// at module load from XDG_CONFIG_HOME, and getDefaultMode() consults the env
+// var first, then repo-local and user config files. Pinning the env var keeps
+// activation results deterministic wherever the suite runs.
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-opencode-'));
+process.env.XDG_CONFIG_HOME = tmp;
+process.env.HOME = tmp;
+process.env.USERPROFILE = tmp;
+process.env.CAVEMAN_DEFAULT_MODE = 'full';
+
+const { parseModeChange } = await import('../src/plugins/opencode/plugin.js');
+
+// Regressions — none of these is a caveman command, so none may change state.
+const NO_CHANGE = [
+  'how do I exit vim normal mode?',
+  'How do I exit vim normal mode?',
+  'in vim, normal mode is the default',
+  'what is caveman mode?',
+  'does caveman mode help?',
+  'how does caveman mode work',
+];
+
+for (const prompt of NO_CHANGE) {
+  test(`leaves state alone: ${prompt}`, () => {
+    assert.equal(parseModeChange(prompt), null);
+  });
+}
+
+// Deactivation that must keep working: "normal mode" in command position
+// (optionally led by a switch-back verb) or anywhere alongside "caveman".
+const DEACTIVATES = [
+  'normal mode',
+  'back to normal mode',
+  'switch to normal mode',
+  'switch back to normal mode',
+  'return to normal mode',
+  'put caveman in normal mode',
+  'stop caveman',
+  'turn off caveman',
+];
+
+for (const prompt of DEACTIVATES) {
+  test(`deactivates: ${prompt}`, () => {
+    assert.equal(parseModeChange(prompt), 'off');
+  });
+}
+
+// Activation and slash commands must survive the isQuestion guard.
+const ACTIVATES = [
+  ['activate caveman', 'full'],
+  ['talk like caveman', 'full'],
+  ['caveman mode', 'full'],
+  ['/caveman', 'full'],
+  ['/caveman ultra', 'ultra'],
+  ['activate caveman mode: full', 'full'],
+  ['activate caveman mode: ultra', 'ultra'],
+];
+
+for (const [prompt, expected] of ACTIVATES) {
+  test(`activates ${expected}: ${prompt}`, () => {
+    assert.equal(parseModeChange(prompt), expected);
+  });
+}


### PR DESCRIPTION
Fixes #778

## What

`parseModeChange()` in the opencode plugin deactivated on a bare `/\bnormal mode\b/i` test, so any prompt containing the phrase turned caveman off — `"how do I exit vim normal mode?"` being the obvious collision. Natural-language activation in the same function had no `isQuestion` guard, so `"what is caveman mode?"` silently switched caveman on.

`src/hooks/caveman-mode-tracker.js` already guards both cases from #598 — it anchors "normal mode" to a command position or caveman context, and skips activation on questions. This port never picked those up. The change ports both guards verbatim so the two implementations agree.

The `/caveman` slash branch and the `"activate caveman mode:"` template branch stay ungated — neither can match the question regex, and gating them would break real commands.

## Verification

Ran the same prompt set through both implementations. The port now matches the canonical tracker on every case, including the `"go back to normal mode"` quirk (the alternation is single-shot, so it matches `"back to normal mode"` but not `"go back to normal mode"`) — inherited from the canonical regex, not introduced here.

| prompt | canonical tracker | opencode (before) | opencode (after) |
|---|---|---|---|
| `how do I exit vim normal mode?` | unchanged | **off** | unchanged |
| `in vim, normal mode is the default` | unchanged | **off** | unchanged |
| `what is caveman mode?` | unchanged | **on** | unchanged |
| `does caveman mode help?` | unchanged | **on** | unchanged |
| `normal mode` | off | off | off |
| `back to normal mode` / `switch to normal mode` / `return to normal mode` | off | off | off |
| `put caveman in normal mode` | off | off | off |
| `stop caveman` / `turn off caveman` | off | off | off |

## Test

New `tests/test_opencode_plugin.mjs` (21 cases, `node --test`). It imports `parseModeChange` — which needed a named export alongside the existing `export default CavemanPlugin`; opencode still loads the default export. Importing from the source tree works because `loadConfig()` already has the dev fallback to `src/hooks/caveman-config.js`.

On the pre-fix parser the 6 regression cases fail and the 15 activation/deactivation cases already pass, so behaviour that worked is provably unchanged:

```
$ node --test tests/test_opencode_plugin.mjs      # pre-fix
ℹ tests 21
ℹ pass 15
ℹ fail 6

$ node --test tests/test_opencode_plugin.mjs      # post-fix
ℹ tests 21
ℹ pass 21
ℹ fail 0
```

Nothing else regressed — `python -m unittest tests.test_mode_tracker` 23/23 OK, `node tests/test_mode_tracker_stdin.js` OK, `npm test` 102/112 with the same 10 pre-existing Windows path-separator failures as on `main`.

`npm test` globs `tests/installer/*.test.mjs`, so the new file is run manually, same as `test_mode_tracker_stdin.js` and the Python suites. Broadening that glob felt like a second concern — happy to add it here if you would rather.

## Out of scope

One difference from the canonical tracker remains: `"caveman off"` deactivates there (via `/\bcaveman(\s+mode)?\s+(off|stop|disabled?)\b/`) but is still a no-op in this port. Pre-existing and unrelated to the two guards above — flagging it rather than widening this PR.

<sub>Found while auditing the repo for functional bugs; diagnosis and patch drafted with Claude Code, then verified by hand against a checkout — the table and test output above are from real runs.</sub>