### PR TITLE
docs(stats): point skill doc at src/hooks/ paths and current additionalContext delivery (#789)

### DIFF
--- a/plugins/caveman/skills/caveman-stats/SKILL.md
+++ b/plugins/caveman/skills/caveman-stats/SKILL.md
@@ -7,6 +7,6 @@ description: >
   the model itself does not compute the numbers.
 ---
 
-This skill is delivered by `hooks/caveman-stats.js` (read by `hooks/caveman-mode-tracker.js` on `/caveman-stats`). The model does not need to do anything when this skill fires — the hook returns `decision: "block"` with the formatted stats as the reason. The user sees the numbers immediately.
+This skill is delivered by `src/hooks/caveman-stats.js` (read by `src/hooks/caveman-mode-tracker.js` on `/caveman-stats`). The hook returns the formatted stats via `hookSpecificOutput.additionalContext` (#618), instructing the model to print the block verbatim. The user sees the numbers immediately.
 
 Output also includes `Est. rule overhead` and `Est. net` lines wherever a savings estimate exists with a known turn count. Rule overhead is the estimated per-turn INPUT-token cost of the injected caveman rules (default 1,250 tokens/turn, override with `CAVEMAN_RULE_OVERHEAD_TOKENS`) times the turn count. Net is savings minus that overhead — when negative, the output says so plainly and suggests turning caveman off for that workload, rather than hiding the net-negative regime behind a gross-savings number (see `docs/HONEST-NUMBERS.md`).

--- a/skills/caveman-stats/SKILL.md
+++ b/skills/caveman-stats/SKILL.md
@@ -7,6 +7,6 @@ description: >
   the model itself does not compute the numbers.
 ---
 
-This skill is delivered by `hooks/caveman-stats.js` (read by `hooks/caveman-mode-tracker.js` on `/caveman-stats`). The model does not need to do anything when this skill fires — the hook returns `decision: "block"` with the formatted stats as the reason. The user sees the numbers immediately.
+This skill is delivered by `src/hooks/caveman-stats.js` (read by `src/hooks/caveman-mode-tracker.js` on `/caveman-stats`). The hook returns the formatted stats via `hookSpecificOutput.additionalContext` (#618), instructing the model to print the block verbatim. The user sees the numbers immediately.
 
 Output also includes `Est. rule overhead` and `Est. net` lines wherever a savings estimate exists with a known turn count. Rule overhead is the estimated per-turn INPUT-token cost of the injected caveman rules (default 1,250 tokens/turn, override with `CAVEMAN_RULE_OVERHEAD_TOKENS`) times the turn count. Net is savings minus that overhead — when negative, the output says so plainly and suggests turning caveman off for that workload, rather than hiding the net-negative regime behind a gross-savings number (see `docs/HONEST-NUMBERS.md`).


### PR DESCRIPTION
## What & why

`skills/caveman-stats/SKILL.md` says the skill is delivered by `hooks/caveman-stats.js` / `hooks/caveman-mode-tracker.js`, but both scripts live at `src/hooks/` — there is no top-level `hooks/` directory. Readers (and automated skill audits) following the documented path hit a dead reference.

The same sentence also described the delivery mechanism as `decision: "block"` with the stats as the reason; since #618 the hook returns the stats via `hookSpecificOutput.additionalContext` (see `src/hooks/caveman-mode-tracker.js`). Since this PR rewrites that exact sentence, it corrects both the paths and the delivery description in one pass.

Fixes #789.

Credit: [@vasugarg09](https://github.com/vasugarg09) for the report (surfaced by their [SkillDoctor](https://github.com/vasugarg09/skill-doctor) audit).

## Changes

- One sentence each in `skills/caveman-stats/SKILL.md` (source of truth) and `plugins/caveman/skills/caveman-stats/SKILL.md`: `hooks/…` → `src/hooks/…` for both script references, and `decision: "block"` → `hookSpecificOutput.additionalContext` (#618) for the delivery description.
- The plugin copy is included deliberately: `.github/workflows/sync-skill.yml` mirrors only `caveman`, `caveman-compress`, and `cavecrew` — `caveman-stats` is not in any sync step, so its `plugins/` copy is hand-maintained and would otherwise stay stale.

## Testing

- Verified both referenced paths exist on `main`: `src/hooks/caveman-stats.js`, `src/hooks/caveman-mode-tracker.js`; confirmed no top-level `hooks/` directory.
- Verified the delivery mechanism on `main`: `src/hooks/caveman-mode-tracker.js` returns `hookSpecificOutput.additionalContext` (its own comment cites #618); no `decision: "block"` path remains for stats delivery.
- Verified sync-workflow coverage by reading `.github/workflows/sync-skill.yml` (no `caveman-stats` step).
- Docs-only change — no code paths affected; test suite not applicable.
