### PR TITLE
docs(caveman): drop arrows from ultra example in skill README

### DIFF
--- a/skills/caveman/README.md
+++ b/skills/caveman/README.md
@@ -40,7 +40,7 @@ Caveman (full):
 > New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`.
 
 Caveman (ultra):
-> Inline obj prop → new ref → re-render. `useMemo`.
+> Inline obj prop, new ref, re-render. `useMemo`.
 
 ## See also
 


### PR DESCRIPTION
Skill README ultra example use arrows. SKILL.md ban arrows. Fix README.

## What

`skills/caveman/README.md:43` show ultra example with `→`:

```
> Inline obj prop → new ref → re-render. `useMemo`.
```

## Why

`skills/caveman/SKILL.md` forbid arrows twice:

- Line 21 (Rules): "No causal arrows (→) either — own token, save nothing."
- Line 38 (ultra row): "NO arrows (X → Y) — measured zero token saving under tokenizer, cost decode clarity."

`SKILL.md:46` already show arrow-free version. README was only file in repo still using arrow form — human-facing doc teaching exact thing spec ban.

## Before / after

Before:
```
> Inline obj prop → new ref → re-render. `useMemo`.
```

After:
```
> Inline obj prop, new ref, re-render. `useMemo`.
```

New wording better: copied verbatim from `SKILL.md:46`, so README and spec now agree, and example stop demonstrating banned syntax.

One line, docs only. CI will resync `dist/caveman.skill` on merge (ZIP of `skills/caveman/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
