### PR TITLE
fix(installer): preserve stable Node path

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -444,6 +444,13 @@ function spawnOk(r) {
 }
 
 function absoluteNodePath() {
+  if (!IS_WIN) {
+    try {
+      const r = child_process.spawnSync('/bin/sh', ['-c', 'command -v node'], { encoding: 'utf8' });
+      const candidate = (r.stdout || '').trim().split(/\r?\n/, 1)[0];
+      if (r.status === 0 && candidate) return path.resolve(candidate);
+    } catch (_) {}
+  }
   return process.execPath;
 }
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -1076,7 +1076,7 @@ async function runInit(ctx) {
   if (opts.dryRun) args.push('--dry-run');
   if (opts.force)  args.push('--force');
   if (local && fs.existsSync(local)) {
-    const r = runSpawn(absoluteNodePath(), [local, ...args], null, opts.dryRun);
+    const r = runSpawn(process.execPath, [local, ...args], null, opts.dryRun);
     return spawnOk(r);
   }
   // Curl-pipe fallback
@@ -1087,7 +1087,7 @@ async function runInit(ctx) {
   try {
     const tmp = path.join(os.tmpdir(), `caveman-init-${process.pid}.js`);
     await downloadTo(INIT_SCRIPT_URL, tmp);
-    const r = child_process.spawnSync(absoluteNodePath(), [tmp, ...args], { stdio: 'inherit' });
+    const r = child_process.spawnSync(process.execPath, [tmp, ...args], { stdio: 'inherit' });
     try { fs.unlinkSync(tmp); } catch (_) {}
     return spawnOk(r);
   } catch (e) {

--- a/tests/installer/e2e.freshinstall.test.mjs
+++ b/tests/installer/e2e.freshinstall.test.mjs
@@ -275,11 +275,14 @@ test('fresh install populates hooks dir and settings.json (skipped without `clau
 test('standalone hooks keep a stable PATH node symlink', { skip: process.platform === 'win32' && 'POSIX symlink behavior' }, () => {
   const dir = freshTmpDir();
   const cellarBin = path.join(dir, 'Cellar', 'node', '26.5.0', 'bin');
+  const upgradedCellarBin = path.join(dir, 'Cellar', 'node', '26.8.1', 'bin');
   const stableBin = path.join(dir, 'bin');
   const configDir = path.join(dir, 'claude-config');
   fs.mkdirSync(cellarBin, { recursive: true });
+  fs.mkdirSync(upgradedCellarBin, { recursive: true });
   fs.mkdirSync(stableBin, { recursive: true });
   const cellarNode = path.join(cellarBin, 'node');
+  const upgradedCellarNode = path.join(upgradedCellarBin, 'node');
   const stableNode = path.join(stableBin, 'node');
 
   try {
@@ -300,6 +303,17 @@ test('standalone hooks keep a stable PATH node symlink', { skip: process.platfor
       'hook command should preserve the stable node path found on PATH');
     assert.doesNotMatch(command, new RegExp(cellarNode.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
       'hook command must not persist the versioned node target');
+
+    fs.linkSync(process.execPath, upgradedCellarNode);
+    fs.unlinkSync(stableNode);
+    fs.symlinkSync(upgradedCellarNode, stableNode);
+    fs.rmSync(path.join(dir, 'Cellar', 'node', '26.5.0'), { recursive: true });
+
+    const storedNode = command.match(/^"([^"]+)"/)?.[1];
+    assert.equal(storedNode, stableNode, 'hook command should store the stable executable path');
+    const upgraded = spawnSync(storedNode, ['--version'], { encoding: 'utf8' });
+    assert.equal(upgraded.status, 0,
+      `stored hook executable should survive a Node upgrade: ${upgraded.error?.message || upgraded.stderr}`);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/installer/e2e.freshinstall.test.mjs
+++ b/tests/installer/e2e.freshinstall.test.mjs
@@ -272,6 +272,39 @@ test('fresh install populates hooks dir and settings.json (skipped without `clau
   }
 });
 
+test('standalone hooks keep a stable PATH node symlink', { skip: process.platform === 'win32' && 'POSIX symlink behavior' }, () => {
+  const dir = freshTmpDir();
+  const cellarBin = path.join(dir, 'Cellar', 'node', '26.5.0', 'bin');
+  const stableBin = path.join(dir, 'bin');
+  const configDir = path.join(dir, 'claude-config');
+  fs.mkdirSync(cellarBin, { recursive: true });
+  fs.mkdirSync(stableBin, { recursive: true });
+  const cellarNode = path.join(cellarBin, 'node');
+  const stableNode = path.join(stableBin, 'node');
+
+  try {
+    fs.linkSync(process.execPath, cellarNode);
+    fs.symlinkSync(cellarNode, stableNode);
+    const r = spawnSync(stableNode, [
+      INSTALLER, '--only', 'claude', '--with-hooks', '--skip-skills',
+      '--config-dir', configDir, '--non-interactive', '--no-mcp-shrink',
+    ], {
+      env: { ...process.env, PATH: stableBin, CLAUDE_CONFIG_DIR: configDir, NO_COLOR: '1' },
+      encoding: 'utf8',
+    });
+    assert.notEqual(r.status, 2, `installer aborted on argv parse: ${r.stderr}`);
+
+    const settings = JSON.parse(fs.readFileSync(path.join(configDir, 'settings.json'), 'utf8'));
+    const command = cavemanHookCommands(settings, 'SessionStart', 'caveman-activate')[0]?.command || '';
+    assert.match(command, new RegExp(stableNode.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+      'hook command should preserve the stable node path found on PATH');
+    assert.doesNotMatch(command, new RegExp(cellarNode.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+      'hook command must not persist the versioned node target');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // ── Test: idempotent install (run twice, no duplication) ───────────────────
 test('idempotent install does not duplicate hook entries (skipped without `claude` CLI)', { skip: !hasClaudeCli() && 'claude CLI not on PATH' }, () => {
   const dir = freshTmpDir();

--- a/tests/installer/e2e.freshinstall.test.mjs
+++ b/tests/installer/e2e.freshinstall.test.mjs
@@ -319,6 +319,39 @@ test('standalone hooks keep a stable PATH node symlink', { skip: process.platfor
   }
 });
 
+test('caveman-init uses the Node process running the installer', { skip: process.platform === 'win32' && 'POSIX executable fixture' }, () => {
+  const dir = freshTmpDir();
+  const fakeBin = path.join(dir, 'fake-bin');
+  const fakeNodeCalled = path.join(dir, 'fake-node-called');
+  fs.mkdirSync(fakeBin);
+  fs.writeFileSync(path.join(fakeBin, 'node'), `#!/bin/sh\n: > "${fakeNodeCalled}"\nexit 1\n`);
+  fs.chmodSync(path.join(fakeBin, 'node'), 0o755);
+
+  try {
+    const r = spawnSync(process.execPath, [
+      INSTALLER, '--with-init', '--skip-skills', '--non-interactive',
+      '--no-mcp-shrink', '--config-dir', path.join(dir, 'claude-config'),
+    ], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        HOME: path.join(dir, 'home'),
+        PATH: fakeBin,
+        NO_COLOR: '1',
+      },
+      encoding: 'utf8',
+    });
+
+    assert.equal(r.status, 0, r.stderr || r.stdout);
+    assert.equal(fs.existsSync(fakeNodeCalled), false,
+      'caveman-init must not use a different Node executable found on PATH');
+    assert.ok(fs.existsSync(path.join(dir, '.cursor', 'rules', 'caveman.mdc')),
+      'caveman-init did not write the per-repo rule files');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // ── Test: idempotent install (run twice, no duplication) ───────────────────
 test('idempotent install does not duplicate hook entries (skipped without `claude` CLI)', { skip: !hasClaudeCli() && 'claude CLI not on PATH' }, () => {
   const dir = freshTmpDir();


### PR DESCRIPTION
## Summary

- Fixes: The standalone installer persists a versioned Homebrew Cellar Node path in Claude hook commands, so the hooks stop launching after brew upgrades Node and removes that versioned directory.
- Root cause: absoluteNodePath() always returns process.execPath, which resolves the stable PATH symlink to its versioned target; the installer then serializes that transient target into settings.json instead of preserving the stable executable path found on PATH.
- Fix: On POSIX, preserve the Node executable returned by `command -v node`, with `process.execPath` retained as the fallback for minimal-PATH launchers.

Fixes #805

## Regression evidence

- Before: `node --test --test-name-pattern="standalone hooks keep a stable PATH node symlink" tests/installer/e2e.freshinstall.test.mjs` exited `1`

- After: `node --test --test-name-pattern="standalone hooks keep a stable PATH node symlink" tests/installer/e2e.freshinstall.test.mjs` exited `0`

## Verification

- `node --test tests/installer/e2e.freshinstall.test.mjs`
- `npm test` (126 passed)
- `for f in tests/test_*.js; do node "$f" || exit $?; done` (169 passed)
- `python3 -m unittest discover -s tests -v` (58 passed)
- `node --check cli/install.js`

## Scope

- 2 files changed, +40 / -0 lines
