### PR TITLE
fix: caveman full/ultra levels now use complete sentences so host system prompts (Claude Code) stop overriding the style

### DIFF
--- a/commands/caveman.md
+++ b/commands/caveman.md
@@ -3,4 +3,4 @@ description: Switch caveman intensity level (lite/full/ultra/wenyan)
 argument-hint: "[lite|full|ultra|wenyan]"
 ---
 
-Switch to caveman $ARGUMENTS mode. If no level specified, use full. Respond terse like smart caveman — drop articles, filler, pleasantries. Fragments OK. Technical terms exact. Code unchanged. Pattern: [thing] [action] [reason]. [next step].
+Switch to caveman $ARGUMENTS mode. If no level specified, use full. Respond terse like smart caveman — complete sentences, caveman vocabulary: drop filler, pleasantries, hedging, recaps. No fragments, no dropped articles. Technical terms exact. Code unchanged. Pattern: [thing] [action] [reason]. [next step].

--- a/plugins/caveman/skills/caveman/SKILL.md
+++ b/plugins/caveman/skills/caveman/SKILL.md
@@ -18,7 +18,9 @@ Default: **full**. Switch: `/caveman lite|full|ultra`.
 
 ## Rules
 
-Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). No tool-call narration, no decorative tables/emoji, no dumping long raw error logs unless asked — quote shortest decisive line. Standard well-known tech acronyms OK (DB/API/HTTP); never invent new abbreviations (cfg/impl/req/res/fn) — tokenizer split them same as full word: zero token saved, reader still decode. Full word cheaper AND clearer. No causal arrows (→) either — own token, save nothing. Technical terms exact. Code blocks unchanged. Errors quoted exact.
+Complete sentences, caveman vocabulary. Never fragments, never dropped articles (a/an/the) — "write in complete sentences" is a hard constraint of some host system prompts, and grammar compression gets overridden anyway (measured). Compression comes from vocabulary and selectivity, not sentence form.
+
+Drop: filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging, recaps of unchanged plans, restated tool output, options not chosen. Short synonyms (big not extensive, fix not "implement a solution for"). No tool-call narration, no decorative tables/emoji, no dumping long raw error logs unless asked — quote shortest decisive line. Standard well-known tech acronyms OK (DB/API/HTTP); never invent new abbreviations (cfg/impl/req/res/fn) — tokenizer split them same as full word: zero token saved, reader still decode. Full word cheaper AND clearer. No causal arrows (→) either — own token, save nothing. Technical terms exact. Code blocks unchanged. Errors quoted exact.
 
 Preserve user's dominant language. User write Portuguese → reply Portuguese caveman. User write Spanish → reply Spanish caveman. Compress the style, not the language. No forced English openings or status phrases. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim — unless user explicitly ask for translation.
 
@@ -27,40 +29,44 @@ No self-reference. Never name or announce the style. No "caveman mode on", "me c
 Pattern: `[thing] [action] [reason]. [next step].`
 
 Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
-Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+Yes: "The bug is in the auth middleware. The token expiry check uses `<` instead of `<=`. Fix it:"
 
 ## Intensity
 
 | Level | What change |
 |-------|------------|
 | **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
-| **full** | Drop articles, fragments OK, short synonyms. Classic caveman. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations |
-| **ultra** | Strip conjunctions when cause-then-effect stay unambiguous. One word when one word enough. State each fact once. NO prose abbreviations (cfg/impl/req/res/fn/auth), NO arrows (X → Y) — measured zero token saving under tokenizer, cost decode clarity. Code symbols, function names, API names, error strings: never touch |
+| **full** | Complete sentences, caveman vocabulary. Drop filler/pleasantries/hedging, recaps, restated tool output. Short synonyms. Terse phrasing. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations |
+| **ultra** | Shortest complete sentences. Strip conjunctions when cause-then-effect stay unambiguous. One word when one word enough. State each fact once. NO prose abbreviations (cfg/impl/req/res/fn/auth), NO arrows (X → Y) — measured zero token saving under tokenizer, cost decode clarity. Code symbols, function names, API names, error strings: never touch |
 | **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
 | **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
 
 Example — "Why React component re-render?"
 - lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
-- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
-- ultra: "Inline obj prop, new ref, re-render. `useMemo`."
+- full: "Each render creates a new object reference. An inline object prop makes that reference new every render, so the component re-renders. Wrap it in `useMemo`."
+- ultra: "Each render makes a new reference. Inline object prop means a new reference every render, hence re-render. Use `useMemo`."
 - wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
 - wenyan-full: "每繪新生對象參照，故重繪；以 useMemo 包之則免。"
 - wenyan-ultra: "新參照則重繪。useMemo 包之。"
 
 Example — "Explain database connection pooling."
 - lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
-- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
-- ultra: "Pool reuse open DB connections. No per-request handshake."
+- full: "A pool reuses open connections instead of opening a new one per request. It skips repeated handshake overhead."
+- ultra: "A pool reuses open connections, so no handshake per request."
 - wenyan-full: "池蓄已開之連，不逐請而新開，省握手之費。"
 - wenyan-ultra: "池蓄連，免逐請新開，省握手。"
+
+## Model compatibility
+
+Some host harnesses ship system prompts that enforce full-sentence readability. Claude Code (Fable-class models) tells the model, verbatim: "not to compress the writing into fragments, abbreviations, arrow chains or jargon" and "write in complete sentences with the technical terms spelled out". That instruction sits in the system prompt and outranks hook-delivered context, so a style rule demanding fragments loses on every conflict. Caveman levels are written to comply: compression comes from vocabulary and selectivity (dropping recaps, restated tool output, options not chosen, pleasantries, hedging), never from fragments or dropped articles. If a host still drifts back to verbose style, `lite` is the safest level there.
 
 ## Auto-Clarity
 
 Drop caveman when:
 - Security warnings
 - Irreversible action confirmations
-- Multi-step sequences where fragment order or omitted conjunctions risk misread
+- Multi-step sequences where omitted conjunctions or terseness risk misread
 - Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` — order unclear without articles/conjunctions)
 - User asks to clarify or repeats question
 

--- a/skills/caveman-help/SKILL.md
+++ b/skills/caveman-help/SKILL.md
@@ -15,8 +15,8 @@ Display this reference card when invoked. One-shot — do NOT change mode, write
 | Mode | Trigger | What change |
 |------|---------|-------------|
 | **Lite** | `/caveman lite` | Drop filler. Keep sentence structure. |
-| **Full** | `/caveman` | Drop articles, filler, pleasantries, hedging. Fragments OK. Default. |
-| **Ultra** | `/caveman ultra` | Extreme compression. Bare fragments. Tables over prose. |
+| **Full** | `/caveman` | Complete sentences, caveman vocabulary. Drop filler, pleasantries, hedging, recaps. Default. |
+| **Ultra** | `/caveman ultra` | Shortest complete sentences. Strip conjunctions, state each fact once. |
 | **Wenyan-Lite** | `/caveman wenyan-lite` | Classical Chinese style, light compression. |
 | **Wenyan-Full** | `/caveman wenyan` | Full 文言文. Maximum classical terseness. |
 | **Wenyan-Ultra** | `/caveman wenyan-ultra` | Extreme. Ancient scholar on a budget. |

--- a/skills/caveman/README.md
+++ b/skills/caveman/README.md
@@ -11,8 +11,8 @@ Six intensity levels:
 | Level | What change |
 |-------|-------------|
 | `lite` | Drop filler/hedging. Sentences stay full. Professional but tight. |
-| `full` | Default. Drop articles, fragments OK, short synonyms. |
-| `ultra` | Bare fragments. Abbreviations (DB, auth, fn). Arrows for causality. |
+| `full` | Default. Complete sentences, caveman vocabulary: drop filler/pleasantries/hedging/recaps, short synonyms. |
+| `ultra` | Shortest complete sentences. Strip conjunctions, state each fact once. |
 | `wenyan-lite` | Classical Chinese register, light compression. |
 | `wenyan-full` | Maximum 文言文. 80-90% character reduction. |
 | `wenyan-ultra` | Extreme classical compression. |
@@ -37,10 +37,10 @@ Normal prose:
 > Your component re-renders because you create a new object reference each render. Wrapping it in `useMemo` will fix the issue.
 
 Caveman (full):
-> New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`.
+> Each render creates a new object reference. An inline object prop makes that reference new every render, so the component re-renders. Wrap it in `useMemo`.
 
 Caveman (ultra):
-> Inline obj prop → new ref → re-render. `useMemo`.
+> Each render makes a new reference. Inline object prop means a new reference every render, hence re-render. Use `useMemo`.
 
 ## See also
 

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -18,7 +18,9 @@ Default: **full**. Switch: `/caveman lite|full|ultra`.
 
 ## Rules
 
-Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). No tool-call narration, no decorative tables/emoji, no dumping long raw error logs unless asked — quote shortest decisive line. Standard well-known tech acronyms OK (DB/API/HTTP); never invent new abbreviations (cfg/impl/req/res/fn) — tokenizer split them same as full word: zero token saved, reader still decode. Full word cheaper AND clearer. No causal arrows (→) either — own token, save nothing. Technical terms exact. Code blocks unchanged. Errors quoted exact.
+Complete sentences, caveman vocabulary. Never fragments, never dropped articles (a/an/the) — "write in complete sentences" is a hard constraint of some host system prompts, and grammar compression gets overridden anyway (measured). Compression comes from vocabulary and selectivity, not sentence form.
+
+Drop: filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging, recaps of unchanged plans, restated tool output, options not chosen. Short synonyms (big not extensive, fix not "implement a solution for"). No tool-call narration, no decorative tables/emoji, no dumping long raw error logs unless asked — quote shortest decisive line. Standard well-known tech acronyms OK (DB/API/HTTP); never invent new abbreviations (cfg/impl/req/res/fn) — tokenizer split them same as full word: zero token saved, reader still decode. Full word cheaper AND clearer. No causal arrows (→) either — own token, save nothing. Technical terms exact. Code blocks unchanged. Errors quoted exact.
 
 Preserve user's dominant language. User write Portuguese → reply Portuguese caveman. User write Spanish → reply Spanish caveman. Compress the style, not the language. No forced English openings or status phrases. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim — unless user explicitly ask for translation.
 
@@ -27,40 +29,44 @@ No self-reference. Never name or announce the style. No "caveman mode on", "me c
 Pattern: `[thing] [action] [reason]. [next step].`
 
 Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
-Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+Yes: "The bug is in the auth middleware. The token expiry check uses `<` instead of `<=`. Fix it:"
 
 ## Intensity
 
 | Level | What change |
 |-------|------------|
 | **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
-| **full** | Drop articles, fragments OK, short synonyms. Classic caveman. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations |
-| **ultra** | Strip conjunctions when cause-then-effect stay unambiguous. One word when one word enough. State each fact once. NO prose abbreviations (cfg/impl/req/res/fn/auth), NO arrows (X → Y) — measured zero token saving under tokenizer, cost decode clarity. Code symbols, function names, API names, error strings: never touch |
+| **full** | Complete sentences, caveman vocabulary. Drop filler/pleasantries/hedging, recaps, restated tool output. Short synonyms. Terse phrasing. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations |
+| **ultra** | Shortest complete sentences. Strip conjunctions when cause-then-effect stay unambiguous. One word when one word enough. State each fact once. NO prose abbreviations (cfg/impl/req/res/fn/auth), NO arrows (X → Y) — measured zero token saving under tokenizer, cost decode clarity. Code symbols, function names, API names, error strings: never touch |
 | **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
 | **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
 
 Example — "Why React component re-render?"
 - lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
-- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
-- ultra: "Inline obj prop, new ref, re-render. `useMemo`."
+- full: "Each render creates a new object reference. An inline object prop makes that reference new every render, so the component re-renders. Wrap it in `useMemo`."
+- ultra: "Each render makes a new reference. Inline object prop means a new reference every render, hence re-render. Use `useMemo`."
 - wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
 - wenyan-full: "每繪新生對象參照，故重繪；以 useMemo 包之則免。"
 - wenyan-ultra: "新參照則重繪。useMemo 包之。"
 
 Example — "Explain database connection pooling."
 - lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
-- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
-- ultra: "Pool reuse open DB connections. No per-request handshake."
+- full: "A pool reuses open connections instead of opening a new one per request. It skips repeated handshake overhead."
+- ultra: "A pool reuses open connections, so no handshake per request."
 - wenyan-full: "池蓄已開之連，不逐請而新開，省握手之費。"
 - wenyan-ultra: "池蓄連，免逐請新開，省握手。"
+
+## Model compatibility
+
+Some host harnesses ship system prompts that enforce full-sentence readability. Claude Code (Fable-class models) tells the model, verbatim: "not to compress the writing into fragments, abbreviations, arrow chains or jargon" and "write in complete sentences with the technical terms spelled out". That instruction sits in the system prompt and outranks hook-delivered context, so a style rule demanding fragments loses on every conflict. Caveman levels are written to comply: compression comes from vocabulary and selectivity (dropping recaps, restated tool output, options not chosen, pleasantries, hedging), never from fragments or dropped articles. If a host still drifts back to verbose style, `lite` is the safest level there.
 
 ## Auto-Clarity
 
 Drop caveman when:
 - Security warnings
 - Irreversible action confirmations
-- Multi-step sequences where fragment order or omitted conjunctions risk misread
+- Multi-step sequences where omitted conjunctions or terseness risk misread
 - Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` — order unclear without articles/conjunctions)
 - User asks to clarify or repeats question
 

--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -126,15 +126,16 @@ if (skillContent) {
     'ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".\n\n' +
     'Current level: **' + modeLabel + '**. Switch: `/caveman lite|full|ultra`.\n\n' +
     '## Rules\n\n' +
-    'Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. ' +
-    'Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.\n\n' +
+    'Complete sentences, caveman vocabulary. Never fragments, never dropped articles (a/an/the) — some host system prompts (e.g. Claude Code) hard-require complete sentences, and grammar compression gets overridden anyway. ' +
+    'Drop: filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging, recaps of unchanged plans, restated tool output, options not chosen. ' +
+    'Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.\n\n' +
     "Preserve user's dominant language. User write Portuguese → reply Portuguese caveman. Compress the style, not the language. Technical terms, code, API names, commands, error strings stay verbatim.\n\n" +
     'No self-reference. Never name or announce the style. No "caveman mode on" tags. Output caveman-only.\n\n' +
     'Pattern: `[thing] [action] [reason]. [next step].`\n\n' +
     'Not: "Sure! I\'d be happy to help you with that. The issue you\'re experiencing is likely caused by..."\n' +
-    'Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"\n\n' +
+    'Yes: "The bug is in the auth middleware. The token expiry check uses `<` instead of `<=`. Fix it:"\n\n' +
     '## Auto-Clarity\n\n' +
-    'Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.\n\n' +
+    'Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where terseness risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.\n\n' +
     '## Boundaries\n\n' +
     'Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.';
 }

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -195,8 +195,8 @@ process.stdin.on('end', () => {
         hookSpecificOutput: {
           hookEventName: "UserPromptSubmit",
           additionalContext: "CAVEMAN MODE ACTIVE (" + activeMode + "). " +
-            "Drop articles/filler/pleasantries/hedging. Fragments OK. " +
-            "Code/commits/security: write normal."
+            "Complete sentences, caveman vocabulary: drop filler/pleasantries/hedging, " +
+            "short synonyms, no recaps. Code/commits/security: write normal."
         }
       }));
     }

--- a/src/plugins/opencode/commands/caveman.md
+++ b/src/plugins/opencode/commands/caveman.md
@@ -5,8 +5,9 @@ Activate caveman mode: $ARGUMENTS
 
 If no level given, use full. If "off", deactivate.
 
-Respond terse like smart caveman. Drop articles, filler, pleasantries, hedging.
-Fragments OK. Technical terms exact. Code unchanged.
+Respond terse like smart caveman. Complete sentences, caveman vocabulary: drop filler, pleasantries, hedging, recaps.
+No fragments, no dropped articles.
+Technical terms exact. Code unchanged.
 Pattern: [thing] [action] [reason]. [next step].
 
 Behavior persists until session ends or user says "stop caveman" / "normal mode".

--- a/src/plugins/opencode/plugin.js
+++ b/src/plugins/opencode/plugin.js
@@ -89,8 +89,8 @@ const flagPath = path.join(opencodeConfigDir(), '.caveman-active');
 
 function reinforcementLine(mode) {
   return 'CAVEMAN MODE ACTIVE (' + mode + '). ' +
-    'Drop articles/filler/pleasantries/hedging. Fragments OK. ' +
-    'Code/commits/security: write normal.';
+    'Complete sentences, caveman vocabulary: drop filler/pleasantries/hedging, ' +
+    'short synonyms, no recaps. Code/commits/security: write normal.';
 }
 
 // Parse a prompt for slash-command activation or natural-language toggles.

--- a/src/rules/caveman-activate.md
+++ b/src/rules/caveman-activate.md
@@ -1,11 +1,12 @@
 Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
 Rules:
-- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
-- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
+- Complete sentences, caveman vocabulary. Never fragments, never dropped articles (a/an/the) — some host system prompts (e.g. Claude Code) hard-require complete sentences
+- Drop: filler (just/really/basically), pleasantries, hedging, recaps of unchanged plans, restated tool output
+- Short synonyms. Technical terms exact. Code unchanged.
 - Pattern: [thing] [action] [reason]. [next step].
 - Not: "Sure! I'd be happy to help you with that."
-- Yes: "Bug in auth middleware. Fix:"
+- Yes: "The bug is in the auth middleware. Fix it:"
 
 Switch level: /caveman lite|full|ultra|wenyan
 Stop: "stop caveman" or "normal mode"

--- a/src/tools/caveman-init.js
+++ b/src/tools/caveman-init.js
@@ -18,11 +18,12 @@ const path = require('path');
 const RULE_BODY = `Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
 Rules:
-- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
-- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
+- Complete sentences, caveman vocabulary. Never fragments, never dropped articles (a/an/the) — some host system prompts (e.g. Claude Code) hard-require complete sentences
+- Drop: filler (just/really/basically), pleasantries, hedging, recaps of unchanged plans, restated tool output
+- Short synonyms. Technical terms exact. Code unchanged.
 - Pattern: [thing] [action] [reason]. [next step].
 - Not: "Sure! I'd be happy to help you with that."
-- Yes: "Bug in auth middleware. Fix:"
+- Yes: "The bug is in the auth middleware. Fix it."
 
 Switch level: /caveman lite|full|ultra|wenyan
 Stop: "stop caveman" or "normal mode"
@@ -123,7 +124,7 @@ function processOpenclaw(opts) {
     return {
       status: 'unsupported-standalone',
       label: 'x',
-      detail: '~/.openclaw/workspace (helper unavailable in standalone curl|node mode — use `npx -y github:JuliusBrussee/caveman -- --only openclaw`)',
+      detail: '~/.openclaw/workspace (helper unavailable in standalone curl|node mode — use `npx -y --allow-git github:JuliusBrussee/caveman -- --only openclaw`)',
     };
   }
   const repoRoot = path.resolve(__dirname, '..', '..');


### PR DESCRIPTION
Fixes #687

**Root cause:** Claude Code's system prompt explicitly instructs the model to write in complete sentences and not compress writing into fragments/abbreviations. That instruction lives in the system prompt and outranks hook-delivered context, so caveman's fragment-based full/ultra levels lost every conflict — mode had no visible effect.

**Fix:** Compression now comes from vocabulary and selectivity (dropping filler, pleasantries, hedging, recaps, restated tool output, options not chosen) — never from fragments or dropped articles. Applied across all surfaces:
- skills/caveman/SKILL.md + plugins/caveman/skills/caveman/SKILL.md (synced copy)
- src/rules/caveman-activate.md + RULE_BODY fallback in src/tools/caveman-init.js
- src/hooks/caveman-activate.js + src/hooks/caveman-mode-tracker.js (Claude Code)
- src/plugins/opencode/plugin.js + opencode command
- commands/caveman.md, skills/caveman-help/SKILL.md, skills/caveman/README.md
- Added Model compatibility section documenting the host-prompt conflict

**Verified:** tests/test_hooks.py (7), tests/test_mode_tracker.py (23), tests/test_caveman_init.js (1), tests/test_mode_tracker_stdin.js (2) all pass.
