### PR TITLE
docs: add more ways to setup caveman.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ gemini extensions install https://github.com/JuliusBrussee/caveman
 npx skills add JuliusBrussee/caveman -a cursor
 ```
 
+Already inside a Claude Code session? Same thing with the `/plugin` command:
+
+```bash
+/plugin marketplace add JuliusBrussee/caveman
+/plugin install caveman@caveman
+```
+
 **Install broke?** Open your agent in this repo and say: *"Read CLAUDE.md and INSTALL.md, install caveman for me."* Agent read repo, agent fix own brain. Snake eat tail.
 
 </details>


### PR DESCRIPTION
**What you want**
When i search caveman github on goggle,
i wan't to be able to install caveman directly in my agent
instead of going to claudepluginhub.com, waiting for the cloudflare protect, and go to manual install.

**Before/after example**

Before: 
Every agent has its own path (plugin, extension, rule file, or `npx skills add`). The full per-agent matrix, all flags, dry-run, and uninstall live in **[INSTALL.md](./INSTALL.md)**. A few common ones:

```bash
# Claude Code plugin
claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman

# Gemini CLI extension
gemini extensions install https://github.com/JuliusBrussee/caveman

# Cursor / Windsurf / Cline / Codex / 30+ more, via the skills registry
npx skills add JuliusBrussee/caveman -a cursor
```

````bash
# Via the /plugin command
/plugin marketplace add juliusbrussee/caveman
````

````bash
# Install Caveman
/plugin install caveman@caveman
````
After: 
Every agent has its own path (plugin, extension, rule file, or `npx skills add`). The full per-agent matrix, all flags, dry-run, and uninstall live in **[INSTALL.md](./INSTALL.md)**. A few common ones:

```bash
# Claude Code plugin
claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman

# Gemini CLI extension
gemini extensions install https://github.com/JuliusBrussee/caveman

# Cursor / Windsurf / Cline / Codex / 30+ more, via the skills registry
npx skills add JuliusBrussee/caveman -a cursor
```

Already inside a Claude Code session? Same thing with the `/plugin` command:

```bash
/plugin marketplace add JuliusBrussee/caveman
/plugin install caveman@caveman
```

**Why good**
Saves times, do not redirect to a third party website that has a cloudflare ddos protection on -_- (and count your visits)
Saves clicks.
