### PR TITLE
fix(cli): owner-only ~/.caveman and safe wrap shutdown order

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2138,8 +2138,8 @@ function printInstallResult(
 async function setupInstall(json: boolean, options: { continuing?: boolean } = {}) {
   const platform = setupPlatform();
   const timeoutSeconds = setupTimeoutSeconds();
-  const binDir = join(cavemanHome(), "bin");
-  mkdirSync(binDir, { recursive: true });
+  const binDir = join(ensureCavemanHome(), "bin");
+  mkdirSync(binDir, { recursive: true, mode: 0o700 });
 
   const local = verifiedLocalInstall(binDir);
   if (local) {
@@ -4898,13 +4898,39 @@ async function spawnWrapped(
       const removeSignalHandlers = () => {
         for (const [signal, handler] of signalHandlers) process.removeListener(signal, handler);
       };
-      for (const signal of ["SIGHUP", "SIGINT", "SIGQUIT", "SIGTERM"] as NodeJS.Signals[]) {
+      const wrapSignals = ["SIGHUP", "SIGINT", "SIGQUIT", "SIGTERM"] as NodeJS.Signals[];
+      for (const signal of wrapSignals) {
         const handler = () => {
-          cleanupWrapTempDirs();
-          removeProxySessionMarker(sessionMarker);
-          child.kill(signal);
+          // Forward the signal but defer cleanup and self-termination until the
+          // child exits: deleting the wrap temp pack before the agent shuts down
+          // races its SessionEnd hooks, which still read the plugin directory.
           removeSignalHandlers();
-          process.kill(process.pid, signal);
+          const finish = () => {
+            cleanupWrapTempDirs();
+            removeProxySessionMarker(sessionMarker);
+            process.kill(process.pid, signal);
+          };
+          // Escape hatch: a second signal, or a child that traps the first one,
+          // must still clean up — the temp pack can hold copied agent
+          // credentials (e.g. the Codex ephemeral home's auth.json), so dying
+          // at default disposition without cleanup would strand them on disk.
+          const escape = () => {
+            removeSignalHandlers();
+            child.kill("SIGKILL");
+            finish();
+          };
+          for (const s of wrapSignals) {
+            signalHandlers.set(s, escape);
+            process.once(s, escape);
+          }
+          child.kill(signal);
+          const grace = setTimeout(escape, 10_000);
+          grace.unref();
+          child.once("exit", () => {
+            clearTimeout(grace);
+            removeSignalHandlers();
+            finish();
+          });
         };
         signalHandlers.set(signal, handler);
         process.once(signal, handler);
@@ -8947,6 +8973,18 @@ export function wrapExternalWritesDisabled(env: NodeJS.ProcessEnv = process.env)
 
 function cavemanHome(): string {
   return process.env.CAVEMAN_HOME ?? join(homedir(), ".caveman");
+}
+
+// ensureCavemanHome creates ~/.caveman itself with owner-only perms and repairs
+// an existing permissive mode. The proxy refuses CCR (sqlite parent check) when
+// this directory is group/world writable, and recursive mkdir with a mode only
+// applies it to directories it creates — an earlier no-mode caller (login, mcp
+// install) would otherwise have already created it 0775 under umask 002.
+function ensureCavemanHome(): string {
+  const home = cavemanHome();
+  mkdirSync(home, { recursive: true, mode: 0o700 });
+  try { chmodSync(home, 0o700); } catch { /* not ours / Windows */ }
+  return home;
 }
 
 // cavemanBin resolves one of caveman's own Go binaries (proxy/engine/mcp/browse):
@@ -14538,7 +14576,7 @@ function credentialsPath() {
 }
 
 function fileTokenSet(token: string) {
-  mkdirSync(caveHome(), { recursive: true });
+  ensureCavemanHome();
   try { chmodSync(credentialsPath(), 0o600); } catch { /* created below */ }
   writeFileSync(credentialsPath(), token, { mode: 0o600 });
   chmodSync(credentialsPath(), 0o600);


### PR DESCRIPTION
Two fixes from the caveman-proxy 502 issue triage (the reporter's two smaller findings — the main fake-IP/SSRF finding needs the proxy's error surface and is tracked separately).

**1. Group-writable `~/.caveman` silently disables CCR.** `setupInstall` created `~/.caveman/bin` with a modeless recursive mkdir, so the directory inherited the umask — 0775 under Homebrew's 002 — and the proxy's sqlite-parent check then refused CCR and downgraded to record pass-through with only a stdout WARN. Fixing the one mkdir isn't enough: login's credential write and the mcp/hook marker writers also create the directory first, so whichever command runs first wins. New `ensureCavemanHome()` creates the root `0700` **and** chmod-repairs an existing permissive one; wired into setup and the login token write. Broken installs self-heal on the next `caveman setup` or `caveman login`.

**2. Wrap temp pack deleted before the agent shuts down.** The wrap signal handler ran `cleanupWrapTempDirs()` before `child.kill(signal)`, so on SIGINT/SIGTERM the ephemeral plugin pack vanished before the agent's SessionEnd hooks ran (`Plugin directory does not exist: $TMPDIR/caveman-wrap-claude-*`). The handler now forwards the signal and defers cleanup + self-termination to the child's exit event. Because the pack can hold copied agent credentials (the Codex ephemeral home's `auth.json`), dying without cleanup is not acceptable either — a re-armed second-signal escape handler and a 10s unref'd grace timer SIGKILL the child and clean up when it never exits.

Independently reviewed (adversarial pass caught two regressions in the first version of these fixes: the mkdir-ordering defeat and the second-signal credential strand — both addressed above).

## Testing
- `tsc --noEmit` clean
- `wrap`, `wrap-gate`, `login`, `setup-install` runtime suites: 77 pass, 0 fail (5 skipped, Go-binary-dependent)

## Related
- Overlaps in intent with #824's "signal forwarding" item — worth reconciling before merging both.
- Telemetry default is being flipped to on-by-default/opt-out (with first-run disclosure and persisted decisions honored) in a follow-up PR; not part of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLNTYJU8vMEdDWpV7e7k7Z
