### PR TITLE
fix(caveman-init): prefer shipped script over curl pipe

### DIFF
--- a/commands/caveman-init.md
+++ b/commands/caveman-init.md
@@ -8,6 +8,7 @@ Write the per-repo caveman rule files (Cursor, Windsurf, Cline, Copilot, AGENTS.
 How to run the init script — pick the first that applies:
 
 1. If `src/tools/caveman-init.js` exists in the current repo (you are inside a caveman checkout), run: `node src/tools/caveman-init.js $ARGUMENTS`
-2. Otherwise download and run the standalone script (it is self-contained and supports stdin execution): `curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/src/tools/caveman-init.js | node - $ARGUMENTS`
+2. Otherwise, if `${CLAUDE_PLUGIN_ROOT}/src/tools/caveman-init.js` exists (plugin install), run the copy caveman ships: `node "${CLAUDE_PLUGIN_ROOT}/src/tools/caveman-init.js" $ARGUMENTS`
+3. Otherwise download and run the standalone script (it is self-contained and supports stdin execution): `curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/src/tools/caveman-init.js | node - $ARGUMENTS`
 
 Use `--dry-run` first if the user did not pass `--force`, so we never silently overwrite an existing rule file.


### PR DESCRIPTION
## What

`/caveman-init` step 1 only checked the user's own repo for `src/tools/caveman-init.js`. Installed users never have it, so every run fell through to the curl pipe.

New step 2 runs the copy caveman ships. Curl drops to step 3, so `npx caveman` keeps working unchanged.

```
1. repo checkout  → node src/tools/caveman-init.js
2. plugin install → node "${CLAUDE_PLUGIN_ROOT}/src/tools/caveman-init.js"   ← new
3. otherwise      → curl … | node -                                          ← unchanged
```

`plugin.json`, `caveman-activate.js:94` and `cavecrew-model-overrides.js:36` already resolve through `${CLAUDE_PLUGIN_ROOT}`.

## Why

Trust thing. Not convenience. Not saving network request.

Pin caveman to SHA, review that code, done. Should be whole story. Is not. Command fetch from branch at call time. Pin cover repo, not runtime URL. So audited pin still run whatever `main` hold that minute.

Fork only defense left. Do not want fork. Want pin to mean something.

After change: plugin install run shipped code only. Pin hold.

## Tests

No test change needed — the `#603` test asserts the curl fallback exists, and it still does.

`npm test` — 121 pass, identical to base. 4 pre-existing failures (uninstall tests, need the `claude` CLI).

No CI sync — `sync-skill.yml` only watches `skills/**`.