### PR TITLE
Fix inconsistencies in off commands; ultra mode inconsistencies

### DIFF
--- a/skills/caveman/README.md
+++ b/skills/caveman/README.md
@@ -12,7 +12,7 @@ Six intensity levels:
 |-------|-------------|
 | `lite` | Drop filler/hedging. Sentences stay full. Professional but tight. |
 | `full` | Default. Drop articles, fragments OK, short synonyms. |
-| `ultra` | Bare fragments. Abbreviations (DB, auth, fn). Arrows for causality. |
+| `ultra` | Bare fragments. Abbreviations (DB, auth, fn). NO ARROWS. |
 | `wenyan-lite` | Classical Chinese register, light compression. |
 | `wenyan-full` | Maximum 文言文. 80-90% character reduction. |
 | `wenyan-ultra` | Extreme classical compression. |

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -12,7 +12,7 @@ Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
 ## Persistence
 
-ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode" / "caveman off".
 
 Default: **full**. Switch: `/caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off`.
 
@@ -85,4 +85,4 @@ Example — destructive op:
 
 ## Boundaries
 
-Persisted outside chat: write normal prose — code, comments, commits, docs, issue/PR/MR text, memory files, third-party messages (/caveman-compress exempt). "stop caveman" or "normal mode": revert. Level persist until changed or session end.
+Persisted outside chat: write normal prose — code, comments, commits, docs, issue/PR/MR text, memory files, third-party messages (/caveman-compress exempt). "stop caveman", "normal mode" or "caveman off": revert. Level persist until changed or session end.


### PR DESCRIPTION
1. Adding `caveman off` in persistence rule so it is not ignored.
2. Fixed conflicting rules about arrows in ultra mode. No arrows should be used based on line 44 of `skills\caveman\SKILL.md`