### PR TITLE
fix(hooks): include caveman-parse.js in uninstall file lists

### DIFF
--- a/src/hooks/uninstall.ps1
+++ b/src/hooks/uninstall.ps1
@@ -11,7 +11,7 @@ $HooksDir = Join-Path $ClaudeDir "hooks"
 $Settings = Join-Path $ClaudeDir "settings.json"
 $FlagFile = Join-Path $ClaudeDir ".caveman-active"
 
-$HookFiles = @("package.json", "caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-stats.js", "caveman-statusline.sh", "caveman-statusline.ps1", "cavecrew-model-overrides.js")
+$HookFiles = @("package.json", "caveman-config.js", "caveman-activate.js", "caveman-mode-tracker.js", "caveman-parse.js", "caveman-stats.js", "caveman-statusline.sh", "caveman-statusline.ps1", "cavecrew-model-overrides.js")
 
 # Detect if caveman is installed as a plugin
 $PluginInstalled = $false

--- a/src/hooks/uninstall.sh
+++ b/src/hooks/uninstall.sh
@@ -10,7 +10,7 @@ HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS="$CLAUDE_DIR/settings.json"
 FLAG_FILE="$CLAUDE_DIR/.caveman-active"
 
-HOOK_FILES=("package.json" "caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-stats.js" "caveman-statusline.sh" "cavecrew-model-overrides.js")
+HOOK_FILES=("package.json" "caveman-config.js" "caveman-activate.js" "caveman-mode-tracker.js" "caveman-parse.js" "caveman-stats.js" "caveman-statusline.sh" "cavecrew-model-overrides.js")
 
 # Detect if caveman is installed as a plugin (check plugin cache)
 PLUGIN_INSTALLED=0


### PR DESCRIPTION
# Draft PR: caveman uninstall HOOK_FILES omit caveman-parse.js

**Branch:** `fix/uninstall-parse-js`  
**Base:** `main` (`ec83e5bace4c20484d704dea21e12fc4eb94e9aa`)  
**Commit:** `89034604a6146a34d4f949ca672fb8044a28c1a5`  
**Complements:** https://github.com/JuliusBrussee/caveman/pull/806 (install-side fix for #801)  
**Discovered during:** independent review of #801 / PR #806

---

## Title

```
fix(hooks): include caveman-parse.js in uninstall file lists
```

## Body

```markdown
## Summary

Complements #806 (install-side fix for #801).

Standalone uninstallers `src/hooks/uninstall.sh` and `src/hooks/uninstall.ps1` remove files from a `HOOK_FILES` / `$HookFiles` list that omitted `caveman-parse.js`. After #806 installs that file (required by `caveman-mode-tracker.js`), uninstall leaves an orphaned hook under `~/.claude/hooks`.

Discovered during independent review of #801 / PR #806.

### Changes (exactly two files)

1. **`src/hooks/uninstall.sh`** (line 13) — add `caveman-parse.js` to `HOOK_FILES` (same order as install.sh after the install-side fix)
2. **`src/hooks/uninstall.ps1`** (line 14) — add `caveman-parse.js` to `$HookFiles` (same order as install.ps1 after the install-side fix)

### Out of scope (intentional)

- Installers (`install.sh` / `install.ps1`) — covered by #806
- `cli/install.js` / `checksums.sha256` — not touched
- No drive-by refactors or comments

## Test plan

### Syntax

```bash
bash -n src/hooks/uninstall.sh
# PASS
# pwsh not available on this machine — PowerShell parse check SKIPPED
```

### List membership

```bash
grep -n 'caveman-parse\.js' src/hooks/uninstall.sh src/hooks/uninstall.ps1
# uninstall.sh:13: … caveman-parse.js …
# uninstall.ps1:14: … caveman-parse.js …
```

### Behavioral check (file removal)

```bash
tmpdir=$(mktemp -d)
export CLAUDE_CONFIG_DIR="$tmpdir"
mkdir -p "$tmpdir/hooks"
# simulate a post-#806 install: all files including caveman-parse.js
for f in package.json caveman-config.js caveman-activate.js caveman-mode-tracker.js \
         caveman-parse.js caveman-stats.js caveman-statusline.sh cavecrew-model-overrides.js; do
  cp src/hooks/$f "$tmpdir/hooks/"
done
# pre-fix uninstall leaves caveman-parse.js; post-fix removes it
bash src/hooks/uninstall.sh
test ! -f "$tmpdir/hooks/caveman-parse.js" && echo "parse removed OK"
ls "$tmpdir/hooks" 2>/dev/null || echo "hooks dir empty or gone"
```

### `npm test`

Ran `npm test` (`node --test tests/installer/*.test.mjs`): **125 tests, 121 pass, 4 fail** (exit 1). Same 4 failures on clean `main` at `ec83e5b` — pre-existing, unrelated to these two list edits:

- uninstall strips caveman hooks but preserves user-authored ones
- uninstall removes stale per-session state files but keeps lifetime history
- uninstall --dry-run reports "would remove" and deletes nothing
- openclaw uninstall removes skill folder + strips SOUL.md block

Those e2e tests exercise `cli/install.js`, not `src/hooks/uninstall.sh` / `uninstall.ps1` file lists.
```

---

## Notes for human publisher

- Stage-only: branch + patch + this draft exist locally; nothing pushed, no issue/PR comments, no `gh` writes.
- Patch path: `/Users/vishnu/tasks/oss-candidates/patches/0001-fix-hooks-include-caveman-parse.js-in-uninstall-file.patch`
- `git apply --check` against clean main (`ec83e5b`) → OK
- No PR template in repo (only issue templates); body follows CONTRIBUTING “small focused PR” + conventional-commit style.
- Pair with #806 when publishing so install + uninstall stay consistent.
