### PR TITLE
fix(hooks): unresolved /caveman arg is silent; prose fires NL triggers

### DIFF
--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { execFileSync } = require('child_process');
-const { getDefaultMode, safeWriteFlag, readFlag, recordModeChange } = require('./caveman-config');
+const { getDefaultMode, safeWriteFlag, readFlag, recordModeChange, VALID_MODES } = require('./caveman-config');
 const { parseModeChange, INDEPENDENT_MODES } = require('./caveman-parse');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
@@ -169,11 +169,34 @@ process.stdin.on('end', () => {
     // hook stdin's cwd through so that check resolves for the session's
     // directory, not this hook process's own cwd. This gates ONLY the
     // reinforcement output below — it never deletes or writes the flag file.
+    // One stdout write per run, so the unresolved-argument notice and the
+    // per-turn reinforcement share a single additionalContext.
+    const context = [];
+
+    // A /caveman argument that matched no mode. The level is deliberately left
+    // alone, but saying nothing reads as success — the user believes the level
+    // switched and the session keeps running at the old one. The notice names
+    // the valid modes, built from VALID_MODES so it cannot drift from the
+    // parser, and NEVER repeats the rejected argument back: this string goes
+    // into model context and the argument is untrusted input.
+    if (change && change.action === 'unresolved') {
+      const selectable = VALID_MODES.filter(m => !INDEPENDENT_MODES.has(m));
+      context.push(
+        `CAVEMAN: /caveman argument not recognized — level unchanged (${readFlag(flagPath) || 'off'}). ` +
+        `Valid: ${selectable.join(', ')}. Tell the user the level did not change ` +
+        `and name the valid modes. Do not quote the argument back.`
+      );
+    }
+
     if (activeMode && !INDEPENDENT_MODES.has(activeMode) && getDefaultMode(data.cwd) !== 'off') {
+      context.push(`CAVEMAN MODE ACTIVE (${activeMode}) — session ruleset applies.`);
+    }
+
+    if (context.length) {
       process.stdout.write(JSON.stringify({
         hookSpecificOutput: {
           hookEventName: "UserPromptSubmit",
-          additionalContext: `CAVEMAN MODE ACTIVE (${activeMode}) — session ruleset applies.`
+          additionalContext: context.join(' ')
         }
       }));
     }

--- a/src/hooks/caveman-parse.js
+++ b/src/hooks/caveman-parse.js
@@ -75,11 +75,35 @@ function parseModeChange(promptRaw, options) {
   prompt = prompt.toLowerCase().replace(/\s+/g, ' ');
   if (!prompt) return null;
 
+  // Natural-language triggers fire only on a SHORT, command-like utterance.
+  // They run over the WHOLE prompt, so prose that merely MENTIONS them fired
+  // them: a bug report quoting the /caveman-help card's own line —
+  //   Say "stop caveman" or "normal mode".
+  // — switched caveman off mid-task. Same exposure for any pasted changelog,
+  // issue text or documentation carrying those words. The envelope unwrap in
+  // the tracker (#537) closes the slash-command path; this closes the prose
+  // one, which needs no envelope at all.
+  //
+  // Slash commands are parsed further down and are NEVER length-capped, so
+  // `/caveman off` still works inside a prompt of any size. 120 chars clears
+  // every documented natural-language form with headroom — the longest,
+  // "back to normal mode please", is 26.
+  const NL_TRIGGER_MAX_CHARS = 120;
+  const isCommandLike =
+    prompt.length <= NL_TRIGGER_MAX_CHARS && !prompt.startsWith('/');
+
+  // Trailing punctuation glued to a mode word defeats the closed-list match
+  // below. It shows up whenever a sentence is appended to the command —
+  // "/caveman ultra; still too verbose" parses the argument as "ultra;". Only
+  // parts[1] is ever read, so extra WORDS after the mode were already
+  // harmless; it is the character glued to the mode that broke it.
+  const stripArgPunctuation = (raw) => (raw || '').replace(/[.,;:!?'")\]}]+$/, '');
+
   // Deactivation intent — computed FIRST so "turn caveman mode off" never
   // falls through to the activation patterns (#598), and applied with the
   // highest priority: it's what the tracker's original unconditional
   // end-of-function deactivation check amounted to.
-  const wantsOff = !options.skipNaturalLanguage && (
+  const wantsOff = !options.skipNaturalLanguage && isCommandLike && (
     /\b(stop|disable|deactivate|quit|exit|kill)\s+(the\s+)?caveman\b/.test(prompt) ||
     /\bcaveman(\s+mode)?\s+(off|stop|disabled?)\b/.test(prompt) ||
     /\bturn\s+off\s+(the\s+)?caveman\b/.test(prompt) ||
@@ -111,7 +135,7 @@ function parseModeChange(promptRaw, options) {
     }
     const tpl = /^activate caveman mode:[ \t]*(\S*)/.exec(firstLine);
     if (tpl) {
-      const arg = tpl[1] || '';
+      const arg = stripArgPunctuation(tpl[1]);
       if (!arg) {
         const mode = getDefaultMode();
         return mode === 'off' ? { action: 'clear' } : { action: 'set', mode };
@@ -119,7 +143,9 @@ function parseModeChange(promptRaw, options) {
       if (arg === 'off' || arg === 'stop' || arg === 'disable') return { action: 'clear' };
       if (arg === 'wenyan-full') return { action: 'set', mode: 'wenyan' };
       if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) return { action: 'set', mode: arg };
-      return null; // unknown/bogus level — leave flag untouched (#602)
+      // Unknown level — flag untouched (#602), but SAY so: silence here reads
+      // as success and the session keeps running at the level it already had.
+      return { action: 'unresolved' };
     }
   }
 
@@ -134,7 +160,7 @@ function parseModeChange(promptRaw, options) {
     // "be brief/terse", "fewer tokens", "shorter answers") — but not when
     // scoped to a single section ("be brief in the summary"), which is a
     // one-off instruction, not a session-wide mode switch.
-    if (!isQuestion) {
+    if (isCommandLike && !isQuestion) {
       if (/\b(activate|enable|start|turn on|use|switch to|want|give me)\b[^.]{0,40}\bcaveman\b/.test(prompt) ||
           /\btalk like\b[^.]{0,40}\bcaveman\b/.test(prompt) ||
           /\bcaveman\s+mode\s+(on|please|now)\b/.test(prompt) ||
@@ -155,7 +181,7 @@ function parseModeChange(promptRaw, options) {
   if (prompt.startsWith('/caveman')) {
     const parts = prompt.split(/\s+/);
     const cmd = parts[0]; // /caveman, /caveman-commit, /caveman-review, etc.
-    const arg = parts[1] || '';
+    const arg = stripArgPunctuation(parts[1]);
 
     if (cmd === '/caveman-commit' || cmd === '/caveman:caveman-commit') {
       return { action: 'set', mode: 'commit' };
@@ -175,8 +201,10 @@ function parseModeChange(promptRaw, options) {
       if (arg === 'off' || arg === 'stop' || arg === 'disable') return { action: 'clear' };
       if (arg === 'wenyan-full') return { action: 'set', mode: 'wenyan' }; // canonical alias — config stores as 'wenyan'
       if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) return { action: 'set', mode: arg };
-      // Unknown arg → no-op, flag untouched (no silent overwrite with default)
-      return null;
+      // Unknown arg → flag untouched (no silent overwrite with default), and
+      // reported rather than swallowed. Consumers that act only on
+      // 'set'/'clear' ignore this verdict, so it is additive.
+      return { action: 'unresolved' };
     }
   }
 

--- a/tests/test_caveman_parse.js
+++ b/tests/test_caveman_parse.js
@@ -66,12 +66,15 @@ test('wenyan-full alias stores as "wenyan"', () => {
   assert.deepStrictEqual(parseModeChange('/caveman wenyan-full', defaultFull), { action: 'set', mode: 'wenyan' });
 });
 
-test('bogus level returns null — never falls through to the default', () => {
-  assert.strictEqual(parseModeChange('/caveman not-a-real-level', defaultFull), null);
+test('bogus level is unresolved — never falls through to the default', () => {
+  // Contract change: was null, now a reported no-op. The danger this guards
+  // against is unchanged — a bogus level must never activate the default —
+  // but the tracker can now tell the user the level did not move.
+  assert.deepStrictEqual(parseModeChange('/caveman not-a-real-level', defaultFull), { action: 'unresolved' });
 });
 
 test('independent modes are not reachable via /caveman <arg>', () => {
-  assert.strictEqual(parseModeChange('/caveman commit', defaultFull), null);
+  assert.deepStrictEqual(parseModeChange('/caveman commit', defaultFull), { action: 'unresolved' });
 });
 
 test('/caveman-commit, /caveman-review, /caveman-compress set independent modes', () => {
@@ -178,10 +181,10 @@ test('expandedTpl: empty level (bare "/caveman", multi-line template head) uses 
   );
 });
 
-test('expandedTpl: bogus level in the template returns null, not the default (#602 drift)', () => {
-  assert.strictEqual(
+test('expandedTpl: bogus level in the template is unresolved, not the default (#602 drift)', () => {
+  assert.deepStrictEqual(
     parseModeChange('Activate caveman mode: not-a-real-level', { ...defaultFull, expandedTpl: true }),
-    null
+    { action: 'unresolved' }
   );
 });
 
@@ -231,14 +234,78 @@ function runTracker(prompt, presetFlag) {
   }
 }
 
+// ---------- punctuation glued to the mode ----------
+
+test('trailing semicolon does not defeat the mode match', () => {
+  assert.deepStrictEqual(
+    parseModeChange('/caveman ultra; still too verbose', defaultFull),
+    { action: 'set', mode: 'ultra' }
+  );
+});
+
+test('trailing period and comma do not defeat the mode match', () => {
+  assert.deepStrictEqual(parseModeChange('/caveman lite.', defaultFull), { action: 'set', mode: 'lite' });
+  assert.deepStrictEqual(parseModeChange('/caveman:caveman ultra,', defaultFull), { action: 'set', mode: 'ultra' });
+});
+
+test('punctuation-only difference still resolves off', () => {
+  assert.deepStrictEqual(parseModeChange('/caveman off.', defaultFull), { action: 'clear' });
+});
+
+test('unknown argument reports unresolved instead of returning null', () => {
+  assert.deepStrictEqual(parseModeChange('/caveman blorptastic', defaultFull), { action: 'unresolved' });
+});
+
+// ---------- phrase triggers must not fire on prose that quotes them ----------
+
+const HELP_CARD_EXCERPT =
+  '| **Ultra** | `/caveman ultra` | Extreme compression. Bare fragments. | ' +
+  'Mode stick until changed or session end. ## Deactivate ' +
+  'Say "stop caveman" or "normal mode". Resume anytime with `/caveman`.';
+
+test('help-card text does not deactivate', () => {
+  assert.strictEqual(parseModeChange(HELP_CARD_EXCERPT, defaultFull), null);
+});
+
+test('long prose quoting the deactivation phrases does not deactivate', () => {
+  const report =
+    'fix these bugs. bug 2, bigger - opening /caveman-help switched caveman off. ' +
+    'the card\'s own line "say stop caveman or normal mode" matched the deactivation ' +
+    'regex, which runs over the whole prompt.';
+  assert.strictEqual(parseModeChange(report, defaultFull), null);
+});
+
+test('long prose describing activation does not activate', () => {
+  const doc =
+    'the readme says users can turn on caveman mode by typing activate caveman, ' +
+    'and that phrasing is what the natural language matcher keys on. document that ' +
+    'in the contributing guide please.';
+  assert.strictEqual(parseModeChange(doc, defaultFull), null);
+});
+
+test('short deactivation and activation still fire (control)', () => {
+  assert.deepStrictEqual(parseModeChange('stop caveman', defaultFull), { action: 'clear' });
+  assert.deepStrictEqual(parseModeChange('activate caveman', defaultFull), { action: 'set', mode: 'full' });
+});
+
+test('/caveman off still works inside a long prompt', () => {
+  const long =
+    '/caveman off and then walk me through why the deactivation regex used to run ' +
+    'over the entire prompt body, including documentation text that quoted the ' +
+    'trigger phrases verbatim.';
+  assert.deepStrictEqual(parseModeChange(long, defaultFull), { action: 'clear' });
+});
+
 const parityCases = [
   { prompt: '/caveman ultra', preset: null },
   { prompt: '/caveman off', preset: 'full' },
   { prompt: '/caveman not-a-real-level', preset: 'ultra' },
+  { prompt: '/caveman ultra; still too verbose', preset: 'full' },
   { prompt: 'be brief', preset: null },
   { prompt: 'activate caveman', preset: null },
   { prompt: 'stop caveman', preset: 'full' },
   { prompt: 'what is caveman mode?', preset: null },
+  { prompt: HELP_CARD_EXCERPT, preset: 'full' },
 ];
 
 for (const { prompt, preset } of parityCases) {
@@ -247,6 +314,9 @@ for (const { prompt, preset } of parityCases) {
     const verdict = parseModeChange(normalized, { getDefaultMode: () => 'full' });
     const expected =
       verdict === null ? (preset || null) :
+      // 'unresolved' leaves the flag exactly where it was, same as null — it
+      // differs only in that the tracker now says so out loud.
+      verdict.action === 'unresolved' ? (preset || null) :
       verdict.action === 'clear' ? null :
       verdict.mode;
     assert.strictEqual(runTracker(prompt, preset), expected);

--- a/tests/test_mode_tracker.py
+++ b/tests/test_mode_tracker.py
@@ -182,6 +182,51 @@ class ModeTrackerTests(unittest.TestCase):
         r = self.send("/caveman-commit")
         self.assertNotIn("CAVEMAN MODE ACTIVE", r.stdout)
 
+    # ── unresolved /caveman argument is reported, not swallowed ─────────
+
+    def test_glued_punctuation_still_switches(self):
+        self.flag.write_text("full", encoding="utf-8")
+        self.send("/caveman ultra; this feature does not seem to be working")
+        self.assertEqual(self.flag_value(), "ultra")
+
+    def test_unresolved_arg_is_announced_without_echo(self):
+        self.flag.write_text("full", encoding="utf-8")
+        r = self.send("/caveman blorptastic")
+        self.assertEqual(self.flag_value(), "full", "level must not change")
+        self.assertIn("not recognized", r.stdout)
+        for mode in ("lite", "full", "ultra", "wenyan-lite", "wenyan-ultra"):
+            self.assertIn(mode, r.stdout, f"notice must name {mode}")
+        self.assertNotIn(
+            "blorptastic", r.stdout,
+            "untrusted argument must never be echoed into model context",
+        )
+
+    def test_unresolved_arg_notice_when_caveman_off(self):
+        r = self.send("/caveman blorptastic")
+        self.assertIsNone(self.flag_value())
+        self.assertIn("not recognized", r.stdout)
+        self.assertNotIn("blorptastic", r.stdout)
+
+    def test_help_card_body_does_not_deactivate(self):
+        # The card documents the deactivation phrases; quoting them is not
+        # issuing them. The envelope unwrap (#537) covers the slash path; this
+        # covers the body arriving as plain prose.
+        self.flag.write_text("full", encoding="utf-8")
+        self.send(
+            '| **Ultra** | `/caveman ultra` | Extreme compression. |\n\n'
+            '## Deactivate\n\n'
+            'Say "stop caveman" or "normal mode". Resume anytime with `/caveman`.\n\n'
+            "## Language\n\nKeep user's language by default."
+        )
+        self.assertEqual(self.flag_value(), "full")
+
+    def test_short_deactivation_still_works(self):
+        # Control for the case above: the same regexes still fire on a real
+        # command, so the silence there is the scoping and not the harness.
+        self.flag.write_text("ultra", encoding="utf-8")
+        self.send("stop caveman")
+        self.assertIsNone(self.flag_value())
+
     def test_deactivation_clears_saved_prev(self):
         self.flag.write_text("ultra", encoding="utf-8")
         self.send("/caveman-commit")


### PR DESCRIPTION
Rebased onto `c72984e` and rewritten against `src/hooks/caveman-parse.js` — the first version of this PR targeted the pre-#602 tracker. Both defects survive on current main.

## 1. Punctuation glued to the mode

`/caveman ultra; still too verbose` parses the argument as `ultra;`, matches no mode, leaves the level untouched, says nothing.

Only `parts[1]` is ever read, so extra *words* after the mode were already harmless. It is the character glued to the mode that breaks it.

Fix: strip trailing punctuation. An argument that still resolves to nothing now returns `{ action: 'unresolved' }` instead of `null`, and the tracker turns that into a notice naming the valid modes.

Notice is built from `VALID_MODES` minus `INDEPENDENT_MODES`, so it cannot drift from the parser. It never echoes the rejected argument — that string lands in model context and is untrusted input.

`unresolved` is additive: `applyModeChange` in the opencode plugin acts only on `set`/`clear`. Three existing tests asserted `null` for a bogus level; they now assert the new verdict and still guard the original danger — a bogus level must never activate the default.

## 2. Prose that quotes the trigger phrases fires them

Natural-language triggers run over the whole prompt. A bug report quoting the `/caveman-help` card's own line —

> Say "stop caveman" or "normal mode".

— switched caveman off mid-task. #537's envelope unwrap closes the slash-command path; this is the prose path, which needs no envelope. Any pasted changelog, issue text, or doc carrying those words does the same.

Fix: triggers require a short, command-like utterance — 120 chars or fewer, not slash-initiated. Slash parsing untouched and never length-capped, so `/caveman off` works inside a prompt of any size. 120 clears every documented form with headroom; the longest, "back to normal mode please", is 26.

## Tests

9 new cases in `tests/test_caveman_parse.js` plus 2 parity cases, and 5 integration cases in `tests/test_mode_tracker.py`.

Verified against pristine files first: 9 of the new JS cases and 4 of the 5 python cases fail on unmodified `c72984e`. The one that passes both ways is the short `stop caveman` control — it is there to prove the silence in the negative cases is the scoping and not the harness.

Suites green: 44 parse, 28 mode-tracker, 11 stdin.

## Note

`src/hooks/checksums.sha256` still carries the old hashes for the two changed hook files. Manifest looks per-release, so leaving it to your release cut rather than guessing — say the word if you want it in this PR.
