### PR TITLE
fix(compress): match fences nested in list items

### DIFF
--- a/skills/caveman-compress/scripts/validate.py
+++ b/skills/caveman-compress/scripts/validate.py
@@ -4,7 +4,7 @@ from collections import Counter
 from pathlib import Path
 
 URL_REGEX = re.compile(r"https?://[^\s)]+")
-FENCE_OPEN_REGEX = re.compile(r"^(\s{0,3})(`{3,}|~{3,})(.*)$")
+FENCE_OPEN_REGEX = re.compile(r"^([ \t]*)(`{3,}|~{3,})(.*)$")
 HEADING_REGEX = re.compile(r"^(#{1,6})\s+(.*)", re.MULTILINE)
 BULLET_REGEX = re.compile(r"^\s*[-*+]\s+", re.MULTILINE)
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -8,10 +8,15 @@ sys.path.insert(0, str(REPO_ROOT / "skills" / "caveman-compress"))
 
 from scripts.validate import (  # noqa: E402
     ValidationResult,
+    extract_code_blocks,
     extract_inline_codes,
     validate,
+    validate_code_blocks,
     validate_inline_codes,
 )
+
+MANGLED = "- step:\n{i}```\n{i}rm -rf /  # rewritten\n{i}```\n"
+INTACT = "- step:\n{i}```\n{i}rm -rf /important\n{i}```\n"
 
 
 class TestExtractInlineCodes(unittest.TestCase):
@@ -52,6 +57,16 @@ More text with `inline3`.
         result = extract_inline_codes(text)
         self.assertEqual(result, ["inline"])
 
+    def test_list_nested_fence_backtick_not_leaked_as_inline(self):
+        text = "- step:\n    ```\n    `weird`\n    ```\nReal `inline` span here."
+        result = extract_inline_codes(text)
+        self.assertEqual(result, ["inline"])
+
+    def test_deeply_nested_fence_backtick_not_leaked_as_inline(self):
+        text = "- a:\n  - b:\n        ```\n        `weird`\n        ```\nReal `inline` span."
+        result = extract_inline_codes(text)
+        self.assertEqual(result, ["inline"])
+
 
 class TestValidateInlineCodes(unittest.TestCase):
     def test_match(self):
@@ -80,6 +95,41 @@ class TestValidateInlineCodes(unittest.TestCase):
         result = ValidationResult()
         validate_inline_codes("plain text", "also plain", result)
         self.assertTrue(result.is_valid)
+
+
+class TestExtractCodeBlocks(unittest.TestCase):
+    def test_top_level_fence(self):
+        self.assertEqual(len(extract_code_blocks("```\ncode\n```\n")), 1)
+
+    def test_fence_indented_within_list_item(self):
+        self.assertEqual(len(extract_code_blocks(INTACT.format(i="    "))), 1)
+
+    def test_fence_indented_within_nested_list_item(self):
+        text = "- a:\n  - b:\n        ```\n        code\n        ```\n"
+        self.assertEqual(len(extract_code_blocks(text)), 1)
+
+    def test_tilde_fence_indented_within_list_item(self):
+        text = "- step:\n    ~~~\n    code\n    ~~~\n"
+        self.assertEqual(len(extract_code_blocks(text)), 1)
+
+
+class TestValidateCodeBlocks(unittest.TestCase):
+    def test_rewritten_block_is_rejected_at_every_indent(self):
+        for indent in ("", "  ", "    ", "        "):
+            with self.subTest(indent=len(indent)):
+                result = ValidationResult()
+                validate_code_blocks(
+                    INTACT.format(i=indent), MANGLED.format(i=indent), result
+                )
+                self.assertFalse(result.is_valid)
+
+    def test_untouched_block_passes(self):
+        for indent in ("", "  ", "    ", "        "):
+            with self.subTest(indent=len(indent)):
+                result = ValidationResult()
+                text = INTACT.format(i=indent)
+                validate_code_blocks(text, text, result)
+                self.assertTrue(result.is_valid)
 
 
 class TestValidateIntegration(unittest.TestCase):


### PR DESCRIPTION
## What

`FENCE_OPEN_REGEX` allowed 0-3 spaces of fence indent. Now unbounded.

## Why

0-3 is right for a **top-level** fence - 4+ spaces there is an indented code block, not a fence. But inside a list item, indent counts from the item's **content column**, not the left margin. A fence under `- ` (content column 2) sits at 4 absolute and is only 2 relative, so CommonMark still reads it as a fence. The 0-3 bound missed every one of them.

Nesting a fence under a bullet is ordinary markdown, common in exactly the `CLAUDE.md` / README files this skill exists to compress.

Two failures, both on real files:

**1. Inline-code pairing desyncs.** The unseen fence stays in the text, so its body backticks pair with ordinary prose backticks. On a real 300-line `CLAUDE.md` with four list-nested fences: 126 spans, 9 of them over 200 chars, longest 2290 - multi-paragraph prose reported as inline code. `Inline code lost` fires, and the cherry-pick retry cannot win, since satisfying it means restoring the prose verbatim. Both retries fail and compression aborts. After this change: 123 spans, longest 57.

**2. Nested code blocks were never validated at all** - the more serious half. `extract_code_blocks` skipped them, so `validate_code_blocks` had nothing to compare:

```python
orig    = "- step:\n    ```\n    rm -rf /important\n    ```\n"
mangled = "- step:\n    ```\n    rm -rf /  # rewritten\n    ```\n"
# before: extract_code_blocks(orig) == []  ->  is_valid = True
# after:  is_valid = False, "Code blocks not preserved exactly"
```

At 2-space indent the same mangling was caught. At 4 it sailed through. So SKILL.md's "anything inside ``` must be copied EXACTLY" had no enforcement behind it for any fence under a bullet.

Follow-up to #619, which fixed the column-0 anchoring but kept the 0-3 bound.

## Trade-off

A top-level *indented* code block whose body contains a literal ``` ``` ``` line now reads as a fence opener. Rare, and strictly better than leaving list-nested blocks unvalidated, but it is a real change and worth your call.

## Tests

`tests/test_validate_inline.py` is renamed to `tests/test_validate.py` and now covers the whole module - one test file per script, matching `test_detect.py` / `test_compress_safety.py`. Nothing covered `validate_code_blocks` before, which is why this survived #619.

66 pass with the fix. Reverting just the regex and keeping the tests fails 7. None of the 5 existing fixtures in `tests/caveman-compress/` contains an indented fence.

## Note

Source-of-truth edit: CI will resync `plugins/caveman/skills/caveman-compress/scripts/validate.py` on merge.
