### PR TITLE
fix(skill): scope article and fragment rules to intensity levels

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -18,7 +18,7 @@ Default: **full**. Switch: `/caveman lite|full|ultra|wenyan-lite|wenyan-full|wen
 
 ## Rules
 
-Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). No tool-call narration, no decorative tables/emoji, no dumping long raw error logs unless asked — quote shortest decisive line. Standard well-known tech acronyms OK (DB/API/HTTP); never invent new abbreviations (cfg/impl/req/res/fn) — tokenizer split them same as full word: zero token saved, reader still decode. Full word cheaper AND clearer. No causal arrows (→) either — own token, save nothing. Technical terms exact. Code blocks unchanged. Errors quoted exact.
+Drop: filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Short synonyms (big not extensive, fix not "implement a solution for"). No tool-call narration, no decorative tables/emoji, no dumping long raw error logs unless asked — quote shortest decisive line. Standard well-known tech acronyms OK (DB/API/HTTP); never invent new abbreviations (cfg/impl/req/res/fn) — tokenizer split them same as full word: zero token saved, reader still decode. Full word cheaper AND clearer. No causal arrows (→) either — own token, save nothing. Technical terms exact. Code blocks unchanged. Errors quoted exact.
 
 Never drop not/never/no/only/except — flip meaning worse than any token saved. Numbers, units exact.
 
@@ -26,7 +26,9 @@ Tool calls: fire direct. No preamble, plan, or progress note before or between c
 
 Preserve user's dominant language exactly — reply in the language user writes, never switch regardless of example text or multilingual context elsewhere. Compress the style, not the language. Every emitted line in that language — openings, pre-tool status lines, all — not just final reply. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim — unless user explicitly ask for translation.
 
-'Drop articles' = article languages only. Where small markers carry case/role (particles, postpositions), keep them — grammar, not filler; compress politeness/filler instead.
+Articles and sentence fragments vary by level — see Intensity, not here. Rules in this section apply at every level.
+
+Where a level does drop articles, that mean article languages only. Where small markers carry case/role (particles, postpositions), keep them — grammar, not filler; compress politeness/filler instead.
 
 No self-reference. Never name or announce the style. No "caveman mode on", "me caveman think", no third-person caveman tags. Output caveman-only — never normal answer plus "Caveman:" recap. Exception: user explicitly ask what the mode is.
 
@@ -41,7 +43,7 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 |-------|------------|
 | **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
 | **full** | Drop articles, fragments OK, short synonyms. Classic caveman. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations |
-| **ultra** | Strip conjunctions when cause-then-effect stay unambiguous. One word when one word enough. State each fact once. NO prose abbreviations (cfg/impl/req/res/fn/auth), NO arrows (X → Y) — measured zero token saving under tokenizer, cost decode clarity. Code symbols, function names, API names, error strings: never touch |
+| **ultra** | Drop articles, fragments OK. Strip conjunctions when cause-then-effect stay unambiguous. One word when one word enough. State each fact once. NO prose abbreviations (cfg/impl/req/res/fn/auth), NO arrows (X → Y) — measured zero token saving under tokenizer, cost decode clarity. Code symbols, function names, API names, error strings: never touch |
 | **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
 | **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction — chars, not tokens. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
 | **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |


### PR DESCRIPTION
## Problem

`## Rules` in `skills/caveman/SKILL.md` states two rules unconditionally:

> Drop: **articles (a/an/the)**, filler ..., hedging. **Fragments OK.**

But `src/hooks/caveman-activate.js` filters only the intensity **table rows** and the `- level:` example lines. The `## Rules` prose is level-agnostic and reaches the model at every level.

So at `lite`, whose row says the opposite, the SessionStart payload contradicts itself:

| line | text |
|------|------|
| `## Rules` | `Drop: articles (a/an/the) ... Fragments OK.` |
| intensity row | `lite ... Keep articles + full sentences` |

## Repro

```bash
CAVEMAN_DEFAULT_MODE=lite node src/hooks/caveman-activate.js | rg -w 'Keep articles|Drop: articles'
```

Both lines come back.

## Measured before / after

Counting `Keep articles` vs `Drop articles` occurrences in the emitted ruleset:

| level | before | after |
|-------|--------|-------|
| `lite` | keep=1 **drop=2** ← contradiction | keep=1 drop=0 |
| `full` | keep=0 drop=3 | keep=0 drop=1 |
| `ultra` | keep=0 drop=2 | keep=0 drop=1 |
| `wenyan-*` | — | — |

## Fix

Move the two level-varying rules out of the shared block into the rows that own them.

- `lite` and `full` already stated both — unchanged.
- `ultra` was **silent** on both, so it inherited them only via the shared block. It now states them explicitly, preserving today's behavior.
- `wenyan-lite` / `wenyan-full` / `wenyan-ultra` were also silent, but articles do not exist in classical Chinese and the existing language clause already scopes the rule to "article languages only". No row change needed.

One file, `skills/caveman/SKILL.md`. No CI-generated mirrors touched.

## Deliberately out of scope

The `Not:` / `Yes:` example under `## Rules` still models full-style prose (`Token expiry check use ...`), which is slightly off at `lite`. It illustrates killing the pleasantry preamble, which is universal, so I left it rather than widen the diff. Happy to follow up if you want it level-filtered via the existing `- level:` mechanism.

## Tests

`npm test`, the standalone `tests/test_*.js` sweep, and the Python suite were run on this branch **and** on `main` at `ec83e5b`. Failure sets are byte-identical, so this change introduces none:

| suite | main | this branch |
|-------|------|-------------|
| `npm test` | 121 pass / 4 fail | 121 pass / 4 fail |
| `test_caveman_parse.js` | 31 pass / 2 fail | 31 pass / 2 fail |
| `test_mode_tracker_stdin.js` | 10 pass / 1 fail | 10 pass / 1 fail |

The pre-existing failures are in the installer/uninstall paths (one is explicitly `skipped without \`claude\` CLI`) and are untouched by a prose change.