### PR TITLE
fix(stats): count each API response once, not once per content-block line

### DIFF
--- a/src/hooks/caveman-stats.js
+++ b/src/hooks/caveman-stats.js
@@ -100,6 +100,14 @@ function parseSession(filePath) {
   let turns = 0;
   let model = null;
   const messages = []; // per-message {ts, outputTokens} for mode attribution (#601)
+  // Claude Code writes one JSONL line PER CONTENT BLOCK of an API response
+  // (text block, then each tool_use block), all sharing the same message.id +
+  // requestId and repeating the same usage object. Summing every line counts
+  // the same response's tokens once per block — 1.5-2.1x inflation measured
+  // on real tool-heavy sessions. Count each (requestId, message.id) once.
+  // Entries without a message.id (synthetic/legacy logs) keep per-line
+  // counting — there is no key to dedupe on.
+  const seenResponses = new Set();
   for (const line of raw.split('\n')) {
     if (!line.trim()) continue;
     let entry;
@@ -107,6 +115,11 @@ function parseSession(filePath) {
     if (entry.type !== 'assistant' || !entry.message) continue;
     const usage = entry.message.usage;
     if (!usage) continue;
+    if (entry.message.id) {
+      const key = (entry.requestId || '') + ':' + entry.message.id;
+      if (seenResponses.has(key)) continue;
+      seenResponses.add(key);
+    }
     outputTokens    += usage.output_tokens           || 0;
     cacheReadTokens += usage.cache_read_input_tokens || 0;
     turns++;

--- a/tests/test_caveman_stats.js
+++ b/tests/test_caveman_stats.js
@@ -54,6 +54,55 @@ test('reads --session-file directly and sums output tokens', (tmp) => {
   assert.match(out, /Cache-read tokens:\s+250/);
 });
 
+test('counts a multi-block API response once, not once per JSONL line', (tmp) => {
+  // Claude Code writes one assistant line per content block (text + each
+  // tool_use) of the same API response — same message.id + requestId, same
+  // usage repeated. Only one line per response may count.
+  const usage = { output_tokens: 487, cache_read_input_tokens: 1000 };
+  const sess = makeSession(tmp, [
+    { type: 'assistant', requestId: 'req_1', message: { id: 'msg_a', usage } },
+    { type: 'assistant', requestId: 'req_1', message: { id: 'msg_a', usage } },
+    { type: 'assistant', requestId: 'req_1', message: { id: 'msg_a', usage } },
+    { type: 'user', message: { content: 'tool result' } },
+    { type: 'assistant', requestId: 'req_2', message: { id: 'msg_b', usage: { output_tokens: 13, cache_read_input_tokens: 500 } } },
+  ]);
+  const out = execFileSync(process.execPath, [STATS, '--session-file', sess], {
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_CONFIG_DIR: path.join(tmp, '.claude') },
+  });
+  assert.match(out, /Turns:\s+2/);
+  assert.match(out, /Output tokens:\s+500\b/);
+  assert.match(out, /Cache-read tokens:\s+1,?\.?500\b/);
+});
+
+test('same message.id under different requestIds counts per response (retry path)', (tmp) => {
+  // A retried request re-sends the same message.id under a new requestId —
+  // those are distinct billed responses and must both count.
+  const sess = makeSession(tmp, [
+    { type: 'assistant', requestId: 'req_1', message: { id: 'msg_a', usage: { output_tokens: 100 } } },
+    { type: 'assistant', requestId: 'req_2', message: { id: 'msg_a', usage: { output_tokens: 100 } } },
+  ]);
+  const out = execFileSync(process.execPath, [STATS, '--session-file', sess], {
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_CONFIG_DIR: path.join(tmp, '.claude') },
+  });
+  assert.match(out, /Turns:\s+2/);
+  assert.match(out, /Output tokens:\s+200\b/);
+});
+
+test('entries without message.id keep per-line counting (no dedupe key)', (tmp) => {
+  const sess = makeSession(tmp, [
+    { type: 'assistant', message: { usage: { output_tokens: 100 } } },
+    { type: 'assistant', message: { usage: { output_tokens: 100 } } },
+  ]);
+  const out = execFileSync(process.execPath, [STATS, '--session-file', sess], {
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_CONFIG_DIR: path.join(tmp, '.claude') },
+  });
+  assert.match(out, /Turns:\s+2/);
+  assert.match(out, /Output tokens:\s+200\b/);
+});
+
 test('shows full-mode savings estimate when flag is full', (tmp) => {
   const sess = makeSession(tmp, [
     { type: 'assistant', message: { usage: { output_tokens: 350 } } },


### PR DESCRIPTION
Fixes #793

`parseSession()` sums `usage.output_tokens` for every `type: "assistant"` line in the session JSONL. But Claude Code writes one JSONL line per content block of the same API response — a response with a text block plus two tool_use blocks lands as three assistant lines, same `message.id` + `requestId`, same `usage` object repeated on each. Every multi-block response is counted once per block.

Measured on 8 real session transcripts: 1.5-2.1x inflation on any session with tool calls (1.00x only on trivial no-tool sessions). One example: summed=119,513 vs deduped=57,132 output tokens; `turns` reported 82 where 44 responses happened.

Everything downstream inflates with it: Est. tokens saved, Est. saved (USD), the lifetime history snapshots, the statusline ⛏ badge, and the per-mode attribution from #601 — against the spirit of docs/HONEST-NUMBERS.md.

## Approach

Dedupe by `(requestId, message.id)` inside the parse loop — count each API response once:

- `message.id` alone is not enough: a retried request re-sends the same `message.id` under a new `requestId`, and those are distinct billed responses (same key ccusage uses).
- Entries without `message.id` (synthetic/legacy logs, existing test fixtures) keep per-line counting — nothing to dedupe on, no behaviour change for them.

Existing `.caveman-history.jsonl` rows keep their inflated snapshots, but `aggregateHistory` keeps only the latest row per session — one /caveman-stats run after the fix self-corrects each session still on disk.

## Testing

Three regression tests added to tests/test_caveman_stats.js:

- multi-block response counted once (fails against unpatched `parseSession`)
- same `message.id` under different `requestId`s still counts per response
- entries without `message.id` keep per-line counting

Full tests/test_caveman_stats.js suite passes with no new failures. Neighbouring suites unaffected: test_caveman_parse.js 33/33, test_mode_tracker_stdin.js 11/11, test_symlink_flag.js 15/15, test_repo_local_config.js 14/14.
