### PR TITLE
fix(hooks): include caveman-parse.js in standalone installers

### DIFF
--- a/src/hooks/install.ps1
+++ b/src/hooks/install.ps1
@@ -22,9 +22,9 @@ if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
 $ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $env:USERPROFILE ".claude" }
 $HooksDir = Join-Path $ClaudeDir "hooks"
 $Settings = Join-Path $ClaudeDir "settings.json"
-$RepoUrl = "https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks"
+$RepoUrl = "https://raw.githubusercontent.com/JuliusBrussee/caveman/main/src/hooks"
 
-$HookFiles = @("package.json", "caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-stats.js", "caveman-statusline.sh", "caveman-statusline.ps1", "cavecrew-model-overrides.js")
+$HookFiles = @("package.json", "caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-parse.js", "caveman-stats.js", "caveman-statusline.sh", "caveman-statusline.ps1", "cavecrew-model-overrides.js")
 
 # Resolve source — works from repo clone or remote
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { $null }

--- a/src/hooks/install.sh
+++ b/src/hooks/install.sh
@@ -35,9 +35,9 @@ fi
 CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS="$CLAUDE_DIR/settings.json"
-REPO_URL="https://raw.githubusercontent.com/JuliusBrussee/caveman/main/hooks"
+REPO_URL="https://raw.githubusercontent.com/JuliusBrussee/caveman/main/src/hooks"
 
-HOOK_FILES=("package.json" "caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-stats.js" "caveman-statusline.sh" "cavecrew-model-overrides.js")
+HOOK_FILES=("package.json" "caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-parse.js" "caveman-stats.js" "caveman-statusline.sh" "cavecrew-model-overrides.js")
 
 # Resolve source — works from repo clone or curl pipe
 SCRIPT_DIR=""


### PR DESCRIPTION
## Summary

Fixes #801 (reported by @prpr289).

Standalone hook installers `src/hooks/install.sh` and `src/hooks/install.ps1` copied a `HOOK_FILES` / `$HookFiles` list that omitted `caveman-parse.js`. `caveman-mode-tracker.js` top-level-`require`s `./caveman-parse`, so a UserPromptSubmit hook installed via those scripts exits 1 on every prompt.

Secondary bug in the same files: remote fallback base URL pointed at `.../main/hooks` while hooks live under `src/hooks/` — every remote fetch 404s.

### Changes (exactly two files)

1. **`src/hooks/install.sh`** — add `caveman-parse.js` to `HOOK_FILES`; set `REPO_URL` to `.../main/src/hooks`
2. **`src/hooks/install.ps1`** — add `caveman-parse.js` to `$HookFiles`; set `$RepoUrl` to `.../main/src/hooks`

### Out of scope (intentional)

- **`cli/install.js`** already lists `caveman-parse.js` and pins a ref (`v1.10.0`) with a checksum integrity gate. Not touched.
- **`checksums.sha256`** not touched.
- Pinning a ref in the shell installers (like `cli/install.js` does) is left to maintainer preference; this PR is the minimal fix for the broken file list + 404 URL.

Shell installers remain a supported install path for users who run them directly; this keeps that path working.

## Test plan

No automated tests cover `src/hooks/install.sh` / `install.ps1` (repo `npm test` only runs `tests/installer/*.test.mjs` against `cli/install.js`). Manual repro + control is the coverage for this change.

### Repro (before fix — old file list, no `caveman-parse.js`)

```bash
tmpdir=$(mktemp -d)
# files from pre-fix HOOK_FILES in install.sh
for f in package.json caveman-config.js caveman-activate.js caveman-mode-tracker.js \
         caveman-stats.js caveman-statusline.sh cavecrew-model-overrides.js; do
  cp src/hooks/$f "$tmpdir/"
done
cd "$tmpdir"
echo '{"prompt":"hello","cwd":"/tmp"}' | node caveman-mode-tracker.js
# expected: Error: Cannot find module './caveman-parse' ; exit 1
```

**Observed (Node v26.5.0):**

```
Error: Cannot find module './caveman-parse'
Require stack:
- .../caveman-mode-tracker.js
...
Node.js v26.5.0
EXIT:1