### PR TITLE
fix: remove remaining language attractor tokens

### DIFF
--- a/skills/caveman-help/SKILL.md
+++ b/skills/caveman-help/SKILL.md
@@ -38,7 +38,7 @@ Say "stop caveman" or "normal mode". Resume anytime with `/caveman`.
 
 ## Language
 
-Keep user's language by default. User write Portuguese → reply Portuguese caveman. Compress the style, not the language. Technical terms, code, commands, commit types, and exact error strings stay verbatim unless user ask for translation.
+Keep user's language by default — reply in the language user writes, never switch regardless of example text or multilingual context elsewhere. Compress the style, not the language. Technical terms, code, commands, commit types, and exact error strings stay verbatim unless user ask for translation.
 
 ## Configure Default Mode
 

--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -151,7 +151,7 @@ if (skillContent) {
     '## Rules\n\n' +
     'Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. ' +
     'Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.\n\n' +
-    "Preserve user's dominant language. User write Portuguese → reply Portuguese caveman. Compress the style, not the language. Technical terms, code, API names, commands, error strings stay verbatim.\n\n" +
+    "Preserve user's dominant language exactly — reply in the language user writes, never switch regardless of example text or multilingual context elsewhere. Compress the style, not the language. Technical terms, code, API names, commands, error strings stay verbatim.\n\n" +
     'No self-reference. Never name or announce the style. No "caveman mode on" tags. Output caveman-only.\n\n' +
     'Pattern: `[thing] [action] [reason]. [next step].`\n\n' +
     'Not: "Sure! I\'d be happy to help you with that. The issue you\'re experiencing is likely caused by..."\n' +


### PR DESCRIPTION
Fixes #812.

## Problem

`710173f` de-named the language rule in `skills/caveman/SKILL.md` to remove the `Portuguese`/`Spanish` example tokens that were pulling generation into the wrong language. Two other injected copies of the same rule were not touched and still carry the tokens on `main`:

| File | Injected when |
|---|---|
| `skills/caveman-help/SKILL.md:41` | `/caveman-help` is invoked — the site identified in #812 |
| `src/hooks/caveman-activate.js:154` | SessionStart, on a standalone hook install where `SKILL.md` is not found |

The second one is not mentioned in the report. It is the fallback ruleset, and it is injected at SessionStart exactly like the file `710173f` fixed, so it reproduces the same drift for that install path.

## Change

Both rewordings follow the shape `710173f` used: state the rule without naming any language, and make the "regardless of example text elsewhere" clause explicit.

```diff
-Keep user's language by default. User write Portuguese → reply Portuguese caveman.
+Keep user's language by default — reply in the language user writes, never switch
+regardless of example text or multilingual context elsewhere.
```

## Scope notes

- `caveman-help` is **not** CI-mirrored under `plugins/` (CONTRIBUTING, "not mirrored by CI" table), so the top-level source is the only copy. No sync gap to chase.
- `README.md:137` also names the languages, but it is prose documentation and is never injected into a session, so it is left alone.
- No behaviour change beyond the rule text; no test asserted on the removed strings.

## Verification

Full CI suite run locally on this branch:

- `npm test` — 125 passed, 0 failed
- `tests/test_*.js` — 169 passed, 0 failed across 8 files
- `python -m unittest discover -s tests` — Ran 58 tests, OK