### PR TITLE
fix(hooks): Windows stdin EOF stall silently kills the UserPromptSubmit hook

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,7 +12,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-activate.js\"",
-            "timeout": 5,
+            "timeout": 15,
             "statusMessage": "Loading caveman mode..."
           }
         ]
@@ -24,7 +24,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-mode-tracker.js\"",
-            "timeout": 5,
+            "timeout": 15,
             "statusMessage": "Tracking caveman mode..."
           }
         ]

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -16,12 +16,46 @@ const flagPath = path.join(claudeDir, '.caveman-active');
 const prevPath = path.join(claudeDir, '.caveman-active.prev');
 
 let input = '';
+let handled = false;
+
+// stdin EOF grace timer. Everything this hook does lives in handleInput,
+// which normally runs off stdin's 'end' event — but on Windows the hook's
+// stdin pipe sometimes never signals EOF, so the process sat idle doing no
+// work until the hook timeout killed it and the per-turn reinforcement was
+// lost. Observed on one Windows 11 install: 28 of 53 runs died at the 5s
+// limit (median 5423ms) while node itself starts in ~130ms — the cost was
+// waiting, not computing. Claude Code writes the whole JSON payload up
+// front, so process whatever is buffered after a short grace period
+// instead. A healthy 'end' fires in single-digit ms and clears this timer
+// before it ever fires.
+const STDIN_GRACE_MS = 250;
+const graceTimer = setTimeout(handleInput, STDIN_GRACE_MS);
+// Never let the timer itself be the reason the process stays alive.
+graceTimer.unref();
+
 process.stdin.on('data', chunk => { input += chunk; });
 // Abnormal stdin close (broken pipe, parent crash) emits 'error'; without a
 // listener Node throws it as an uncaught exception and the hook exits
 // non-zero — a spurious hook failure (#538). Hooks must always exit 0.
 process.stdin.on('error', () => process.exit(0));
-process.stdin.on('end', () => {
+process.stdin.on('end', handleInput);
+
+function handleInput() {
+  if (handled) return;          // 'end' and the timer must never both run
+  handled = true;
+  clearTimeout(graceTimer);
+  try {
+    runHook();
+  } finally {
+    // Release the stdin handle so the event loop drains and the process
+    // exits on its own once stdout has flushed. Deliberately not
+    // process.exit() — on Windows stdout to a pipe is async and exit() can
+    // truncate the write.
+    try { process.stdin.destroy(); } catch (e) {}
+  }
+}
+
+function runHook() {
   try {
     const data = JSON.parse(input);
     // Collapse whitespace so phrase triggers still match multiline prompts —
@@ -170,4 +204,4 @@ process.stdin.on('end', () => {
   } catch (e) {
     // Silent fail
   }
-});
+}

--- a/tests/test_mode_tracker_stdin.js
+++ b/tests/test_mode_tracker_stdin.js
@@ -255,5 +255,53 @@ test('/caveman-stats emits hookSpecificOutput.additionalContext, not decision:bl
   }
 });
 
-console.log(`\n${passed} passed, ${failed} failed`);
-process.exit(failed === 0 ? 0 : 1);
+// ---------- Windows stdin EOF stall: buffered input processed anyway ----------
+
+// On Windows the hook's stdin pipe sometimes never signals EOF, so a hook
+// that does all its work in the 'end' handler idles until the hook timeout
+// kills it and the per-turn reinforcement is lost. The grace timer in the
+// tracker must process the buffered payload and exit on its own even when
+// stdin is deliberately held open. Async because spawnSync cannot keep the
+// child's stdin open past the write.
+function testStalledStdin() {
+  return new Promise(resolve => {
+    const { spawn } = require('child_process');
+    const name = 'stdin held open (no EOF): buffered input processed, clean self-exit';
+    const cfg = makeConfigDir();
+    const child = spawn(process.execPath, [HOOK_PATH], {
+      env: { ...process.env, CLAUDE_CONFIG_DIR: cfg },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    // Watchdog well below the 15s hook timeout: a hang here is the exact
+    // regression this test guards against.
+    const killer = setTimeout(() => child.kill(), 4000);
+    child.on('exit', (code, signal) => {
+      clearTimeout(killer);
+      try {
+        assert.strictEqual(signal, null,
+          'hook hung with stdin open and was killed by the watchdog (EOF-stall regression)');
+        assert.strictEqual(code, CLEAN_EXIT,
+          `expected clean exit, got status=${code}`);
+        assert.strictEqual(flagValue(cfg), 'ultra',
+          'buffered "/caveman ultra" was never processed');
+        passed++;
+        console.log(`  ✓ ${name}`);
+      } catch (e) {
+        failed++;
+        console.error(`  ✗ ${name}`);
+        console.error(`    ${e.message}`);
+      } finally {
+        fs.rmSync(cfg, { recursive: true, force: true });
+        resolve();
+      }
+    });
+    child.stdin.on('error', () => {}); // hook destroys its stdin; EPIPE here is expected
+    child.stdin.write(JSON.stringify({ prompt: '/caveman ultra' }));
+    // Deliberately NO child.stdin.end() — simulates the pipe that never EOFs.
+  });
+}
+
+testStalledStdin().then(() => {
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed === 0 ? 0 : 1);
+});


### PR DESCRIPTION
## Problem

On Windows, the `caveman-mode-tracker.js` hook's stdin pipe sometimes never signals EOF. All of the tracker's work runs in stdin's `'end'` handler, so when that happens the process sits idle until the hook timeout kills it — the mode flag is never updated and the per-turn caveman reinforcement is silently lost. The user just sees Claude drift out of caveman mode.

**Evidence** (Windows 11, Claude Code, caveman installed as plugin): across one machine's transcripts, 28 of 53 hook runs died at the 5s timeout with median 5423ms wall clock — while `node` itself starts in ~130ms on the same machine. The cost was waiting for an EOF that never came, not computing. After this patch ran locally for ~2 weeks: daily successful injections, zero timeouts.

## Fix

- 250ms stdin grace timer: Claude Code writes the whole JSON payload up front, so process whatever is buffered once the grace period passes instead of waiting for EOF. A healthy `'end'` fires in single-digit milliseconds and clears the timer, so the normal path is unchanged.
- `handled` guard so `'end'` and the timer can never both run; work extracted to `handleInput()`/`runHook()`.
- `process.stdin.destroy()` afterwards so the event loop drains and the process exits on its own — deliberately not `process.exit()`, which can truncate async pipe writes on Windows.
- Both hook timeouts raised 5s → 15s: SessionStart legitimately takes 3–5s wall clock on Windows when session start spawns several MCP servers concurrently and antivirus scans each node spawn, putting it within margin of the old 5s limit.

## Tests

New regression test in `tests/test_mode_tracker_stdin.js` holds the child's stdin open (no EOF, no close) and asserts the buffered `/caveman ultra` is processed with a clean self-exit. It fails against the previous tracker (watchdog SIGTERM after hang) and passes with the fix. All 12 tests in that file pass; `tests/test_mode_tracker.py` passes (23 tests). The two failures in `tests/test_hooks.py` are pre-existing on main (Windows path-separator mismatch in statusline install tests, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)