### PR TITLE
feat(install): add native OMP support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,6 +45,7 @@ If you want to install for one agent (or want to know exactly what command runs 
 | **Claude Code** | `claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman` | Yes |
 | **Gemini CLI** | `gemini extensions install https://github.com/JuliusBrussee/caveman` | Yes |
 | **opencode** | `node bin/install.js --only opencode` *(or `npx -y github:JuliusBrussee/caveman -- --only opencode`)* | Yes (plugin + AGENTS.md) |
+| **Oh My Pi (OMP)** | `npx -y github:JuliusBrussee/caveman -- --only omp` *(or `node bin/install.js --only omp` from a clone)* | Yes (native OMP plugin) |
 | **OpenClaw** | `npx -y github:JuliusBrussee/caveman -- --only openclaw` | Yes (workspace skill + SOUL.md) |
 | **Hermes Agent** | `npx -y github:JuliusBrussee/caveman -- --only hermes` *(or `node bin/install.js --only hermes` from a clone)* | Yes (native skills, enabled on load) |
 | **Codex CLI** | `npx skills add JuliusBrussee/caveman -a codex` | Per-session: `/caveman` |
@@ -127,7 +128,7 @@ Useful flags:
 | `--no-mcp-shrink` | Skip MCP-shrink registration. (Default.) |
 | `--with-hooks` / `--no-hooks` | Force-on or force-off the Claude Code hook installer. (Default: on.) |
 | `--skip-skills` | Don't run the npx-skills auto-detect fallback when nothing else matched. |
-| `--config-dir <path>` | Claude Code config dir for hook files + `settings.json`. **Does NOT scope** `claude plugin install`, `gemini extensions install`, opencode (`XDG_CONFIG_HOME`), or openclaw (`OPENCLAW_WORKSPACE`) — those use their own paths. Default: `$CLAUDE_CONFIG_DIR` or `~/.claude`. `~` is expanded. |
+| `--config-dir <path>` | Claude Code config dir for hook files + `settings.json`. **Does NOT scope** `claude plugin install`, `gemini extensions install`, OMP (`~/.omp/`), opencode (`XDG_CONFIG_HOME`), or openclaw (`OPENCLAW_WORKSPACE`) — those use their own paths. Default: `$CLAUDE_CONFIG_DIR` or `~/.claude`. `~` is expanded. |
 | `--non-interactive` | Never prompt; use defaults. (Auto when stdin is not a TTY.) |
 | `--no-color` | Disable ANSI colors. |
 | `--list` | Print full agent matrix and exit. |
@@ -188,6 +189,7 @@ What it removes:
 - Hook files in `$CLAUDE_CONFIG_DIR/hooks/` (`caveman-activate.js`, `caveman-mode-tracker.js`, `caveman-parse.js`, `caveman-stats.js`, `caveman-config.js`, `cavecrew-model-overrides.js`, `caveman-statusline.{sh,ps1}`, plus the dir's `package.json` marker).
 - The Claude Code plugin and the Gemini CLI extension (if installed).
 - The opencode native plugin (`~/.config/opencode/plugins/caveman/`, the `plugin` and `mcp.caveman-shrink` entries from `opencode.json`, our skill/agent/command files, the caveman block from `AGENTS.md`, and the opencode flag file).
+- The Oh My Pi plugin (`omp plugin uninstall caveman`) and Caveman's managed OMP plugin package at `~/.omp/caveman-plugin/`.
 - The OpenClaw workspace skill folder and the marker-fenced block from `~/.openclaw/workspace/SOUL.md` (when present).
 - Per-session state (`.caveman-active`, `.caveman-active.prev`, `.caveman-mode-log.jsonl`, `.caveman-statusline-suffix`, and `.caveman-nudge-shown`).
 
@@ -256,9 +258,10 @@ The installer doesn't phone home. It writes to:
 - `$CLAUDE_CONFIG_DIR` (default `~/.claude/`) — hooks, flag file, `settings.json` merge.
 - Each agent's own config location — Cursor's `.cursor/rules/`, Windsurf's `.windsurf/rules/`, opencode's `~/.config/opencode/`, etc.
 - Your current working directory (only with `--with-init`) — repo-local rule files.
+- `~/.omp/caveman-plugin/` (only with `--only omp`, or auto-detect when `omp` is on `PATH`) — managed OMP plugin package installed through `omp plugin install`.
 - `~/.openclaw/workspace/` (only with `--only openclaw` or `--with-init` when OpenClaw is detected) — the one `--with-init` side-effect outside the cwd.
 
-Installer sends no Caveman telemetry or analytics. Run from a clone or via npx, its own code copies files locally. One exception: run detached from any checkout (the rare curl-fallback path), it downloads hook files from raw.githubusercontent.com pinned to an immutable release tag and verifies each against a SHA-256 manifest before wiring anything. Network requests also happen indirectly through per-agent CLIs it shells out to — `claude plugin marketplace add`, `claude plugin install`, `gemini extensions install`, `npm view caveman-shrink`, and `npx -y skills add`. Each fetches from its own registry (Anthropic / GitHub / npm). Source: [`bin/install.js`](bin/install.js).
+Installer sends no Caveman telemetry or analytics. Run from a clone or via npx, its own code copies files locally. One exception: run detached from any checkout (the rare curl-fallback path), it downloads hook files from raw.githubusercontent.com pinned to an immutable release tag and verifies each against a SHA-256 manifest before wiring anything. Network requests also happen indirectly through per-agent CLIs it shells out to — `claude plugin marketplace add`, `claude plugin install`, `gemini extensions install`, `omp plugin install`, `npm view caveman-shrink`, and `npx -y skills add`. Each fetches from its own registry or local plugin manager (Anthropic / GitHub / OMP / npm). Source: [`bin/install.js`](bin/install.js).
 
 After install, classic skill and output hooks stay local. CLI telemetry is off by default and sends content-free events only after explicit opt-in. Proxy, SDK, provider, authenticated sync, and managed gateway commands use network according to their configured purpose. Full data-flow statement: [SECURITY.md](./SECURITY.md#privacy--telemetry).
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Measured on the caveman skill itself: **1,069 → 415 est. tokens, −61%**, `in
 
 ## The skill
 
-The original, and still the fastest way to feel caveman. MIT forever. Works in [Claude Code](https://docs.anthropic.com/en/docs/claude-code), Codex, Gemini, Cursor, Windsurf, Cline, Copilot, and 30+ other agents.
+The original, and still the fastest way to feel caveman. MIT forever. Works in [Claude Code](https://docs.anthropic.com/en/docs/claude-code), Oh My Pi (OMP), Codex, Gemini, Cursor, Windsurf, Cline, Copilot, and 30+ other agents.
 
 Type `/caveman` if your agent does not activate it automatically. Switch with `/caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra`; turn it off with `/caveman off` or `normal mode`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -153,10 +153,10 @@ third-party tools trustworthy.
 
 Network installers fetch source from GitHub and may invoke npm or agent-specific
 registries. Per-agent installers can contact Anthropic/GitHub, Gemini extension,
-npm, or other configured registries. Detached hook installation downloads files
-from an immutable release tag and verifies SHA-256 manifest entries. Runtime
-companion setup downloads a signed checksum manifest and verifies each binary's
-signature and SHA-256 before installation.
+the Oh My Pi plugin manager, npm, or other configured registries. Detached hook
+installation downloads files from an immutable release tag and verifies SHA-256
+manifest entries. Runtime companion setup downloads a signed checksum manifest
+and verifies each binary's signature and SHA-256 before installation.
 
 For inspection-first installation, clone a pinned tag and run the local installer
 instead of piping a remote script into a shell. A source clone avoids installer

--- a/bin/install.js
+++ b/bin/install.js
@@ -231,6 +231,7 @@ const PROVIDERS = [
   { id: 'claude',     label: 'Claude Code',         mech: 'claude plugin install',         detect: 'command:claude' },
   { id: 'gemini',     label: 'Gemini CLI',          mech: 'gemini extensions install',     detect: 'command:gemini' },
   { id: 'opencode',   label: 'opencode',            mech: 'native opencode plugin',        detect: 'command:opencode' },
+  { id: 'omp',        label: 'Oh My Pi (OMP)',      mech: 'native OMP plugin',             detect: 'command:omp' },
   { id: 'openclaw',   label: 'OpenClaw',            mech: 'workspace skill + SOUL.md',     detect: 'command:openclaw||dir:$HOME/.openclaw/workspace' },
   { id: 'codex',      label: 'Codex CLI',           mech: 'npx skills add (codex)',        detect: 'command:codex',           profile: 'codex' },
 
@@ -710,6 +711,185 @@ function countOccurrences(haystack, needle) {
   let n = 0;
   for (let i = haystack.indexOf(needle); i !== -1; i = haystack.indexOf(needle, i + needle.length)) n++;
   return n;
+}
+
+// ── Oh My Pi native install ────────────────────────────────────────────────
+// OMP local-path installs intentionally route through its plugin manager:
+// `omp plugin install <path>` symlinks the package into ~/.omp/plugins/
+// node_modules and records runtime state in omp-plugins.lock.json. We prepare
+// a stable managed plugin package under ~/.omp/ so the symlink never points at
+// an npx cache directory that may disappear after install.
+const OMP_PLUGIN_NAME = 'caveman';
+const OMP_PLUGIN_DIRNAME = 'caveman-plugin';
+const OMP_STAGING_PREFIX = 'caveman-plugin-staging-';
+const OMP_BACKUP_SUFFIX = '.previous';
+const OMP_EXTENSION_ENTRY = './index.js';
+const OMP_SKILL_DIRS = OPENCODE_SKILL_DIRS;
+const OMP_AGENT_FILES = OPENCODE_AGENT_FILES;
+const OMP_COMMAND_FILES = OPENCODE_COMMAND_FILES;
+const OMP_RULE_FILE = 'caveman.md';
+const OMP_PACKAGE_FILE = 'package.json';
+const OMP_INDEX_FILE = 'index.js';
+const OMP_PACKAGE_VERSION = '0.1.0';
+const OMP_PLUGIN_DESCRIPTION = 'Caveman terse communication mode for Oh My Pi';
+const OMP_RULE_COUNT = 1;
+const OMP_EXTENSION_SOURCE = `'use strict';
+
+const STATUS_LABEL = 'caveman';
+const STATUS_TEXT = 'CAVEMAN';
+
+module.exports = function cavemanPlugin(pi) {
+  if (!pi || typeof pi.on !== 'function') return;
+  pi.on('session_start', async (_event, ctx) => {
+    if (ctx && ctx.ui && typeof ctx.ui.setStatus === 'function') {
+      ctx.ui.setStatus(STATUS_LABEL, STATUS_TEXT);
+    }
+  });
+};
+`;
+
+function ompPluginDir() {
+  return path.join(os.homedir(), '.omp', OMP_PLUGIN_DIRNAME);
+}
+
+function packageVersion(repoRoot) {
+  if (!repoRoot) return OMP_PACKAGE_VERSION;
+  try {
+    const raw = fs.readFileSync(path.join(repoRoot, OMP_PACKAGE_FILE), 'utf8');
+    const pkg = JSON.parse(raw);
+    return typeof pkg.version === 'string' && pkg.version ? pkg.version : OMP_PACKAGE_VERSION;
+  } catch (_) {
+    return OMP_PACKAGE_VERSION;
+  }
+}
+
+function writeOmpPluginPackage(ctx, pluginDir) {
+  const { repoRoot } = ctx;
+  if (!repoRoot) throw new Error('native install requires local repo clone');
+
+  fs.mkdirSync(pluginDir, { recursive: true });
+
+  const pkg = {
+    name: OMP_PLUGIN_NAME,
+    version: packageVersion(repoRoot),
+    description: OMP_PLUGIN_DESCRIPTION,
+    omp: {
+      description: OMP_PLUGIN_DESCRIPTION,
+      extensions: [OMP_EXTENSION_ENTRY],
+    },
+  };
+  fs.writeFileSync(path.join(pluginDir, OMP_PACKAGE_FILE), JSON.stringify(pkg, null, 2) + '\n');
+  fs.writeFileSync(path.join(pluginDir, OMP_INDEX_FILE), OMP_EXTENSION_SOURCE);
+
+  const skillsRoot = path.join(pluginDir, 'skills');
+  for (const name of OMP_SKILL_DIRS) {
+    const src = path.join(repoRoot, 'skills', name);
+    if (fs.existsSync(src)) fs.cpSync(src, path.join(skillsRoot, name), { recursive: true });
+  }
+
+  const commandsRoot = path.join(pluginDir, 'commands');
+  fs.mkdirSync(commandsRoot, { recursive: true });
+  const commandSrcRoot = path.join(repoRoot, 'src', 'plugins', 'opencode', 'commands');
+  for (const name of OMP_COMMAND_FILES) {
+    const src = path.join(commandSrcRoot, name);
+    if (fs.existsSync(src)) fs.copyFileSync(src, path.join(commandsRoot, name));
+  }
+
+  const agentsRoot = path.join(pluginDir, 'agents');
+  fs.mkdirSync(agentsRoot, { recursive: true });
+  const agentSrcRoot = path.join(repoRoot, 'agents');
+  for (const name of OMP_AGENT_FILES) {
+    const src = path.join(agentSrcRoot, name);
+    if (fs.existsSync(src)) {
+      fs.writeFileSync(path.join(agentsRoot, name), transformOpencodeAgentFrontmatter(fs.readFileSync(src, 'utf8')));
+    }
+  }
+
+  const rulesRoot = path.join(pluginDir, 'rules');
+  fs.mkdirSync(rulesRoot, { recursive: true });
+  const ruleBody = fs.readFileSync(path.join(repoRoot, 'src', 'rules', 'caveman-activate.md'), 'utf8');
+  fs.writeFileSync(path.join(rulesRoot, OMP_RULE_FILE), ruleBody);
+}
+
+function prepareOmpPluginPackage(ctx, pluginDir) {
+  const parentDir = path.dirname(pluginDir);
+  fs.mkdirSync(parentDir, { recursive: true });
+  const stagingDir = fs.mkdtempSync(path.join(parentDir, OMP_STAGING_PREFIX));
+  try {
+    writeOmpPluginPackage(ctx, stagingDir);
+    return stagingDir;
+  } catch (err) {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+    throw err;
+  }
+}
+
+function replaceOmpPluginPackage(stagingDir, pluginDir) {
+  const backupDir = pluginDir + OMP_BACKUP_SUFFIX;
+  fs.rmSync(backupDir, { recursive: true, force: true });
+  const hadPrevious = fs.existsSync(pluginDir);
+  if (hadPrevious) fs.renameSync(pluginDir, backupDir);
+  try {
+    fs.renameSync(stagingDir, pluginDir);
+  } catch (err) {
+    if (hadPrevious) fs.renameSync(backupDir, pluginDir);
+    throw err;
+  }
+  return hadPrevious ? backupDir : null;
+}
+
+function restoreOmpPluginPackage(pluginDir, backupDir) {
+  fs.rmSync(pluginDir, { recursive: true, force: true });
+  if (backupDir && fs.existsSync(backupDir)) fs.renameSync(backupDir, pluginDir);
+}
+
+function installOmp(ctx) {
+  const { say, note, warn, opts, repoRoot, results } = ctx;
+  results.detected++;
+  say('→ Oh My Pi (OMP) detected');
+
+  if (!repoRoot) {
+    warn('  OMP native install requires a local clone of the caveman repo.');
+    note('  Re-run from a clone: git clone https://github.com/' + REPO + ' && cd caveman && node bin/install.js --only omp');
+    results.failed.push(['omp', 'native install requires local repo clone']);
+    process.stdout.write('\n');
+    return;
+  }
+
+  const pluginDir = ompPluginDir();
+  if (opts.dryRun) {
+    note(`  would prepare OMP plugin package at ${pluginDir}/`);
+    note(`  would copy ${OMP_SKILL_DIRS.length} skill dirs, ${OMP_COMMAND_FILES.length} commands, ${OMP_AGENT_FILES.length} agents, and ${OMP_RULE_COUNT} rule`);
+    runSpawn('omp', ['plugin', 'install', pluginDir], null, true);
+    results.installed.push('omp');
+    process.stdout.write('\n');
+    return;
+  }
+
+  let stagingDir = null;
+  let backupDir = null;
+  let packageReplaced = false;
+  try {
+    stagingDir = prepareOmpPluginPackage(ctx, pluginDir);
+    backupDir = replaceOmpPluginPackage(stagingDir, pluginDir);
+    stagingDir = null;
+    packageReplaced = true;
+    process.stdout.write(`  prepared: ${pluginDir}/\n`);
+    const r = runSpawn('omp', ['plugin', 'install', pluginDir], null, false);
+    if (spawnOk(r)) {
+      if (backupDir) fs.rmSync(backupDir, { recursive: true, force: true });
+      results.installed.push('omp');
+    } else {
+      restoreOmpPluginPackage(pluginDir, backupDir);
+      results.failed.push(['omp', 'omp plugin install failed']);
+    }
+  } catch (e) {
+    if (packageReplaced) restoreOmpPluginPackage(pluginDir, backupDir);
+    if (stagingDir) fs.rmSync(stagingDir, { recursive: true, force: true });
+    warn('  OMP install failed: ' + (e && e.message || e));
+    results.failed.push(['omp', (e && e.message) || 'unknown error']);
+  }
+  process.stdout.write('\n');
 }
 
 function opencodeConfigDir() {
@@ -1430,6 +1610,17 @@ function uninstall(ctx) {
     }
   }
 
+  // Oh My Pi native plugin — delegate lifecycle removal to OMP, then remove
+  // the managed local package source we prepared for its plugin-manager link.
+  const ompDir = ompPluginDir();
+  if (hasCmd('omp')) {
+    runSpawn('omp', ['plugin', 'uninstall', OMP_PLUGIN_NAME], null, opts.dryRun);
+  }
+  if (fs.existsSync(ompDir)) {
+    if (!opts.dryRun) { try { fs.rmSync(ompDir, { recursive: true, force: true }); } catch (_) {} }
+    note(`  removed ${ompDir}`);
+  }
+
   // Hermes native install — same journal/digest contract as opencode.
   const hermesRoot = path.join(hermesConfigDir(), 'productivity');
   try {
@@ -1549,8 +1740,9 @@ FLAGS
   --config-dir <path>   Claude Code config dir for hook files + settings.json.
                         Default: \$CLAUDE_CONFIG_DIR or ~/.claude. Does NOT
                         scope \`claude plugin install\`, \`gemini extensions
-                        install\`, opencode (XDG_CONFIG_HOME), or openclaw
-                        (OPENCLAW_WORKSPACE) — those use their own paths.
+                        install\`, OMP (~/.omp/), opencode (XDG_CONFIG_HOME),
+                        or openclaw (OPENCLAW_WORKSPACE) — those use their
+                        own paths.
   --non-interactive     Never prompt; use defaults. (Auto when stdin is not a TTY.)
   --list                Print provider matrix and exit.
   --no-color            Disable ANSI colors.
@@ -1623,6 +1815,7 @@ async function main() {
     if (prov.id === 'claude')   { await installClaude(ctx); continue; }
     if (prov.id === 'gemini')   { installGemini(ctx); continue; }
     if (prov.id === 'opencode') { installOpencode(ctx); continue; }
+    if (prov.id === 'omp')      { installOmp(ctx); continue; }
     if (prov.id === 'openclaw') { installOpenclaw(ctx); continue; }
     if (prov.id === 'hermes')   { installHermes(ctx); continue; }
     if (prov.profile)           { installViaSkills(ctx, prov); continue; }

--- a/tests/installer/omp.test.mjs
+++ b/tests/installer/omp.test.mjs
@@ -1,0 +1,137 @@
+// OMP native plugin install — prepares a real local OMP plugin package, then
+// routes through `omp plugin install <path>` so OMP owns lifecycle state.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const INSTALLER = path.join(REPO_ROOT, 'bin', 'install.js');
+const OMP_PLUGIN_DIR = path.join('.omp', 'caveman-plugin');
+const OMP_ARGS_LOG = 'omp-args.log';
+const OMP_SHIM_NAME = process.platform === 'win32' ? 'omp.cmd' : 'omp';
+const OMP_SHIM_SCRIPT_NAME = 'omp-shim.js';
+// The fake `omp` binary lives in a Node script both platforms share; only the
+// launcher differs. On Windows the installer never executes a `.cmd` — it reads
+// it, extracts the Node entrypoint (bin/lib/portable-process.js) and spawns node
+// directly — so the shim must be shaped like the npm-generated cmd-shim a real
+// `npm i -g oh-my-pi` produces. A plain batch script is rejected as a
+// "non-Node Windows command shim" and never runs.
+const OMP_SHIM_SCRIPT = `const fs = require('fs');
+const path = require('path');
+const args = process.argv.slice(2);
+fs.appendFileSync(path.join(process.env.HOME || process.env.USERPROFILE, '${OMP_ARGS_LOG}'), args.join(' ') + '\\n');
+if (process.env.OMP_FAIL_INSTALL === '1' && args[0] === 'plugin' && args[1] === 'install') process.exit(1);
+`;
+const OMP_SHIM_BODY = process.platform === 'win32'
+  ? `@echo off\r\nendLocal & "%_prog%" "%dp0%\\${OMP_SHIM_SCRIPT_NAME}" %*\r\n`
+  : `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} "$(dirname "$0")/${OMP_SHIM_SCRIPT_NAME}" "$@"\n`;
+const PATH_SEPARATOR = process.platform === 'win32' ? ';' : ':';
+const OMP_SKILLS = ['caveman', 'caveman-commit', 'caveman-review', 'caveman-help', 'caveman-stats', 'caveman-compress', 'cavecrew'];
+const OMP_COMMANDS = ['caveman.md', 'caveman-commit.md', 'caveman-review.md', 'caveman-compress.md', 'caveman-stats.md', 'caveman-help.md'];
+const OMP_AGENTS = ['cavecrew-investigator.md', 'cavecrew-builder.md', 'cavecrew-reviewer.md'];
+const EXISTING_MARKER = 'existing package must survive failed install';
+
+function freshHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-omp-'));
+}
+
+function shimOmp(home) {
+  const bin = path.join(home, 'bin');
+  fs.mkdirSync(bin, { recursive: true });
+  fs.writeFileSync(path.join(bin, OMP_SHIM_SCRIPT_NAME), OMP_SHIM_SCRIPT);
+  const shim = path.join(bin, OMP_SHIM_NAME);
+  fs.writeFileSync(shim, OMP_SHIM_BODY);
+  if (process.platform !== 'win32') fs.chmodSync(shim, 0o755);
+  return bin;
+}
+
+function runInstaller(args, home, extraEnv = {}) {
+  const bin = shimOmp(home);
+  return spawnSync(process.execPath, [INSTALLER, ...args, '--non-interactive', '--no-mcp-shrink'], {
+    env: {
+      ...process.env,
+      ...extraEnv,
+      HOME: home,
+      USERPROFILE: home,
+      PATH: bin + PATH_SEPARATOR + (process.env.PATH || ''),
+      NO_COLOR: '1',
+    },
+    encoding: 'utf8',
+  });
+}
+
+test('omp fresh install prepares plugin package and invokes OMP plugin install', () => {
+  const home = freshHome();
+  try {
+    const r = runInstaller(['--only', 'omp'], home);
+    assert.notEqual(r.status, 2, `argv error: ${r.stderr}`);
+
+    const pluginDir = path.join(home, OMP_PLUGIN_DIR);
+    const pkgPath = path.join(pluginDir, 'package.json');
+    assert.ok(fs.existsSync(pkgPath), 'OMP plugin package.json missing');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    assert.equal(pkg.name, 'caveman');
+    assert.deepEqual(pkg.omp.extensions, ['./index.js']);
+
+    assert.ok(fs.existsSync(path.join(pluginDir, 'index.js')), 'OMP extension entry missing');
+    for (const name of OMP_SKILLS) {
+      assert.ok(fs.existsSync(path.join(pluginDir, 'skills', name, 'SKILL.md')), `skill ${name}/SKILL.md missing`);
+    }
+    for (const name of OMP_COMMANDS) {
+      assert.ok(fs.existsSync(path.join(pluginDir, 'commands', name)), `command ${name} missing`);
+    }
+    for (const name of OMP_AGENTS) {
+      const agentPath = path.join(pluginDir, 'agents', name);
+      assert.ok(fs.existsSync(agentPath), `agent ${name} missing`);
+      assert.doesNotMatch(fs.readFileSync(agentPath, 'utf8'), /^tools[ \t]*:/m, `agent ${name} kept incompatible tools field`);
+    }
+    const rule = fs.readFileSync(path.join(pluginDir, 'rules', 'caveman.md'), 'utf8');
+    assert.match(rule, /Respond terse like smart caveman/, 'activation rule missing sentinel');
+
+    const shimCalls = fs.readFileSync(path.join(home, OMP_ARGS_LOG), 'utf8');
+    assert.match(shimCalls, new RegExp(`plugin install ${pluginDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('omp install restores previous prepared package when plugin install fails', () => {
+  const home = freshHome();
+  try {
+    const pluginDir = path.join(home, OMP_PLUGIN_DIR);
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, 'package.json'), EXISTING_MARKER);
+
+    const r = runInstaller(['--only', 'omp'], home, { OMP_FAIL_INSTALL: '1' });
+    assert.notEqual(r.status, 2, `argv error: ${r.stderr}`);
+    assert.match(r.stdout + r.stderr, /omp plugin install failed/, 'install failure was not reported');
+    assert.equal(fs.readFileSync(path.join(pluginDir, 'package.json'), 'utf8'), EXISTING_MARKER);
+    assert.equal(fs.existsSync(pluginDir + '.previous'), false, 'backup directory leaked after failed install');
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('omp uninstall uses plugin lifecycle and removes prepared package', () => {
+  const home = freshHome();
+  try {
+    const r1 = runInstaller(['--only', 'omp'], home);
+    assert.notEqual(r1.status, 2);
+    const pluginDir = path.join(home, OMP_PLUGIN_DIR);
+    assert.ok(fs.existsSync(pluginDir), 'precondition: OMP plugin package missing');
+
+    const r2 = runInstaller(['--uninstall'], home);
+    assert.notEqual(r2.status, 2, `uninstall argv error: ${r2.stderr}`);
+    assert.equal(fs.existsSync(pluginDir), false, 'prepared OMP plugin package survived uninstall');
+    const shimCalls = fs.readFileSync(path.join(home, OMP_ARGS_LOG), 'utf8');
+    assert.match(shimCalls, /plugin uninstall caveman/, 'OMP plugin uninstall was not invoked');
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #743

## Summary
- Add `omp` provider detection and native installer routing (Oh My Pi).
- Prepare a managed OMP plugin package at `~/.omp/caveman-plugin` with `package.json#omp`, an extension entry, skills, commands, agents, and an activation rule, then delegate lifecycle to `omp plugin install` / `omp plugin uninstall`.
- Restore any previous prepared package if `omp plugin install` fails.
- Update installer/security docs (`INSTALL.md`, `README.md`, `SECURITY.md`) for the new user-facing OMP support.

## Rebased onto latest `main`
The branch was 26 commits behind `main` and `CONFLICTING`. Rebased onto `origin/main` and resolved the conflicts:
- The unified installer moved from `cli/install.js` to `bin/install.js` (now the source of truth; `cli/install.js` is a thin shim). The OMP code was **re-applied to `bin/install.js`** accordingly, and the OMP test now targets `bin/install.js`.
- One implementation change from the original: the local `copyDirRecursive` helper no longer exists in `bin/install.js`, so skill-dir copying uses stdlib `fs.cpSync(src, dest, { recursive: true })` (Node 18+).
- `INSTALL.md` / `README.md` / `SECURITY.md` conflicts resolved onto main's current structure, with the OMP entries re-added (install-matrix row, supported-agent list, install network-access note).

## Test Verification (RED → GREEN)
New OMP tests fail on the upstream base (feature absent):

```text
node --test tests/installer/omp.test.mjs   # against origin/main bin/install.js
1..3
# pass 0
# fail 3
```

Pass with the fix applied:

```text
node --test tests/installer/omp.test.mjs
1..3
# pass 3
# fail 0
```

Full installer suite — baseline preserved, +3 new OMP tests:

```text
# origin/main baseline
npm test → # tests 156 # pass 156 # fail 0

# fix/issue-743 (this branch)
npm test → # tests 159 # pass 159 # fail 0
```

Local CI replay (`npm test` + standalone `tests/test_*.js` + `python -m unittest discover -s tests`) is green on both the upstream baseline and this branch.

Note: the `typescript` and `windows` checks are red on `main` itself (a pre-existing `pnpm-lock.yaml` drift — `@caveman-ai/cli@^1.1.0`), unrelated to this change, which touches no `package.json` / lockfile / engine / packages files.
