### PR TITLE
fix(hooks): cap UserPromptSubmit timeout at 2s

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -24,7 +24,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-mode-tracker.js\"",
-            "timeout": 5,
+            "timeout": 2,
             "statusMessage": "Tracking caveman mode..."
           }
         ]


### PR DESCRIPTION
## What

Lowers the `UserPromptSubmit` hook timeout in `.claude-plugin/plugin.json` from 5s to 2s. `SessionStart` stays at 5s.

## Why

`UserPromptSubmit` hooks run synchronously — Claude Code waits for the hook before processing the user's message, on every prompt. The timeout is therefore the worst-case input latency the plugin can add.

- Normal runtime of `caveman-mode-tracker.js` is 20–30ms (measured, node cold start included).
- Under heavy system load a cold node start can hang until the timeout. Observed in the wild: a 5.4s prompt stall (hook_cancelled, timedOut) while an unrelated CPU/IO-heavy job saturated the machine.
- Timing out is benign by design: the per-turn reinforcement line is skipped for one turn; the mode itself stays active via the SessionStart ruleset and the flag file.

2s keeps ~100× headroom over normal runtime while halving-plus the worst-case stall. `SessionStart` is left at 5s since it runs once per session and injects the full ruleset — worth waiting for.

## Testing

- `jq empty .claude-plugin/plugin.json`
- Hook exercised locally with the 2s cap: normal prompts unaffected (20–30ms), reminder still injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)