### PR TITLE
feat(cli): add --doctor to report install health

### DIFF
--- a/cli/install.js
+++ b/cli/install.js
@@ -63,7 +63,7 @@ function parseArgs(argv) {
     dryRun: false, force: false, skipSkills: false,
     withHooks: 'auto', withInit: false, withMcpShrink: false,
     all: false, minimal: false, listOnly: false, noColor: false,
-    only: [], uninstall: false, nonInteractive: false,
+    only: [], uninstall: false, doctor: false, nonInteractive: false,
     configDir: null, help: false, always: true,
   };
   for (let i = 0; i < argv.length; i++) {
@@ -116,6 +116,7 @@ function parseArgs(argv) {
       case '--list': opts.listOnly = true; break;
       case '--no-color': opts.noColor = true; break;
       case '--uninstall': case '-u': opts.uninstall = true; break;
+      case '--doctor': opts.doctor = true; break;
       case '--non-interactive': opts.nonInteractive = true; break;
       case '-h': case '--help': opts.help = true; break;
       // POSIX end-of-options marker. Older curl|bash flows pipe `-- --only foo`
@@ -1455,6 +1456,9 @@ FLAGS
                         Example: --with-mcp-shrink="npx @modelcontextprotocol/server-filesystem /tmp"
   --no-mcp-shrink       Skip MCP shrink. (Default.)
   --uninstall, -u       Remove caveman from this machine.
+  --doctor              Report the health of the Claude Code hooks install
+                        (files, integrity, settings.json wiring) and exit.
+                        Read-only; honors --config-dir. Exit 1 if problems.
   --config-dir <path>   Claude Code config dir for hook files + settings.json.
                         Default: \$CLAUDE_CONFIG_DIR or ~/.claude. Does NOT
                         scope \`claude plugin install\`, \`gemini extensions
@@ -1487,6 +1491,17 @@ async function main() {
 
   const configDir = opts.configDir || process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
   const repoRoot = detectRepoRoot();
+
+  if (opts.doctor) {
+    const { runDoctor } = require('./lib/doctor.js');
+    const problems = runDoctor({
+      configDir,
+      hookFiles: HOOK_FILES,
+      manifestPath: repoRoot ? path.join(repoRoot, 'src', 'hooks', 'checksums.sha256') : null,
+      c,
+    });
+    return problems > 0 ? 1 : 0;
+  }
 
   const ctx = {
     opts, configDir, repoRoot,

--- a/cli/lib/doctor.js
+++ b/cli/lib/doctor.js
@@ -1,0 +1,184 @@
+// caveman --doctor — read-only health report for a Claude Code install. Never
+// writes anything: broken installs get diagnosed here and fixed by
+// re-running the installer or --uninstall, not by doctor itself.
+//
+// caveman installs one of two ways (see installClaude in ../install.js):
+//   - plugin:     `claude plugin install caveman@caveman` — the plugin
+//                 manifest wires SessionStart/UserPromptSubmit itself.
+//   - standalone: hook files copied into <configDir>/hooks, wired by hand
+//                 into settings.json.
+// The installer's own 'auto' hook-wiring mode only falls back to standalone
+// wiring when the plugin install did not succeed, precisely to avoid both
+// paths firing on the same event. doctor mirrors that same either/or model:
+// which checks apply depends on which mode is actually active.
+//
+// Exit-code contract (mapped by the caller): 0 problems -> healthy, >0 -> the
+// install needs attention. Notes (legacy command shapes, statusline state)
+// are informational and never count as problems.
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { spawnSync } = require('child_process');
+const {
+  readSettings, hasCavemanHook, tokenizeCommand, MANAGED_HOOK_BASENAMES,
+} = require('./settings.js');
+
+function sha256File(p) {
+  return crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex');
+}
+
+// Parse a `sha256sum`-style manifest (`<64-hex>  <basename>` per line) into a
+// Map. Returns null when the manifest is missing or unreadable — integrity
+// checks are then skipped with a note rather than failing the whole report,
+// same stance installHooks takes when the remote manifest is absent.
+function loadManifest(manifestPath) {
+  if (!manifestPath) return null;
+  let raw;
+  try { raw = fs.readFileSync(manifestPath, 'utf8'); }
+  catch (_) { return null; }
+  const map = new Map();
+  for (const line of raw.split('\n')) {
+    const m = /^([0-9a-f]{64})\s+(\S+)\s*$/.exec(line.trim());
+    if (m) map.set(m[2], m[1]);
+  }
+  return map.size ? map : null;
+}
+
+// Same probe installClaude uses to decide whether the plugin install already
+// succeeded (`claude plugin list` mentioning caveman). Any failure to run
+// `claude` at all — not on PATH, non-zero exit, spawn error — is read as "no
+// plugin install", the same way the installer treats it.
+function probeClaudePlugin() {
+  let r;
+  try { r = spawnSync('claude', ['plugin', 'list'], { encoding: 'utf8' }); }
+  catch (_) { return false; }
+  if (!r || r.error || r.status !== 0) return false;
+  return /caveman/i.test(r.stdout || '');
+}
+
+// Extract the managed-script target of a hook command, resolved against
+// configDir when relative. Returns null when the command doesn't reference a
+// managed script at all. Same exact-basename rule as the settings helpers so
+// a user script that merely contains a managed name is never ours.
+function managedTarget(command, configDir) {
+  try {
+    for (const tok of tokenizeCommand(command)) {
+      if (!tok || typeof tok !== 'string') continue;
+      if (!MANAGED_HOOK_BASENAMES.has(path.win32.basename(tok))) continue;
+      return path.isAbsolute(tok) ? tok : path.join(configDir, tok);
+    }
+  } catch (_) { /* malformed command — not ours */ }
+  return null;
+}
+
+// Walk every hook command in settings (plus statusLine, which lives outside
+// settings.hooks) and hand each one to visit(event, command). Tolerates the
+// malformed shapes readSettings lets through — never assumes arrays.
+function eachHookCommand(settings, visit) {
+  if (settings.hooks && typeof settings.hooks === 'object') {
+    for (const ev of Object.keys(settings.hooks)) {
+      if (!Array.isArray(settings.hooks[ev])) continue;
+      for (const entry of settings.hooks[ev]) {
+        if (!entry || !Array.isArray(entry.hooks)) continue;
+        for (const h of entry.hooks) {
+          if (h && typeof h.command === 'string') visit(ev, h.command);
+        }
+      }
+    }
+  }
+  if (settings.statusLine && typeof settings.statusLine.command === 'string') {
+    visit('statusLine', settings.statusLine.command);
+  }
+}
+
+// ── runDoctor ─────────────────────────────────────────────────────────────
+// opts: { configDir, hookFiles, manifestPath, c }  (c = chalk from makeChalk)
+// Prints the report, returns the number of problems found.
+function runDoctor({ configDir, hookFiles, manifestPath, c }) {
+  const out = (s) => process.stdout.write(s + '\n');
+  const problems = [];
+  const notes = [];
+
+  out(c.orange('🪨 caveman doctor'));
+  out(c.dim(`  config dir: ${configDir}`));
+
+  const pluginInstalled = probeClaudePlugin();
+  out(c.dim(`  install mode: ${pluginInstalled ? 'Claude Code plugin' : 'standalone hooks (or plugin not detected)'}`));
+  out('');
+
+  const hooksDir = path.join(configDir, 'hooks');
+  const settingsPath = path.join(configDir, 'settings.json');
+  const settings = readSettings(settingsPath);
+
+  if (settings === null) {
+    problems.push(`settings.json is not valid JSON or JSONC: ${settingsPath}`);
+  } else {
+    const sessionWired = hasCavemanHook(settings, 'SessionStart', 'caveman-activate');
+    const promptWired = hasCavemanHook(settings, 'UserPromptSubmit', 'caveman-mode-tracker');
+
+    if (pluginInstalled) {
+      // The plugin manifest wires these events itself. Standalone wiring on
+      // top of that fires each event twice — the exact double-firing the
+      // installer's 'auto' mode exists to avoid at install time.
+      if (sessionWired || promptWired) {
+        problems.push(
+          'the Claude Code plugin is installed and standalone hooks are also wired in settings.json — ' +
+          'SessionStart/UserPromptSubmit will fire twice per event; remove the standalone wiring (or reinstall without --with-hooks)'
+        );
+      }
+    } else {
+      // No plugin detected — a healthy install must be standalone, which
+      // means the hook files need to exist AND be wired.
+      if (!sessionWired) problems.push('SessionStart hook not wired in settings.json');
+      if (!promptWired) problems.push('UserPromptSubmit hook not wired in settings.json');
+
+      if (!fs.existsSync(hooksDir)) {
+        problems.push(`hooks directory missing: ${hooksDir} — run the installer to set up hooks`);
+      } else {
+        const manifest = loadManifest(manifestPath);
+        for (const f of hookFiles) {
+          const p = path.join(hooksDir, f);
+          if (!fs.existsSync(p)) {
+            problems.push(`missing hook file: ${f}`);
+            continue;
+          }
+          if (manifest && manifest.has(f) && manifest.get(f) !== sha256File(p)) {
+            problems.push(`modified hook file: ${f} differs from the shipped version — re-run the installer to restore it`);
+          }
+        }
+        if (!manifest) notes.push('no integrity manifest available — file contents not verified');
+      }
+    }
+
+    // Orphans and legacy command shapes matter regardless of which mode is
+    // currently active — both are leftovers from a previous install that
+    // migrating to the plugin (or back) can strand (#471).
+    eachHookCommand(settings, (ev, command) => {
+      const target = managedTarget(command, configDir);
+      if (target && !fs.existsSync(target)) {
+        problems.push(`orphaned ${ev} hook points at missing script: ${target}`);
+      }
+    });
+    eachHookCommand(settings, (ev, command) => {
+      const toks = tokenizeCommand(command);
+      if (toks[0] === 'node' && managedTarget(command, configDir)) {
+        notes.push(`${ev} hook uses a bare \`node\` command — re-running the installer pins the absolute path`);
+      }
+    });
+
+    if (!settings.statusLine) notes.push('statusline badge not configured');
+  }
+
+  for (const p of problems) out(c.red(`  problem  ${p}`));
+  for (const n of notes) out(c.dim(`  note     ${n}`));
+  out('');
+  if (problems.length) {
+    out(c.red(`${problems.length} problem(s) found`));
+  } else {
+    out(c.green('no problems found'));
+  }
+  return problems.length;
+}
+
+module.exports = { runDoctor };

--- a/cli/lib/settings.js
+++ b/cli/lib/settings.js
@@ -364,5 +364,6 @@ module.exports = {
   rewriteLegacyManagedHookCommands,
   pruneOrphanedManagedHooks,
   claudeConfigDir,
+  tokenizeCommand,
   MANAGED_HOOK_BASENAMES,
 };

--- a/tests/installer/doctor.test.mjs
+++ b/tests/installer/doctor.test.mjs
@@ -1,0 +1,290 @@
+// End-to-end: --doctor reports install health read-only, across both
+// install modes (Claude Code plugin vs standalone hooks).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '..', '..');
+const INSTALLER = path.join(REPO, 'cli', 'install.js');
+const HOOKS_SRC = path.join(REPO, 'src', 'hooks');
+const IS_WIN = process.platform === 'win32';
+
+// Mirrors the installer's hook-file plan: everything the standalone install
+// copies into <configDir>/hooks.
+const HOOK_FILES = [
+  'package.json',
+  'caveman-config.js',
+  'caveman-parse.js',
+  'caveman-activate.js',
+  'caveman-mode-tracker.js',
+  'caveman-stats.js',
+  'caveman-statusline.sh',
+  'caveman-statusline.ps1',
+  'cavecrew-model-overrides.js',
+];
+
+function freshTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cm-doctor-'));
+}
+
+// Build a healthy STANDALONE install: all hook files copied verbatim from
+// src/hooks plus a settings.json wired the way installHooks writes it.
+function healthyStandaloneInstall() {
+  const cfg = freshTmpDir();
+  const hooksDir = path.join(cfg, 'hooks');
+  fs.mkdirSync(hooksDir, { recursive: true });
+  for (const f of HOOK_FILES) {
+    fs.copyFileSync(path.join(HOOKS_SRC, f), path.join(hooksDir, f));
+  }
+  const node = process.execPath;
+  const settings = {
+    hooks: {
+      SessionStart: [{ hooks: [{ type: 'command', command: `"${node}" "${path.join(hooksDir, 'caveman-activate.js')}"`, timeout: 5 }] }],
+      UserPromptSubmit: [{ hooks: [{ type: 'command', command: `"${node}" "${path.join(hooksDir, 'caveman-mode-tracker.js')}"`, timeout: 5 }] }],
+    },
+    statusLine: { type: 'command', command: `bash "${path.join(hooksDir, 'caveman-statusline.sh')}"` },
+  };
+  fs.writeFileSync(path.join(cfg, 'settings.json'), JSON.stringify(settings, null, 2) + '\n');
+  return cfg;
+}
+
+// A fake `claude` binary that answers `plugin list` deterministically,
+// independent of whatever the host machine actually has installed. Returns
+// the directory to prepend to PATH.
+function fakeClaudeDir(pluginListStdout) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cm-fakebin-'));
+  if (IS_WIN) {
+    const bin = path.join(dir, 'claude.cmd');
+    fs.writeFileSync(bin,
+      `@echo off\r\nif "%1"=="plugin" if "%2"=="list" (\r\n  echo ${pluginListStdout}\r\n  exit /b 0\r\n)\r\nexit /b 1\r\n`);
+  } else {
+    const bin = path.join(dir, 'claude');
+    fs.writeFileSync(bin,
+      `#!/usr/bin/env bash\nif [ "$1" = "plugin" ] && [ "$2" = "list" ]; then\n  echo "${pluginListStdout}"\n  exit 0\nfi\nexit 1\n`);
+    fs.chmodSync(bin, 0o755);
+  }
+  return dir;
+}
+
+// PATH deliberately excludes wherever the host might have a real `claude`
+// installed (npm global bin, ~/.local/bin, etc.) so every test's outcome
+// depends only on the fixtures it sets up, never on the machine running it.
+function controlledEnv(cfg, extraPathDir) {
+  const sysDirs = IS_WIN
+    ? [process.env.SystemRoot ? path.join(process.env.SystemRoot, 'System32') : 'C:\\Windows\\System32']
+    : ['/usr/bin', '/bin'];
+  const PATH = [extraPathDir, path.dirname(process.execPath), ...sysDirs].filter(Boolean).join(path.delimiter);
+  return { ...process.env, CLAUDE_CONFIG_DIR: cfg, PATH };
+}
+
+function doctor(cfg, extraPathDir) {
+  return spawnSync(process.execPath, [INSTALLER, '--doctor', '--no-color', '--config-dir', cfg],
+    { encoding: 'utf8', env: controlledEnv(cfg, extraPathDir) });
+}
+
+// Snapshot every file path + content hash under a dir, for read-only checks.
+function snapshot(dir) {
+  const out = new Map();
+  const walk = (d) => {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) walk(p);
+      else out.set(p, fs.readFileSync(p, 'utf8'));
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+// ── Standalone mode ─────────────────────────────────────────────────────
+
+test('doctor exits 0 on a healthy standalone install', () => {
+  const cfg = healthyStandaloneInstall();
+  const r = doctor(cfg);
+  assert.equal(r.status, 0, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`);
+});
+
+test('doctor exits 1 and names the file when a hook file is missing', () => {
+  const cfg = healthyStandaloneInstall();
+  fs.unlinkSync(path.join(cfg, 'hooks', 'caveman-parse.js'));
+  const r = doctor(cfg);
+  assert.equal(r.status, 1);
+  assert.match(r.stdout + r.stderr, /caveman-parse\.js/);
+});
+
+test('doctor exits 1 and names the file when a hook file was modified', () => {
+  const cfg = healthyStandaloneInstall();
+  fs.appendFileSync(path.join(cfg, 'hooks', 'caveman-stats.js'), '\n// local edit\n');
+  const r = doctor(cfg);
+  assert.equal(r.status, 1);
+  assert.match(r.stdout + r.stderr, /caveman-stats\.js/);
+});
+
+test('doctor exits 1 when settings.json is unparseable', () => {
+  const cfg = healthyStandaloneInstall();
+  fs.writeFileSync(path.join(cfg, 'settings.json'), '{ definitely not json');
+  const r = doctor(cfg);
+  assert.equal(r.status, 1);
+  assert.match(r.stdout + r.stderr, /settings\.json/);
+});
+
+test('doctor exits 1 when the SessionStart wiring is absent (no plugin)', () => {
+  const cfg = healthyStandaloneInstall();
+  const p = path.join(cfg, 'settings.json');
+  const settings = JSON.parse(fs.readFileSync(p, 'utf8'));
+  delete settings.hooks.SessionStart;
+  fs.writeFileSync(p, JSON.stringify(settings, null, 2));
+  const r = doctor(cfg);
+  assert.equal(r.status, 1);
+  assert.match(r.stdout + r.stderr, /SessionStart/);
+});
+
+test('doctor exits 1 when the UserPromptSubmit wiring is absent (no plugin)', () => {
+  const cfg = healthyStandaloneInstall();
+  const p = path.join(cfg, 'settings.json');
+  const settings = JSON.parse(fs.readFileSync(p, 'utf8'));
+  delete settings.hooks.UserPromptSubmit;
+  fs.writeFileSync(p, JSON.stringify(settings, null, 2));
+  const r = doctor(cfg);
+  assert.equal(r.status, 1);
+  assert.match(r.stdout + r.stderr, /UserPromptSubmit/);
+});
+
+test('doctor exits 1 on a wired hook whose target script is gone (orphan)', () => {
+  const cfg = healthyStandaloneInstall();
+  // Migration-to-plugin scenario: hook files removed, settings left behind,
+  // and (for this test) no plugin actually detected either — pure orphan.
+  fs.rmSync(path.join(cfg, 'hooks'), { recursive: true });
+  const r = doctor(cfg);
+  assert.equal(r.status, 1);
+  assert.match(r.stdout + r.stderr, /caveman-activate\.js/);
+});
+
+test('doctor does not treat a user script containing a managed name as ours', () => {
+  const cfg = healthyStandaloneInstall();
+  const p = path.join(cfg, 'settings.json');
+  const settings = JSON.parse(fs.readFileSync(p, 'utf8'));
+  settings.hooks.PostToolUse = [{ hooks: [{ type: 'command', command: `node "${path.join(cfg, 'mycaveman-activate.js')}"`, timeout: 5 }] }];
+  fs.writeFileSync(p, JSON.stringify(settings, null, 2));
+  const r = doctor(cfg);
+  assert.equal(r.status, 0, `stdout:\n${r.stdout}`);
+});
+
+test('a bare-node command on an existing script is not a problem', () => {
+  const cfg = healthyStandaloneInstall();
+  const p = path.join(cfg, 'settings.json');
+  const settings = JSON.parse(fs.readFileSync(p, 'utf8'));
+  settings.hooks.SessionStart[0].hooks[0].command = `node "${path.join(cfg, 'hooks', 'caveman-activate.js')}"`;
+  fs.writeFileSync(p, JSON.stringify(settings, null, 2));
+  const r = doctor(cfg);
+  assert.equal(r.status, 0, `stdout:\n${r.stdout}`);
+});
+
+test('doctor exits 1 on a completely empty config dir', () => {
+  const cfg = freshTmpDir();
+  const r = doctor(cfg);
+  assert.equal(r.status, 1);
+});
+
+test('doctor is read-only: a broken install is left byte-for-byte untouched', () => {
+  const cfg = healthyStandaloneInstall();
+  fs.unlinkSync(path.join(cfg, 'hooks', 'caveman-parse.js'));
+  fs.appendFileSync(path.join(cfg, 'hooks', 'caveman-stats.js'), '\n// local edit\n');
+  const before = snapshot(cfg);
+  const r = doctor(cfg);
+  assert.equal(r.status, 1);
+  const after = snapshot(cfg);
+  assert.deepEqual([...after.keys()].sort(), [...before.keys()].sort());
+  for (const [p, contents] of before) assert.equal(after.get(p), contents, `changed: ${p}`);
+});
+
+test('doctor respects --config-dir over CLAUDE_CONFIG_DIR', () => {
+  const good = healthyStandaloneInstall();
+  const bad = freshTmpDir();
+  const r = spawnSync(process.execPath, [INSTALLER, '--doctor', '--no-color', '--config-dir', good],
+    { encoding: 'utf8', env: controlledEnv(bad) });
+  assert.equal(r.status, 0, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`);
+});
+
+// ── Plugin mode ────────────────────────────────────────────────────────
+
+test('doctor exits 0 on a healthy plugin-only install (no standalone files at all)', () => {
+  const cfg = freshTmpDir(); // nothing on disk — plugin owns its own hooks
+  const claudeBin = fakeClaudeDir('caveman@caveman  1.4.0  active');
+  const r = doctor(cfg, claudeBin);
+  assert.equal(r.status, 0, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`);
+});
+
+test('doctor exits 1 when the plugin is installed and standalone hooks are also wired', () => {
+  const cfg = healthyStandaloneInstall();
+  const claudeBin = fakeClaudeDir('caveman@caveman  1.4.0  active');
+  const r = doctor(cfg, claudeBin);
+  assert.equal(r.status, 1);
+  // Behavior only: the report must call out the plugin conflict specifically
+  // (not just "something's wired wrong"), but the exact wording — whether it
+  // says "twice", "duplicate", "both fire", etc. — is the solution's choice.
+  assert.match(r.stdout + r.stderr, /plugin/i);
+});
+
+test('doctor exits 1 for a double-wired install even if only one of the two events is standalone-wired', () => {
+  const cfg = healthyStandaloneInstall();
+  const p = path.join(cfg, 'settings.json');
+  const settings = JSON.parse(fs.readFileSync(p, 'utf8'));
+  delete settings.hooks.UserPromptSubmit; // only SessionStart still double-wired
+  fs.writeFileSync(p, JSON.stringify(settings, null, 2));
+  const claudeBin = fakeClaudeDir('caveman@caveman  1.4.0  active');
+  const r = doctor(cfg, claudeBin);
+  assert.equal(r.status, 1);
+  assert.match(r.stdout + r.stderr, /plugin/i);
+});
+
+test('doctor does not flag double-wiring when claude is installed but the caveman plugin is not', () => {
+  const cfg = healthyStandaloneInstall(); // legitimate standalone install
+  const claudeBin = fakeClaudeDir('some-other-plugin@acme  2.0.0  active');
+  const r = doctor(cfg, claudeBin);
+  assert.equal(r.status, 0, `stdout:\n${r.stdout}`);
+});
+
+test('doctor does not require standalone hook files or wiring when the plugin is installed', () => {
+  const cfg = freshTmpDir();
+  fs.writeFileSync(path.join(cfg, 'settings.json'), JSON.stringify({ statusLine: null }, null, 2));
+  const claudeBin = fakeClaudeDir('caveman@caveman  1.4.0  active');
+  const r = doctor(cfg, claudeBin);
+  assert.equal(r.status, 0, `stdout:\n${r.stdout}`);
+});
+
+test('doctor still flags an orphaned hook in plugin mode (leftover from a pre-plugin install)', () => {
+  const cfg = freshTmpDir();
+  const node = process.execPath;
+  const settings = {
+    hooks: {
+      // Left behind by an old standalone install whose hook files were
+      // removed when the user migrated to the plugin (#471) — the plugin
+      // itself never wires SessionStart/UserPromptSubmit through this path,
+      // so this entry is pure debris, not a double-wiring case.
+      PreToolUse: [{ hooks: [{ type: 'command', command: `"${node}" "${path.join(cfg, 'hooks', 'caveman-activate.js')}"`, timeout: 5 }] }],
+    },
+  };
+  fs.writeFileSync(path.join(cfg, 'settings.json'), JSON.stringify(settings, null, 2));
+  const claudeBin = fakeClaudeDir('caveman@caveman  1.4.0  active');
+  const r = doctor(cfg, claudeBin);
+  assert.equal(r.status, 1);
+  assert.match(r.stdout + r.stderr, /caveman-activate\.js/);
+});
+
+test('doctor treats a broken `claude` CLI probe as no plugin installed, not a crash', () => {
+  // claude exists on PATH but exits non-zero / prints nothing usable.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cm-badbin-'));
+  const bin = path.join(dir, IS_WIN ? 'claude.cmd' : 'claude');
+  fs.writeFileSync(bin, IS_WIN ? '@echo off\r\nexit /b 1\r\n' : '#!/usr/bin/env bash\nexit 1\n');
+  if (!IS_WIN) fs.chmodSync(bin, 0o755);
+  const cfg = healthyStandaloneInstall();
+  const r = doctor(cfg, dir);
+  assert.equal(r.status, 0, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`);
+});


### PR DESCRIPTION
## What

Adds `caveman --doctor`: a read-only report on an existing install. It never writes anything, so a broken install is diagnosed here and fixed by re-running the installer or `--uninstall`.

```
$ caveman --doctor
🪨 caveman doctor
  config dir: /home/u/.claude
  install mode: standalone hooks (or plugin not detected)

  problem  missing hook file: caveman-parse.js
  problem  orphaned SessionStart hook points at missing script: /home/u/.claude/hooks/caveman-activate.js
  note     statusline badge not configured

2 problem(s) found
```

## Why

Half-broken installs are hard to diagnose today. A hook file deleted or edited by hand, a `settings.json` that stopped parsing after a manual edit, entries left behind pointing at scripts that no longer exist (#471), or standalone hooks still wired alongside the plugin so every event fires twice (#392). The symptom is a session that crashes at start, double-fires, or silently does nothing, and nothing tells the user which piece is wrong.

## How

Doctor probes for the plugin the same way `installClaude` does (`claude plugin list`) and applies the checks that fit the mode it finds:

- **No plugin detected** — the standalone hook files must all be present, unmodified against the shipped `checksums.sha256`, and wired into `settings.json`.
- **Plugin detected** — the plugin owns that wiring, so missing standalone files are expected; standalone wiring found *on top* of the plugin is the conflict, and gets reported by name.

Orphaned entries are reported in either mode, since migrating between the two paths in either direction can strand them. A user hook whose path merely contains a caveman-like name is never flagged, reusing the exact-basename rule the settings helpers already apply.

Bare `node` invocations and a missing statusline are reported as notes rather than problems: the installer already migrates the former on re-run, and neither breaks anything.

Exits 1 when at least one problem was found, 0 otherwise. Honors `--config-dir` and `--no-color`.

## Tests

19 tests in `tests/installer/doctor.test.mjs` covering both install modes, including a fake `claude` binary on `PATH` so the outcome never depends on what the machine running the suite happens to have installed, and a check that a broken install is left byte-for-byte untouched.

`npm test` passes 144/144 (125 existing + 19 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)