### PR TITLE
fix(hooks): resolve node robustly in SessionStart/UserPromptSubmit hooks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-activate.js\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/src/hooks/run-with-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-activate.js\"",
             "timeout": 5,
             "statusMessage": "Loading caveman mode..."
           }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-mode-tracker.js\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/src/hooks/run-with-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-mode-tracker.js\"",
             "timeout": 5,
             "statusMessage": "Tracking caveman mode..."
           }

--- a/src/hooks/install.ps1
+++ b/src/hooks/install.ps1
@@ -24,7 +24,7 @@ $HooksDir = Join-Path $ClaudeDir "hooks"
 $Settings = Join-Path $ClaudeDir "settings.json"
 $RepoUrl = "https://raw.githubusercontent.com/JuliusBrussee/caveman/main/src/hooks"
 
-$HookFiles = @("package.json", "caveman-config.js", "caveman-parse.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-stats.js", "caveman-statusline.sh", "caveman-statusline.ps1", "cavecrew-model-overrides.js")
+$HookFiles = @("package.json", "caveman-config.js", "caveman-parse.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-stats.js", "caveman-statusline.sh", "caveman-statusline.ps1", "cavecrew-model-overrides.js", "run-with-node.sh")
 
 # Resolve source — works from repo clone or remote
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { $null }
@@ -134,7 +134,7 @@ if (!hasStart) {
   settings.hooks.SessionStart.push({
     hooks: [{
       type: 'command',
-      command: 'node "' + hooksDir + '/caveman-activate.js"',
+      command: 'sh "' + hooksDir + '/run-with-node.sh" "' + hooksDir + '/caveman-activate.js"',
       timeout: 5,
       statusMessage: 'Loading caveman mode...'
     }]
@@ -150,7 +150,7 @@ if (!hasPrompt) {
   settings.hooks.UserPromptSubmit.push({
     hooks: [{
       type: 'command',
-      command: 'node "' + hooksDir + '/caveman-mode-tracker.js"',
+      command: 'sh "' + hooksDir + '/run-with-node.sh" "' + hooksDir + '/caveman-mode-tracker.js"',
       timeout: 5,
       statusMessage: 'Tracking caveman mode...'
     }]

--- a/src/hooks/install.sh
+++ b/src/hooks/install.sh
@@ -37,7 +37,7 @@ HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS="$CLAUDE_DIR/settings.json"
 REPO_URL="https://raw.githubusercontent.com/JuliusBrussee/caveman/main/src/hooks"
 
-HOOK_FILES=("package.json" "caveman-config.js" "caveman-parse.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-stats.js" "caveman-statusline.sh" "cavecrew-model-overrides.js")
+HOOK_FILES=("package.json" "caveman-config.js" "caveman-parse.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-stats.js" "caveman-statusline.sh" "cavecrew-model-overrides.js" "run-with-node.sh")
 
 # Resolve source — works from repo clone or curl pipe
 SCRIPT_DIR=""
@@ -143,7 +143,7 @@ CAVEMAN_SETTINGS="$SETTINGS" CAVEMAN_HOOKS_DIR="$HOOKS_DIR" node -e "
     settings.hooks.SessionStart.push({
       hooks: [{
         type: 'command',
-        command: 'node \"' + hooksDir + '/caveman-activate.js\"',
+        command: 'sh \"' + hooksDir + '/run-with-node.sh\" \"' + hooksDir + '/caveman-activate.js\"',
         timeout: 5,
         statusMessage: 'Loading caveman mode...'
       }]
@@ -159,7 +159,7 @@ CAVEMAN_SETTINGS="$SETTINGS" CAVEMAN_HOOKS_DIR="$HOOKS_DIR" node -e "
     settings.hooks.UserPromptSubmit.push({
       hooks: [{
         type: 'command',
-        command: 'node \"' + hooksDir + '/caveman-mode-tracker.js\"',
+        command: 'sh \"' + hooksDir + '/run-with-node.sh\" \"' + hooksDir + '/caveman-mode-tracker.js\"',
         timeout: 5,
         statusMessage: 'Tracking caveman mode...'
       }]

--- a/src/hooks/run-with-node.sh
+++ b/src/hooks/run-with-node.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# run-with-node.sh <script.js> — resolve node from a robust fallback chain and
+# exec the given hook script with it.
+#
+# Claude Code runs hook commands with a minimal, non-interactive PATH (no
+# nvm/profile sourcing), so a bare `node "$script"` prints
+# "/bin/sh: 1: node: not found" on every prompt even when node is installed
+# and perfectly usable from an interactive shell (issue: SessionStart /
+# UserPromptSubmit hook noise). Try PATH first, then the common absolute
+# install locations, and if node genuinely isn't installed anywhere, skip the
+# hook silently rather than printing non-blocking noise every turn.
+set -eu
+
+script="$1"
+
+find_node() {
+  command -v node 2>/dev/null && return 0
+  command -v nodejs 2>/dev/null && return 0
+  # nvm's installed versions (no active shell profile to resolve "default")
+  # and the common OS package-manager / Homebrew install locations.
+  for candidate in "$HOME"/.nvm/versions/node/*/bin/node \
+                   /usr/local/bin/node /opt/homebrew/bin/node /usr/bin/node; do
+    [ -x "$candidate" ] && printf '%s\n' "$candidate" && return 0
+  done
+  return 1
+}
+
+node_bin=$(find_node) || exit 0
+exec "$node_bin" "$script"

--- a/src/hooks/run-with-node.sh
+++ b/src/hooks/run-with-node.sh
@@ -18,7 +18,10 @@ find_node() {
   command -v nodejs 2>/dev/null && return 0
   # nvm's installed versions (no active shell profile to resolve "default")
   # and the common OS package-manager / Homebrew install locations.
-  for candidate in "$HOME"/.nvm/versions/node/*/bin/node \
+  # ${HOME:-} — HOME is occasionally unset in the minimal env hooks run
+  # under; under `set -u` a bare "$HOME" would abort the script here
+  # instead of falling through to the other candidates below.
+  for candidate in "${HOME:-}"/.nvm/versions/node/*/bin/node \
                    /usr/local/bin/node /opt/homebrew/bin/node /usr/bin/node; do
     [ -x "$candidate" ] && printf '%s\n' "$candidate" && return 0
   done

--- a/src/hooks/uninstall.ps1
+++ b/src/hooks/uninstall.ps1
@@ -11,7 +11,7 @@ $HooksDir = Join-Path $ClaudeDir "hooks"
 $Settings = Join-Path $ClaudeDir "settings.json"
 $FlagFile = Join-Path $ClaudeDir ".caveman-active"
 
-$HookFiles = @("package.json", "caveman-config.js", "caveman-parse.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-stats.js", "caveman-statusline.sh", "caveman-statusline.ps1", "cavecrew-model-overrides.js")
+$HookFiles = @("package.json", "caveman-config.js", "caveman-parse.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-stats.js", "caveman-statusline.sh", "caveman-statusline.ps1", "cavecrew-model-overrides.js", "run-with-node.sh")
 
 # Detect if caveman is installed as a plugin
 $PluginInstalled = $false

--- a/src/hooks/uninstall.sh
+++ b/src/hooks/uninstall.sh
@@ -10,7 +10,7 @@ HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS="$CLAUDE_DIR/settings.json"
 FLAG_FILE="$CLAUDE_DIR/.caveman-active"
 
-HOOK_FILES=("package.json" "caveman-config.js" "caveman-parse.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-stats.js" "caveman-statusline.sh" "cavecrew-model-overrides.js")
+HOOK_FILES=("package.json" "caveman-config.js" "caveman-parse.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-stats.js" "caveman-statusline.sh" "cavecrew-model-overrides.js" "run-with-node.sh")
 
 # Detect if caveman is installed as a plugin (check plugin cache)
 PLUGIN_INSTALLED=0

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -58,6 +58,28 @@ class HookScriptTests(unittest.TestCase):
             self.assertIn(str(statusline), settings["statusLine"]["command"])
 
     @POSIX_SHELL_ONLY
+    def test_install_wires_hooks_through_run_with_node_wrapper(self):
+        # Regression: install.sh used to wire hooks as a bare `node "$script"`
+        # — the exact "node: not found" hook-noise bug the run-with-node.sh
+        # wrapper exists to fix — so a fresh install must route through it too,
+        # not just the plugin manifest.
+        if BASH is None:
+            self.skipTest("bash not found")
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-wrapper-") as tmp:
+            home = Path(tmp)
+
+            self.run_cmd(["bash", "src/hooks/install.sh"], home)
+
+            hooks_dir = home / ".claude" / "hooks"
+            self.assertTrue((hooks_dir / "run-with-node.sh").exists(), "run-with-node.sh should be installed")
+
+            settings = json.loads((home / ".claude" / "settings.json").read_text(encoding="utf-8"))
+            start_cmd = settings["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+            prompt_cmd = settings["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"]
+            self.assertIn("run-with-node.sh", start_cmd)
+            self.assertIn("run-with-node.sh", prompt_cmd)
+
+    @POSIX_SHELL_ONLY
     def test_install_reconfigures_missing_statusline(self):
         if BASH is None:
             self.skipTest("bash not found")

--- a/tests/test_run_with_node.py
+++ b/tests/test_run_with_node.py
@@ -60,6 +60,22 @@ class RunWithNodeTests(unittest.TestCase):
             self.assertIn("fake-node saw:", result.stdout)
             self.assertIn(str(script), result.stdout)
 
+    def test_survives_unset_home_without_crashing(self):
+        # Regression: under `set -eu`, referencing "$HOME" while HOME is
+        # entirely absent from the environment (not just empty — genuinely
+        # unset, as hook runners occasionally leave it) aborts the `for`
+        # candidate loop with "HOME: parameter not set" before any of the
+        # other absolute-path fallbacks are even tried. `run_wrapper` with no
+        # `home=` already omits HOME from the child env, so this only needs
+        # a PATH with no node on it to force the fallback loop to run.
+        with tempfile.TemporaryDirectory(prefix="run-with-node-nohome-") as tmp:
+            script = Path(tmp) / "probe.js"
+            script.write_text("unused\n")
+
+            result = self.run_wrapper(script, "/usr/bin:/bin")
+            self.assertEqual(result.returncode, 0)
+            self.assertNotIn("parameter not set", result.stderr)
+
     def test_silently_skips_when_node_is_nowhere_to_be_found(self):
         with tempfile.TemporaryDirectory(prefix="run-with-node-none-") as tmp:
             home = Path(tmp)

--- a/tests/test_run_with_node.py
+++ b/tests/test_run_with_node.py
@@ -1,0 +1,76 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WRAPPER = REPO_ROOT / "src" / "hooks" / "run-with-node.sh"
+
+
+# Regression for hooks printing "/bin/sh: 1: node: not found" on every prompt:
+# plugin hooks run with a minimal PATH (no nvm/profile sourcing), so a bare
+# `node "$script"` fails even when node is installed and usable interactively.
+class RunWithNodeTests(unittest.TestCase):
+    def run_wrapper(self, script, path, home=None, extra_env=None):
+        env = {"PATH": path}
+        if home is not None:
+            env["HOME"] = str(home)
+        if extra_env:
+            env.update(extra_env)
+        return subprocess.run(
+            ["sh", str(WRAPPER), str(script)],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_resolves_node_from_path(self):
+        with tempfile.TemporaryDirectory(prefix="run-with-node-path-") as tmp:
+            script = Path(tmp) / "probe.js"
+            script.write_text("console.log('ok-from-path')\n")
+            real_node = subprocess.run(
+                ["sh", "-c", "command -v node"], text=True, capture_output=True
+            ).stdout.strip()
+            if not real_node:
+                self.skipTest("no node on PATH in this test environment")
+            result = self.run_wrapper(script, os.path.dirname(real_node) + ":/usr/bin:/bin")
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("ok-from-path", result.stdout)
+
+    def test_falls_back_to_nvm_absolute_path_when_path_is_broken(self):
+        # Simulates the reported bug: hook PATH has no node, but node is
+        # installed via nvm for the interactive shell.
+        with tempfile.TemporaryDirectory(prefix="run-with-node-nvm-") as tmp:
+            home = Path(tmp)
+            fake_version_dir = home / ".nvm" / "versions" / "node" / "v99.0.0" / "bin"
+            fake_version_dir.mkdir(parents=True)
+            fake_node = fake_version_dir / "node"
+            fake_node.write_text(
+                "#!/bin/sh\necho \"fake-node saw: $*\"\n"
+            )
+            fake_node.chmod(0o755)
+
+            script = home / "probe.js"
+            script.write_text("unused\n")
+
+            result = self.run_wrapper(script, "/usr/bin:/bin", home=home)
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("fake-node saw:", result.stdout)
+            self.assertIn(str(script), result.stdout)
+
+    def test_silently_skips_when_node_is_nowhere_to_be_found(self):
+        with tempfile.TemporaryDirectory(prefix="run-with-node-none-") as tmp:
+            home = Path(tmp)
+            script = home / "probe.js"
+            script.write_text("unused\n")
+
+            result = self.run_wrapper(script, "/usr/bin:/bin", home=home)
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertEqual(result.stderr, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/verify_repo.py
+++ b/tests/verify_repo.py
@@ -190,6 +190,19 @@ def verify_manifests_and_syntax() -> None:
         actual = hashlib.sha256((hook_dir / filename).read_bytes()).hexdigest()
         ensure(actual == expected, f"hook checksum mismatch: {filename}")
 
+    # Regression guard: plugin hooks must resolve node through run-with-node.sh,
+    # not invoke it bare — a bare `node "$script"` fails under the minimal PATH
+    # hook commands run with (no nvm/profile sourcing), printing
+    # "/bin/sh: 1: node: not found" noise on every prompt.
+    plugin_manifest = read_json(ROOT / ".claude-plugin/plugin.json")
+    for event in ("SessionStart", "UserPromptSubmit"):
+        for group in plugin_manifest["hooks"][event]:
+            for hook in group["hooks"]:
+                ensure(
+                    "run-with-node.sh" in hook["command"],
+                    f"{event} hook does not route node through run-with-node.sh: {hook['command']}",
+                )
+
     run(["node", "--check", "src/hooks/caveman-config.js"])
     run(["node", "--check", "src/hooks/caveman-parse.js"])
     run(["node", "--check", "src/hooks/caveman-activate.js"])
@@ -202,6 +215,7 @@ def verify_manifests_and_syntax() -> None:
         run([bash, "-n", "src/hooks/install.sh"])
         run([bash, "-n", "src/hooks/uninstall.sh"])
         run([bash, "-n", "src/hooks/caveman-statusline.sh"])
+        run([bash, "-n", "src/hooks/run-with-node.sh"])
     else:
         print("SKIP: Bash syntax checks require Bash; PowerShell static checks still run")
 


### PR DESCRIPTION
## Problem
The `SessionStart` and `UserPromptSubmit` plugin hooks invoke `node` directly
(`.claude-plugin/plugin.json`). Claude Code runs hook commands with a
minimal, non-interactive PATH (no nvm/profile sourcing), so on any machine
where node is only on PATH via nvm/an interactive shell, every single prompt
prints:

```
UserPromptSubmit hook error ... /bin/sh: 1: node: not found
```

Non-blocking, but constant noise across every session.

## Solution
Added `src/hooks/run-with-node.sh`, a small POSIX-sh wrapper that:
1. tries `command -v node` / `nodejs` (PATH),
2. falls back to common absolute install locations (`~/.nvm/versions/node/*/bin/node`,
   `/usr/local/bin`, `/opt/homebrew/bin`, `/usr/bin`),
3. if node genuinely isn't installed anywhere, exits 0 silently rather than
   printing hook-error noise every turn.

Both hook entries in `plugin.json` now route through it. Added
`tests/test_run_with_node.py` (PATH resolution, nvm-absolute-path fallback,
silent skip when absent) and a `verify_repo.py` regression guard asserting
both hook commands route through the wrapper (so a future edit can't
silently reintroduce the bare `node` call).

## Test plan
- [x] `python -m unittest discover -s tests` — 61/61 pass
- [x] `python tests/verify_repo.py` — all local checks pass
- [x] Manually reproduced the bug (PATH with no `node`, only nvm-installed)
      and confirmed the wrapper resolves via the nvm fallback and the real
      `caveman-mode-tracker.js` hook runs and emits correct JSON output

## Scope note
Verified on POSIX (Linux/WSL) — matches the reported `/bin/sh` failure signature. Native Windows (non-WSL) Claude Code would need `sh.exe` on PATH (ships with Git for Windows, common on Node dev machines) for the wrapper to run; not verified there.