### PR TITLE
feat(compress): add provider model selection

### DIFF
--- a/skills/caveman-compress/README.md
+++ b/skills/caveman-compress/README.md
@@ -91,6 +91,19 @@ skills/caveman-compress/
 
 Requires Python 3.10 or newer.
 
+### Provider / model
+
+Default path uses Claude: `ANTHROPIC_API_KEY` + Anthropic SDK when set, else `claude --print`.
+
+To use opencode instead:
+
+```bash
+export CAVEMAN_COMPRESS_PROVIDER=opencode
+export CAVEMAN_COMPRESS_MODEL=github-copilot/gpt-4.1
+```
+
+`CAVEMAN_PROVIDER` and `CAVEMAN_MODEL` are fallback env vars when compress-specific values are unset.
+
 ## Usage
 
 ```
@@ -124,13 +137,13 @@ acquire cross-session lock on the file  (waits up to 15 min if another run holds
         ↓
 detect file type        (no tokens)
         ↓
-Claude compresses       (tokens: one call)
+configured provider compresses       (tokens — one call)
         ↓
 validate output         (no tokens)
   checks: headings, code blocks, URLs, file paths, bullets
         ↓
-if errors: Claude fixes cherry-picked issues only   (tokens: targeted fix)
-  does NOT recompress; only patches broken parts
+if errors: configured provider fixes cherry-picked issues only   (tokens — targeted fix)
+  does NOT recompress — only patches broken parts
         ↓
 retry up to 2 times
         ↓

--- a/skills/caveman-compress/SECURITY.md
+++ b/skills/caveman-compress/SECURITY.md
@@ -6,21 +6,23 @@
 
 ### What triggers the rating
 
-1. **subprocess usage**: The skill calls the `claude` CLI via `subprocess.run()` as a fallback when `ANTHROPIC_API_KEY` is not set. The subprocess call uses a fixed argument list — no shell interpolation occurs. User file content is passed via stdin, not as a shell argument.
+1. **subprocess usage**: The skill calls the `claude` CLI via `subprocess.run()` as a fallback when `ANTHROPIC_API_KEY` is not set. It can also call `opencode run` when `CAVEMAN_COMPRESS_PROVIDER=opencode`. Subprocess calls use fixed argument lists — no shell interpolation occurs. Claude receives user file content via stdin; opencode receives the generated prompt through a temporary `--file` attachment that is deleted after the call.
 
-2. **File read/write**: The skill reads the file the user explicitly points it at, compresses it, and writes the result back to the same path. A `.original.md` backup is saved to an out-of-tree data dir (`$XDG_DATA_HOME/caveman-compress/backups/<parent-dir-name>/`, or `%LOCALAPPDATA%\caveman-compress\backups\<parent-dir-name>\` on Windows). Beyond the target file and that backup location, no files are read or written.
+2. **File read/write**: The skill reads the file the user explicitly points it at, compresses it, and writes the result back to the same path. A `.original.md` backup is saved to an out-of-tree data dir (`$XDG_DATA_HOME/caveman-compress/backups/<parent-dir-name>/`, or `%LOCALAPPDATA%\caveman-compress\backups\<parent-dir-name>\` on Windows). The opencode provider writes a temporary prompt attachment in the OS temp directory and deletes it after the subprocess exits. Beyond the target file, that backup location, and the temporary attachment, no files are read or written.
 
 ### What the skill does NOT do
 
 - Does not execute user file content as code
-- Does not make network requests except to Anthropic's API (via SDK or CLI)
-- Does not access files outside the path the user provides
+- Does not make network requests except through the configured LLM provider CLI or SDK
+- Does not read unrelated files outside the path the user provides
 - Does not use shell=True or string interpolation in subprocess calls
 - Does not collect or transmit any data beyond the file being compressed
 
 ### Auth behavior
 
-If `ANTHROPIC_API_KEY` is set, the skill uses the Anthropic Python SDK directly (no subprocess). If not set, it falls back to the `claude` CLI, which uses the user's existing Claude desktop authentication.
+Default path uses Claude. If `ANTHROPIC_API_KEY` is set, the skill uses the Anthropic Python SDK directly (no subprocess). If not set, it falls back to the `claude` CLI, which uses the user's existing Claude desktop authentication.
+
+Set `CAVEMAN_COMPRESS_PROVIDER=opencode` to use `opencode run` instead. Set `CAVEMAN_COMPRESS_MODEL=provider/model` for compress-specific model selection. `CAVEMAN_PROVIDER` and `CAVEMAN_MODEL` are fallback env vars when compress-specific values are unset.
 
 ### File size limit
 

--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -554,8 +554,8 @@ def call_opencode_cli(prompt: str) -> str:
             suffix=OPENCODE_PROMPT_SUFFIX,
             delete=False,
         ) as prompt_file:
-            prompt_file.write(prompt)
             prompt_path = Path(prompt_file.name)
+            prompt_file.write(prompt)
         args.extend(
             [OPENCODE_FILE_ARG, str(prompt_path), OPENCODE_PROMPT_MESSAGE]
         )

--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -18,7 +18,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 _IS_WINDOWS = os.name == "nt" or sys.platform == "win32"
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)  # unix-only; refuses to open through a pre-placed symlink at the lock path
@@ -361,6 +361,37 @@ from .detect import should_compress
 from .validate import validate
 
 MAX_RETRIES = 2
+MAX_FILE_SIZE_BYTES = 500_000
+MAX_FILE_SIZE_LABEL = "500KB"
+
+ENV_ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY"
+ENV_COMPRESS_PROVIDER = "CAVEMAN_COMPRESS_PROVIDER"
+ENV_FALLBACK_PROVIDER = "CAVEMAN_PROVIDER"
+ENV_COMPRESS_MODEL = "CAVEMAN_COMPRESS_MODEL"
+ENV_FALLBACK_MODEL = "CAVEMAN_MODEL"
+
+PROVIDER_CLAUDE = "claude"
+PROVIDER_ANTHROPIC = "anthropic"
+PROVIDER_OPENCODE = "opencode"
+SUPPORTED_PROVIDERS = frozenset({
+    PROVIDER_CLAUDE,
+    PROVIDER_ANTHROPIC,
+    PROVIDER_OPENCODE,
+})
+
+DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-5"
+ANTHROPIC_MAX_TOKENS = 8192
+CLAUDE_CLI = "claude"
+CLAUDE_PRINT_ARG = "--print"
+CLAUDE_SETTING_SOURCES_ARG = "--setting-sources"
+CLAUDE_STRICT_MCP_ARG = "--strict-mcp-config"
+OPENCODE_CLI = "opencode"
+OPENCODE_RUN_ARG = "run"
+OPENCODE_FILE_ARG = "--file"
+MODEL_ARG = "--model"
+OPENCODE_PROMPT_PREFIX = ".caveman-compress-prompt-"
+OPENCODE_PROMPT_SUFFIX = ".md"
+OPENCODE_PROMPT_MESSAGE = "Follow the attached prompt exactly. Return only the final answer."
 
 
 def _is_smaller_than_body(candidate_body: str, body: str) -> bool:
@@ -394,14 +425,158 @@ def _is_smaller_than_body(candidate_body: str, body: str) -> bool:
 CLAUDE_CALL_TIMEOUT_SECONDS = LOCK_WAIT_SECONDS // (MAX_RETRIES + 1)
 
 
-# ---------- Claude Calls ----------
+# ---------- LLM Calls ----------
+
+
+class AnthropicSdkUnavailable(RuntimeError):
+    """Raised when the explicitly selected Anthropic SDK is unavailable."""
+
+
+def configured_provider() -> str:
+    provider = (
+        os.environ.get(ENV_COMPRESS_PROVIDER)
+        or os.environ.get(ENV_FALLBACK_PROVIDER)
+        or PROVIDER_CLAUDE
+    ).strip().lower()
+    if provider not in SUPPORTED_PROVIDERS:
+        supported = ", ".join(sorted(SUPPORTED_PROVIDERS))
+        raise ValueError(
+            f"Unsupported caveman-compress provider: {provider}. "
+            f"Supported providers: {supported}"
+        )
+    return provider
+
+
+def configured_model(default_model: Optional[str] = None) -> Optional[str]:
+    model = (
+        os.environ.get(ENV_COMPRESS_MODEL)
+        or os.environ.get(ENV_FALLBACK_MODEL)
+        or default_model
+    )
+    if model is None:
+        return None
+    return model.strip() or None
+
+
+def run_cli(
+    binary_name: str,
+    args: List[str],
+    stdin_prompt: Optional[str] = None,
+) -> str:
+    binary = shutil.which(binary_name) or binary_name
+    command = [binary, *args]
+    run_kwargs = {
+        "text": True,
+        "capture_output": True,
+        "check": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+        "timeout": CLAUDE_CALL_TIMEOUT_SECONDS,
+    }
+    if stdin_prompt is not None:
+        run_kwargs["input"] = stdin_prompt
+    try:
+        result = subprocess.run(command, **run_kwargs)
+        return strip_llm_wrapper(result.stdout.strip())
+    except FileNotFoundError as error:
+        raise RuntimeError(f"{binary_name} CLI not found on PATH") from error
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip() if error.stderr else "no stderr"
+        raise RuntimeError(f"{binary_name} call failed:\n{stderr}") from error
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError(
+            f"{binary_name} CLI call timed out after "
+            f"{CLAUDE_CALL_TIMEOUT_SECONDS}s"
+        ) from error
+
+
+def call_anthropic_sdk(prompt: str) -> str:
+    api_key = os.environ.get(ENV_ANTHROPIC_API_KEY)
+    if not api_key:
+        raise RuntimeError(
+            f"{ENV_ANTHROPIC_API_KEY} is required for provider "
+            f"'{PROVIDER_ANTHROPIC}'"
+        )
+    try:
+        import anthropic
+    except ImportError as error:
+        raise AnthropicSdkUnavailable(
+            f"anthropic package is required for provider '{PROVIDER_ANTHROPIC}'"
+        ) from error
+
+    client = anthropic.Anthropic(
+        api_key=api_key,
+        timeout=CLAUDE_CALL_TIMEOUT_SECONDS,
+    )
+    message = client.messages.create(
+        model=configured_model(DEFAULT_CLAUDE_MODEL),
+        max_tokens=ANTHROPIC_MAX_TOKENS,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    # Tool-heavy models can put a tool_use or thinking block first.
+    text = next(
+        (
+            block.text
+            for block in message.content
+            if getattr(block, "type", None) == "text"
+        ),
+        "",
+    )
+    return strip_llm_wrapper(text.strip())
+
+
+def call_claude_cli(prompt: str) -> str:
+    args = []
+    model = configured_model()
+    if model:
+        args.extend([MODEL_ARG, model])
+    args.extend([
+        CLAUDE_PRINT_ARG,
+        CLAUDE_SETTING_SOURCES_ARG,
+        "",
+        CLAUDE_STRICT_MCP_ARG,
+    ])
+    return run_cli(CLAUDE_CLI, args, prompt)
+
+
+def call_opencode_cli(prompt: str) -> str:
+    args = [OPENCODE_RUN_ARG]
+    model = configured_model()
+    if model:
+        args.extend([MODEL_ARG, model])
+
+    prompt_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            prefix=OPENCODE_PROMPT_PREFIX,
+            suffix=OPENCODE_PROMPT_SUFFIX,
+            delete=False,
+        ) as prompt_file:
+            prompt_file.write(prompt)
+            prompt_path = Path(prompt_file.name)
+        args.extend(
+            [OPENCODE_FILE_ARG, str(prompt_path), OPENCODE_PROMPT_MESSAGE]
+        )
+        return run_cli(OPENCODE_CLI, args)
+    finally:
+        if prompt_path is not None:
+            try:
+                prompt_path.unlink(missing_ok=True)
+            except OSError as error:
+                raise RuntimeError(
+                    f"Failed to delete temporary opencode prompt: {prompt_path}"
+                ) from error
 
 
 def call_claude(prompt: str) -> str:
-    """Send a prompt to Claude.
+    """Send a prompt to the configured compression provider.
 
     Prefers the Anthropic SDK when ANTHROPIC_API_KEY is set; otherwise falls
-    back to the ``claude --print`` CLI (which handles desktop auth).
+    back to the ``claude --print`` CLI (which handles desktop auth). Set
+    ``CAVEMAN_COMPRESS_PROVIDER=opencode`` and ``CAVEMAN_COMPRESS_MODEL`` (or
+    ``CAVEMAN_MODEL``) to route compression through opencode instead.
 
     On Windows the CLI subprocess decoding defaults to the system codepage
     (cp1251 / cp1252) and crashes on UTF-8 output — see issue #152. Pinning
@@ -410,55 +585,17 @@ def call_claude(prompt: str) -> str:
     report. Windows users with non-ASCII content can also set
     ``ANTHROPIC_API_KEY`` to route through the SDK and skip the subprocess.
     """
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if api_key:
+    provider = configured_provider()
+    if provider == PROVIDER_OPENCODE:
+        return call_opencode_cli(prompt)
+    if provider == PROVIDER_ANTHROPIC:
+        return call_anthropic_sdk(prompt)
+    if os.environ.get(ENV_ANTHROPIC_API_KEY):
         try:
-            import anthropic
-
-            client = anthropic.Anthropic(api_key=api_key, timeout=CLAUDE_CALL_TIMEOUT_SECONDS)
-            msg = client.messages.create(
-                model=os.environ.get("CAVEMAN_MODEL", "claude-sonnet-4-5"),
-                max_tokens=8192,
-                messages=[{"role": "user", "content": prompt}],
-            )
-            # Tool-heavy models can put a tool_use or thinking block first; take
-            # the first text block instead of trusting content[0].
-            text = next((block.text for block in msg.content if getattr(block, "type", None) == "text"), "")
-            return strip_llm_wrapper(text.strip())
-        except ImportError:
-            pass  # anthropic not installed, fall back to CLI
-    # Fallback: use claude CLI (handles desktop auth).
-    # Resolve binary via shutil.which so Windows .cmd/.bat shims (e.g.
-    # %APPDATA%\npm\claude.CMD) work without shell=True. On POSIX,
-    # shutil.which returns the same absolute path as the implicit lookup,
-    # so this is a no-op there. Falls back to bare "claude" if not found
-    # on PATH so subprocess raises a clear FileNotFoundError.
-    claude_bin = shutil.which("claude") or "claude"
-    try:
-        result = subprocess.run(
-            [
-                claude_bin,
-                "--print",
-                "--setting-sources",
-                "",
-                "--strict-mcp-config",
-            ],
-            input=prompt,
-            text=True,
-            capture_output=True,
-            check=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=CLAUDE_CALL_TIMEOUT_SECONDS,
-        )
-        return strip_llm_wrapper(result.stdout.strip())
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"Claude call failed:\n{e.stderr}")
-    except subprocess.TimeoutExpired:
-        raise RuntimeError(
-            f"Claude CLI call timed out after {CLAUDE_CALL_TIMEOUT_SECONDS}s "
-            "(stalled network, or an auth prompt with no TTY to answer it)"
-        )
+            return call_anthropic_sdk(prompt)
+        except AnthropicSdkUnavailable:
+            pass
+    return call_claude_cli(prompt)
 
 
 def build_compress_prompt(original: str) -> str:
@@ -591,22 +728,24 @@ def compress_file(filepath: Path) -> bool:
     # Resolve first so the lock and every check below key off the same canonical path regardless of how the caller spelled it.
     filepath = filepath.resolve()
 
-    MAX_FILE_SIZE = 500_000  # 500KB
     # None of these three checks depends on mutual exclusion, so they run before the lock is taken — a rejected input (bad path, oversized, sensitive name) shouldn't leave a permanent lock file behind in shared state.
     if not filepath.exists():
         raise FileNotFoundError(f"File not found: {filepath}")
-    if filepath.stat().st_size > MAX_FILE_SIZE:
-        raise ValueError(f"File too large to compress safely (max 500KB): {filepath}")
+    if filepath.stat().st_size > MAX_FILE_SIZE_BYTES:
+        raise ValueError(
+            f"File too large to compress safely (max {MAX_FILE_SIZE_LABEL}): "
+            f"{filepath}"
+        )
 
     # Refuse files that look like they contain secrets or PII. Compressing ships
-    # the raw bytes to the Anthropic API — a third-party boundary — so we fail
+    # the raw bytes to the configured provider — a third-party boundary — so we fail
     # loudly rather than silently exfiltrate credentials or keys. Override is
     # intentional: the user must rename the file if the heuristic is wrong.
     if is_sensitive_path(filepath):
         raise ValueError(
             f"Refusing to compress {filepath}: filename looks sensitive "
             "(credentials, keys, secrets, or known private paths). "
-            "Compression sends file contents to the Anthropic API. "
+            "Compression sends file contents to the configured LLM provider. "
             "Rename the file if this is a false positive."
         )
 

--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -399,7 +399,7 @@ def _is_smaller_than_body(candidate_body: str, body: str) -> bool:
 
     The non-expansion invariant for #776. It lives in a helper because it has
     to hold for EVERY candidate, not just the first one: a candidate that fails
-    validation is sent back to Claude for repair, and the repaired text is what
+    validation is sent back to the provider for repair, and the repaired text is what
     gets written if it validates. Checking only the first candidate left the
     retry path able to write a longer file and report it as a successful
     compression — the original bug, one branch over.
@@ -705,7 +705,7 @@ def restore_code_blocks(text: str, blocks: List[Tuple[str, str]]) -> str:
     for marker, block in blocks:
         if restored.count(marker) != 1:
             raise ValueError(
-                f"Claude changed preserved code marker {marker}; refusing to write"
+                f"Provider changed preserved code marker {marker}; refusing to write"
             )
         # Masking gives marker its own transport newline. Consume that wrapper
         # when present so restoring a block that already ended in newline does
@@ -717,7 +717,7 @@ def restore_code_blocks(text: str, blocks: List[Tuple[str, str]]) -> str:
         else:
             restored = restored.replace(marker, block, 1)
     if CODE_MARKER_PREFIX in restored:
-        raise ValueError("Claude returned an unknown Caveman code-preservation marker")
+        raise ValueError("Provider returned an unknown Caveman code-preservation marker")
     return restored
 
 
@@ -779,7 +779,7 @@ def _compress_file_locked(filepath: Path) -> bool:
         print("Aborting to prevent data loss. Please remove or rename the backup file if you want to proceed.")
         return False
 
-    # Split YAML frontmatter off before compression. Claude tends to strip or
+    # Split YAML frontmatter off before compression. LLMs tend to strip or
     # rewrite frontmatter despite preserve-structure rules; we keep it verbatim
     # by removing it from the input and re-prepending it to the output.
     frontmatter, body = split_frontmatter(original_text)
@@ -791,7 +791,8 @@ def _compress_file_locked(filepath: Path) -> bool:
         return False
 
     # Step 1: Compress (body only, frontmatter excluded)
-    print("Compressing with Claude...")
+    provider = configured_provider()
+    print(f"Compressing with {provider}...")
     masked_body, code_blocks = mask_code_blocks(body)
     masked_compressed = call_claude(build_compress_prompt(masked_body))
     try:
@@ -802,7 +803,7 @@ def _compress_file_locked(filepath: Path) -> bool:
         return False
 
     if compressed_body is None or not compressed_body.strip():
-        print("❌ Compression aborted: Claude returned an empty response.")
+        print(f"❌ Compression aborted: {provider} returned an empty response.")
         print("   Original file is untouched (no backup created).")
         return False
 
@@ -810,7 +811,7 @@ def _compress_file_locked(filepath: Path) -> bool:
     # and would never change, so identity must be judged on the compressible part.
     if compressed_body.strip() == body.strip():
         print("❌ Compression aborted: output is identical to input.")
-        print("   Likely causes: Claude refused, returned the prompt verbatim, or the file is")
+        print(f"   Likely causes: {provider} refused, returned the prompt verbatim, or the file is")
         print("   already in caveman form. Original file is untouched (no backup created).")
         return False
 
@@ -866,13 +867,13 @@ def _compress_file_locked(filepath: Path) -> bool:
             print("Failed after retries: original left untouched")
             return False
 
-        print("Fixing with Claude...")
+        print(f"Fixing with {provider}...")
         fixed = call_claude(
             build_fix_prompt(original_text, compressed, result.errors)
         )
 
         if fixed is None or not fixed.strip():
-            print("❌ Fix attempt aborted: Claude returned an empty response.")
+            print(f"❌ Fix attempt aborted: {provider} returned an empty response.")
             print("   Skipping this attempt.")
             continue
 

--- a/tests/test_compress_safety.py
+++ b/tests/test_compress_safety.py
@@ -13,6 +13,7 @@ import stat
 import sys
 import tempfile
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 from unittest import mock
 
@@ -20,6 +21,40 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "skills" / "caveman-compress"))
 
 from scripts import compress as compress_mod  # noqa: E402
+
+LLM_ENV_KEYS = (
+    "ANTHROPIC_API_KEY",
+    "CAVEMAN_MODEL",
+    "CAVEMAN_PROVIDER",
+    "CAVEMAN_COMPRESS_MODEL",
+    "CAVEMAN_COMPRESS_PROVIDER",
+)
+OPENCODE_PROVIDER = "opencode"
+OPENCODE_MODEL = "github-copilot/gpt-4.1"
+PROMPT_TEXT = "Compress this memory."
+OPENCODE_OUTPUT = "Memory compressed."
+OPENCODE_BIN = "/usr/local/bin/opencode"
+OPENCODE_PROMPT_MESSAGE = "Follow the attached prompt exactly. Return only the final answer."
+OPENCODE_FILE_ARG = "--file"
+CLAUDE_MODEL = "claude-haiku-4-5"
+CLAUDE_OUTPUT = "Claude compressed."
+CLAUDE_BIN = "/usr/local/bin/claude"
+
+
+@contextmanager
+def llm_env(**overrides):
+    original = {key: os.environ.get(key) for key in LLM_ENV_KEYS}
+    try:
+        for key in LLM_ENV_KEYS:
+            os.environ.pop(key, None)
+        os.environ.update(overrides)
+        yield
+    finally:
+        for key, value in original.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 class CompressSafetyTests(unittest.TestCase):
@@ -405,8 +440,110 @@ class CompressSafetyTests(unittest.TestCase):
             backup = compress_mod.backup_dir_for(path) / "task.original.md"
             self.assertEqual(backup.read_bytes(), raw)
             backup.unlink()
+    def test_opencode_provider_uses_configured_model(self):
+        def run_opencode(command, **kwargs):
+            prompt_path = Path(command[command.index(OPENCODE_FILE_ARG) + 1])
+            self.assertEqual(prompt_path.read_text(), PROMPT_TEXT)
+            return mock.Mock(stdout=OPENCODE_OUTPUT)
 
+        with llm_env(
+            CAVEMAN_COMPRESS_PROVIDER=OPENCODE_PROVIDER,
+            CAVEMAN_COMPRESS_MODEL=OPENCODE_MODEL,
+        ), \
+             mock.patch.object(compress_mod.shutil, "which", return_value=OPENCODE_BIN), \
+             mock.patch.object(compress_mod.subprocess, "run", side_effect=run_opencode) as run:
+            output = compress_mod.call_claude(PROMPT_TEXT)
 
+        self.assertEqual(output, OPENCODE_OUTPUT)
+        run.assert_called_once()
+        command = run.call_args.args[0]
+        prompt_path = Path(command[command.index(OPENCODE_FILE_ARG) + 1])
+        self.assertEqual(command[:4], [OPENCODE_BIN, "run", "--model", OPENCODE_MODEL])
+        self.assertEqual(command[-1], OPENCODE_PROMPT_MESSAGE)
+        self.assertNotIn(PROMPT_TEXT, command)
+        self.assertNotEqual(prompt_path.parent, Path.cwd())
+        self.assertFalse(prompt_path.exists())
+        self.assertEqual(
+            run.call_args.kwargs,
+            {
+                "text": True,
+                "capture_output": True,
+                "check": True,
+                "encoding": "utf-8",
+                "errors": "replace",
+                "timeout": compress_mod.CLAUDE_CALL_TIMEOUT_SECONDS,
+            },
+        )
+
+    def test_claude_cli_uses_configured_model(self):
+        completed = mock.Mock(stdout=CLAUDE_OUTPUT)
+        with llm_env(CAVEMAN_COMPRESS_MODEL=CLAUDE_MODEL), \
+             mock.patch.object(compress_mod.shutil, "which", return_value=CLAUDE_BIN), \
+             mock.patch.object(compress_mod.subprocess, "run", return_value=completed) as run:
+            output = compress_mod.call_claude(PROMPT_TEXT)
+
+        self.assertEqual(output, CLAUDE_OUTPUT)
+        run.assert_called_once_with(
+            [
+                CLAUDE_BIN,
+                "--model",
+                CLAUDE_MODEL,
+                "--print",
+                "--setting-sources",
+                "",
+                "--strict-mcp-config",
+            ],
+            text=True,
+            capture_output=True,
+            check=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=compress_mod.CLAUDE_CALL_TIMEOUT_SECONDS,
+            input=PROMPT_TEXT,
+        )
+
+    def test_provider_specific_environment_takes_precedence(self):
+        with llm_env(
+            CAVEMAN_PROVIDER="anthropic",
+            CAVEMAN_COMPRESS_PROVIDER=OPENCODE_PROVIDER,
+            CAVEMAN_MODEL="fallback/model",
+            CAVEMAN_COMPRESS_MODEL=OPENCODE_MODEL,
+        ):
+            self.assertEqual(compress_mod.configured_provider(), OPENCODE_PROVIDER)
+            self.assertEqual(compress_mod.configured_model(), OPENCODE_MODEL)
+
+    def test_explicit_anthropic_provider_requires_api_key(self):
+        with llm_env(CAVEMAN_COMPRESS_PROVIDER="anthropic"):
+            with self.assertRaisesRegex(RuntimeError, "ANTHROPIC_API_KEY is required"):
+                compress_mod.call_claude(PROMPT_TEXT)
+
+    def test_opencode_prompt_cleanup_failure_is_reported(self):
+        prompt_paths = []
+
+        def run_opencode(command, **kwargs):
+            prompt_paths.append(Path(command[command.index(OPENCODE_FILE_ARG) + 1]))
+            return mock.Mock(stdout=OPENCODE_OUTPUT)
+
+        try:
+            with llm_env(CAVEMAN_COMPRESS_PROVIDER=OPENCODE_PROVIDER), \
+                 mock.patch.object(compress_mod.subprocess, "run", side_effect=run_opencode), \
+                 mock.patch.object(Path, "unlink", side_effect=OSError("denied")):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "Failed to delete temporary opencode prompt",
+                ):
+                    compress_mod.call_claude(PROMPT_TEXT)
+        finally:
+            for prompt_path in prompt_paths:
+                prompt_path.unlink(missing_ok=True)
+
+    def test_unknown_provider_is_rejected_before_subprocess(self):
+        with llm_env(CAVEMAN_COMPRESS_PROVIDER="bogus"), \
+             mock.patch.object(compress_mod.subprocess, "run") as run:
+            with self.assertRaisesRegex(ValueError, "Unsupported caveman-compress provider"):
+                compress_mod.call_claude(PROMPT_TEXT)
+
+        run.assert_not_called()
 if __name__ == "__main__":
     unittest.main()
 

--- a/tests/test_compress_safety.py
+++ b/tests/test_compress_safety.py
@@ -554,6 +554,41 @@ class CompressSafetyTests(unittest.TestCase):
             for prompt_path in prompt_paths:
                 prompt_path.unlink(missing_ok=True)
 
+    def test_opencode_prompt_is_removed_when_write_fails(self):
+        prompt_paths = []
+        named_temporary_file = tempfile.NamedTemporaryFile
+
+        class FailingPromptFile:
+            def __init__(self, *args, **kwargs):
+                self._prompt_file = named_temporary_file(*args, **kwargs)
+                self.name = self._prompt_file.name
+                prompt_paths.append(Path(self.name))
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return self._prompt_file.__exit__(exc_type, exc_value, traceback)
+
+            def write(self, _prompt):
+                raise OSError("prompt write failed")
+
+        try:
+            with llm_env(CAVEMAN_COMPRESS_PROVIDER=OPENCODE_PROVIDER), \
+                 mock.patch.object(
+                     compress_mod.tempfile,
+                     "NamedTemporaryFile",
+                     side_effect=FailingPromptFile,
+                 ):
+                with self.assertRaisesRegex(OSError, "prompt write failed"):
+                    compress_mod.call_claude(PROMPT_TEXT)
+
+            self.assertEqual(len(prompt_paths), 1)
+            self.assertFalse(prompt_paths[0].exists())
+        finally:
+            for prompt_path in prompt_paths:
+                prompt_path.unlink(missing_ok=True)
+
     def test_unknown_provider_is_rejected_before_subprocess(self):
         with llm_env(CAVEMAN_COMPRESS_PROVIDER="bogus"), \
              mock.patch.object(compress_mod.subprocess, "run") as run:

--- a/tests/test_compress_safety.py
+++ b/tests/test_compress_safety.py
@@ -561,6 +561,77 @@ class CompressSafetyTests(unittest.TestCase):
                 compress_mod.call_claude(PROMPT_TEXT)
 
         run.assert_not_called()
+
+    def test_missing_provider_cli_has_actionable_error(self):
+        with llm_env(CAVEMAN_COMPRESS_PROVIDER=OPENCODE_PROVIDER), \
+             mock.patch.object(compress_mod.shutil, "which", return_value=None), \
+             mock.patch.object(
+                 compress_mod.subprocess,
+                 "run",
+                 side_effect=FileNotFoundError,
+             ):
+            with self.assertRaisesRegex(RuntimeError, "opencode CLI not found on PATH"):
+                compress_mod.call_claude(PROMPT_TEXT)
+
+    def test_provider_cli_failure_includes_stderr(self):
+        failure = compress_mod.subprocess.CalledProcessError(
+            1,
+            [OPENCODE_BIN, "run"],
+            stderr="authentication failed",
+        )
+        with llm_env(CAVEMAN_COMPRESS_PROVIDER=OPENCODE_PROVIDER), \
+             mock.patch.object(
+                 compress_mod.subprocess,
+                 "run",
+                 side_effect=failure,
+             ):
+            with self.assertRaisesRegex(RuntimeError, "authentication failed"):
+                compress_mod.call_claude(PROMPT_TEXT)
+
+    def test_default_provider_falls_back_when_anthropic_sdk_is_missing(self):
+        completed = mock.Mock(stdout=CLAUDE_OUTPUT)
+        with llm_env(ANTHROPIC_API_KEY="test-key"), \
+             mock.patch.dict(sys.modules, {"anthropic": None}), \
+             mock.patch.object(compress_mod.subprocess, "run", return_value=completed):
+            self.assertEqual(compress_mod.call_claude(PROMPT_TEXT), CLAUDE_OUTPUT)
+
+    def test_unknown_provider_code_marker_is_rejected(self):
+        unknown_marker = f"{compress_mod.CODE_MARKER_PREFIX}unknown@@"
+        with self.assertRaisesRegex(ValueError, "unknown Caveman code-preservation marker"):
+            compress_mod.restore_code_blocks(unknown_marker, [])
+
+    def test_oversized_file_is_rejected_before_provider_call(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "task.md"
+            path.write_bytes(b"x" * (compress_mod.MAX_FILE_SIZE_BYTES + 1))
+            with mock.patch.object(compress_mod, "call_claude") as call:
+                with self.assertRaisesRegex(ValueError, compress_mod.MAX_FILE_SIZE_LABEL):
+                    compress_mod.compress_file(path)
+
+        call.assert_not_called()
+
+    def test_empty_fix_response_names_configured_provider(self):
+        invalid = mock.Mock(is_valid=False, errors=["heading mismatch"], warnings=[])
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._file_with(
+                Path(tmp),
+                "# Title\n\nA sufficiently long body that needs a structural repair.\n",
+            )
+            with llm_env(CAVEMAN_COMPRESS_PROVIDER=OPENCODE_PROVIDER), \
+                 mock.patch.object(
+                     compress_mod,
+                     "call_claude",
+                     side_effect=["# Title\n\nShort.\n", ""],
+                 ), \
+                 mock.patch.object(compress_mod, "validate", return_value=invalid), \
+                 mock.patch("builtins.print") as print_message:
+                ok = compress_mod.compress_file(path)
+
+        self.assertFalse(ok)
+        print_message.assert_any_call("Fixing with opencode...")
+        print_message.assert_any_call(
+            "❌ Fix attempt aborted: opencode returned an empty response."
+        )
 if __name__ == "__main__":
     unittest.main()
 

--- a/tests/test_compress_safety.py
+++ b/tests/test_compress_safety.py
@@ -475,6 +475,23 @@ class CompressSafetyTests(unittest.TestCase):
             },
         )
 
+    def test_compression_status_names_configured_provider(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._file_with(
+                Path(tmp),
+                "# Title\n\nA sufficiently long body for provider status testing.\n",
+            )
+            with llm_env(CAVEMAN_COMPRESS_PROVIDER=OPENCODE_PROVIDER), \
+                 mock.patch.object(compress_mod, "call_claude", return_value=""), \
+                 mock.patch("builtins.print") as print_message:
+                ok = compress_mod.compress_file(path)
+
+        self.assertFalse(ok)
+        print_message.assert_any_call("Compressing with opencode...")
+        print_message.assert_any_call(
+            "❌ Compression aborted: opencode returned an empty response."
+        )
+
     def test_claude_cli_uses_configured_model(self):
         completed = mock.Mock(stdout=CLAUDE_OUTPUT)
         with llm_env(CAVEMAN_COMPRESS_MODEL=CLAUDE_MODEL), \


### PR DESCRIPTION
Fixes #759

## Summary

- Add env-driven provider routing for `caveman-compress`: default Claude path, explicit `anthropic`, and explicit `opencode`.
- Add compress-specific model env support through `CAVEMAN_COMPRESS_MODEL`, with `CAVEMAN_MODEL` as fallback.
- Send opencode prompts through a temporary `--file` attachment instead of argv, then delete the temp file.
- Document provider/model env behavior and security implications.

CI will resync `plugins/caveman/skills/caveman-compress/...` on merge.

## Test verification (RED -> GREEN)

RED, upstream behavior ignored opencode provider and still called Claude CLI:

```text
FAIL: test_opencode_provider_uses_configured_model
Expected: run(['/usr/local/bin/opencode', 'run', '--model', 'github-copilot/gpt-4.1', 'Compress this memory.'], ...)
  Actual: run(['/usr/local/bin/opencode', '--print'], input='Compress this memory.', ...)
FAILED (failures=1, errors=1)
```

RED, Claude CLI ignored configured model:

```text
FAIL: test_claude_cli_uses_configured_model
Expected: run(['/usr/local/bin/claude', '--model', 'claude-haiku-4-5', '--print'], ...)
  Actual: run(['/usr/local/bin/claude', '--print'], ...)
FAILED (failures=1)
```

RED, opencode path needed non-argv prompt attachment:

```text
ERROR: test_opencode_provider_uses_configured_model
ValueError: '--file' is not in list
FAILED (errors=1)
```

GREEN, provider/model tests:

```text
Ran 3 tests in 0.002s

OK
```

Full local CI baseline on upstream main:

```text
# tests 112
# pass 112
python compress safety: Ran 5 tests ... OK
```

Full local CI final branch:

```text
# tests 112
# pass 112
python compress safety: Ran 8 tests ... OK
```

Review gates:

```text
contribute-code:     PASS
local-ci-docker:     PASS
pr-check:            PASS
ocr-codex:           PASS
main-codex-review:   PASS
```
