### PR TITLE
feat(hooks): level-aware per-turn reinforcement

### DIFF
--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -25,6 +25,72 @@ function removeFlag(path) {
   }
 }
 
+// Per-level directives. Every level used to inject one identical sentence, so
+// `/caveman ultra` mid-session moved the statusline badge and changed nothing
+// about the output — the level-specific rules are emitted ONLY by the
+// SessionStart hook, i.e. only for whatever level the session opened at.
+const LEVEL_DIRECTIVE = {
+  lite: 'Cut filler, pleasantries and hedging. Keep articles and whole sentences.',
+  full: 'Drop articles, filler, pleasantries, hedging. Fragments OK. ' +
+        'Short synonyms. No tool-call narration, no decorative tables.',
+  ultra: 'Fragments only. One word where one word carries it. Each fact once. ' +
+         'Drop conjunctions where cause-then-effect stays unambiguous. ' +
+         'No invented abbreviations, no arrows — both cost tokens and clarity.',
+  'wenyan-lite': 'Semi-classical Chinese register. Drop filler and hedging, keep grammar.',
+  wenyan: 'Full 文言文. Classical sentence patterns, subjects often omitted.',
+  'wenyan-full': 'Full 文言文. Classical sentence patterns, subjects often omitted.',
+  'wenyan-ultra': 'Extreme classical Chinese. Maximum compression, ultra terse.'
+};
+
+// Exemptions, restated every turn, because this is where caveman loses. Another
+// active instruction set (a task-start protocol, a review checklist, an audit
+// block) demands fixed-format multi-line output; caveman demands compression;
+// the model resolves the clash by dropping one of them. Neither should be
+// dropped — they govern different things. A required block is a structured
+// artifact like a code block and gets the same verbatim treatment.
+const VERBATIM_CLAUSE =
+  'Verbatim, never compressed: code, commit messages, security warnings, ' +
+  'error strings, and any fixed-format block another active instruction ' +
+  'requires (protocol blocks, gates, checklists, audit blocks) — including ' +
+  'their field labels. Compress the prose around such a block, not the block.';
+
+// The level's own ruleset, filtered out of SKILL.md — the same source of truth
+// the SessionStart hook reads, with the same candidate paths. Emitted only on a
+// level CHANGE, so an ordinary turn still costs one short line. Returns '' on
+// any miss: a standalone hook install may have no skills dir at all, and a
+// missing ruleset must never break a turn.
+function readLevelRuleset(modeLabel) {
+  const candidates = [];
+  if (process.env.CLAUDE_PLUGIN_ROOT) {
+    candidates.push(path.join(process.env.CLAUDE_PLUGIN_ROOT, 'skills', 'caveman', 'SKILL.md'));
+  }
+  candidates.push(
+    path.join(__dirname, '..', '..', 'skills', 'caveman', 'SKILL.md'),
+    path.join(__dirname, '..', 'skills', 'caveman', 'SKILL.md')
+  );
+
+  for (const candidate of candidates) {
+    try {
+      const body = fs.readFileSync(candidate, 'utf8').replace(/^---[\s\S]*?---\s*/, '');
+      return body.split('\n').reduce((acc, line) => {
+        const row = line.match(/^\|\s*\*\*(\S+?)\*\*\s*\|/);
+        if (row) {
+          if (row[1] === modeLabel) acc.push(line);
+          return acc;
+        }
+        const example = line.match(/^- (\S+?):\s/);
+        if (example) {
+          if (example[1] === modeLabel) acc.push(line);
+          return acc;
+        }
+        acc.push(line);
+        return acc;
+      }, []).join('\n').trim();
+    } catch (e) { /* try next candidate */ }
+  }
+  return '';
+}
+
 let input = '';
 process.stdin.on('data', chunk => { input += chunk; });
 // Abnormal stdin close (broken pipe, parent crash) emits 'error'; without a
@@ -114,8 +180,14 @@ process.stdin.on('end', () => {
     // "Level persist until changed or session end", and a one-shot skill
     // invocation should not count as "changed" forever.
     let setIndependentThisTurn = false;
+    // Set when THIS prompt moved the level. Drives the one-time re-emission of
+    // the new level's ruleset below.
+    let switchedTo = null;
     if (change && change.action === 'set') {
       const mode = change.mode;
+      if (!INDEPENDENT_MODES.has(mode) && readFlag(flagPath) !== mode) {
+        switchedTo = mode;
+      }
       if (INDEPENDENT_MODES.has(mode)) {
         // Save the prose mode being displaced — but never overwrite an
         // already-saved one with another independent mode (/caveman-commit
@@ -189,7 +261,21 @@ process.stdin.on('end', () => {
     }
 
     if (activeMode && !INDEPENDENT_MODES.has(activeMode) && getDefaultMode(data.cwd) !== 'off') {
-      context.push(`CAVEMAN MODE ACTIVE (${activeMode}) — session ruleset applies.`);
+      // 'wenyan' is stored canonically; SKILL.md labels that row wenyan-full.
+      const label = activeMode === 'wenyan' ? 'wenyan-full' : activeMode;
+      context.push(
+        `CAVEMAN MODE ACTIVE (${label}). ` +
+        `${LEVEL_DIRECTIVE[activeMode] || LEVEL_DIRECTIVE.full} ${VERBATIM_CLAUSE}`
+      );
+
+      // Level just changed: re-emit that level's own rules once, so the switch
+      // reaches the model instead of only the flag file and the statusline.
+      if (switchedTo === activeMode) {
+        const ruleset = readLevelRuleset(label);
+        if (ruleset) {
+          context.push(`CAVEMAN LEVEL NOW ${label} — rules for this level:\n${ruleset}`);
+        }
+      }
     }
 
     if (context.length) {

--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { execFileSync } = require('child_process');
-const { getDefaultMode, safeWriteFlag, readFlag, recordModeChange } = require('./caveman-config');
+const { getDefaultMode, safeWriteFlag, readFlag, recordModeChange, VALID_MODES } = require('./caveman-config');
 const { parseModeChange, INDEPENDENT_MODES } = require('./caveman-parse');
 
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
@@ -169,11 +169,34 @@ process.stdin.on('end', () => {
     // hook stdin's cwd through so that check resolves for the session's
     // directory, not this hook process's own cwd. This gates ONLY the
     // reinforcement output below — it never deletes or writes the flag file.
+    // One stdout write per run, so the unresolved-argument notice and the
+    // per-turn reinforcement share a single additionalContext.
+    const context = [];
+
+    // A /caveman argument that matched no mode. The level is deliberately left
+    // alone, but saying nothing reads as success — the user believes the level
+    // switched and the session keeps running at the old one. The notice names
+    // the valid modes, built from VALID_MODES so it cannot drift from the
+    // parser, and NEVER repeats the rejected argument back: this string goes
+    // into model context and the argument is untrusted input.
+    if (change && change.action === 'unresolved') {
+      const selectable = VALID_MODES.filter(m => !INDEPENDENT_MODES.has(m));
+      context.push(
+        `CAVEMAN: /caveman argument not recognized — level unchanged (${readFlag(flagPath) || 'off'}). ` +
+        `Valid: ${selectable.join(', ')}. Tell the user the level did not change ` +
+        `and name the valid modes. Do not quote the argument back.`
+      );
+    }
+
     if (activeMode && !INDEPENDENT_MODES.has(activeMode) && getDefaultMode(data.cwd) !== 'off') {
+      context.push(`CAVEMAN MODE ACTIVE (${activeMode}) — session ruleset applies.`);
+    }
+
+    if (context.length) {
       process.stdout.write(JSON.stringify({
         hookSpecificOutput: {
           hookEventName: "UserPromptSubmit",
-          additionalContext: `CAVEMAN MODE ACTIVE (${activeMode}) — session ruleset applies.`
+          additionalContext: context.join(' ')
         }
       }));
     }

--- a/src/hooks/caveman-parse.js
+++ b/src/hooks/caveman-parse.js
@@ -75,11 +75,35 @@ function parseModeChange(promptRaw, options) {
   prompt = prompt.toLowerCase().replace(/\s+/g, ' ');
   if (!prompt) return null;
 
+  // Natural-language triggers fire only on a SHORT, command-like utterance.
+  // They run over the WHOLE prompt, so prose that merely MENTIONS them fired
+  // them: a bug report quoting the /caveman-help card's own line —
+  //   Say "stop caveman" or "normal mode".
+  // — switched caveman off mid-task. Same exposure for any pasted changelog,
+  // issue text or documentation carrying those words. The envelope unwrap in
+  // the tracker (#537) closes the slash-command path; this closes the prose
+  // one, which needs no envelope at all.
+  //
+  // Slash commands are parsed further down and are NEVER length-capped, so
+  // `/caveman off` still works inside a prompt of any size. 120 chars clears
+  // every documented natural-language form with headroom — the longest,
+  // "back to normal mode please", is 26.
+  const NL_TRIGGER_MAX_CHARS = 120;
+  const isCommandLike =
+    prompt.length <= NL_TRIGGER_MAX_CHARS && !prompt.startsWith('/');
+
+  // Trailing punctuation glued to a mode word defeats the closed-list match
+  // below. It shows up whenever a sentence is appended to the command —
+  // "/caveman ultra; still too verbose" parses the argument as "ultra;". Only
+  // parts[1] is ever read, so extra WORDS after the mode were already
+  // harmless; it is the character glued to the mode that broke it.
+  const stripArgPunctuation = (raw) => (raw || '').replace(/[.,;:!?'")\]}]+$/, '');
+
   // Deactivation intent — computed FIRST so "turn caveman mode off" never
   // falls through to the activation patterns (#598), and applied with the
   // highest priority: it's what the tracker's original unconditional
   // end-of-function deactivation check amounted to.
-  const wantsOff = !options.skipNaturalLanguage && (
+  const wantsOff = !options.skipNaturalLanguage && isCommandLike && (
     /\b(stop|disable|deactivate|quit|exit|kill)\s+(the\s+)?caveman\b/.test(prompt) ||
     /\bcaveman(\s+mode)?\s+(off|stop|disabled?)\b/.test(prompt) ||
     /\bturn\s+off\s+(the\s+)?caveman\b/.test(prompt) ||
@@ -111,7 +135,7 @@ function parseModeChange(promptRaw, options) {
     }
     const tpl = /^activate caveman mode:[ \t]*(\S*)/.exec(firstLine);
     if (tpl) {
-      const arg = tpl[1] || '';
+      const arg = stripArgPunctuation(tpl[1]);
       if (!arg) {
         const mode = getDefaultMode();
         return mode === 'off' ? { action: 'clear' } : { action: 'set', mode };
@@ -119,7 +143,9 @@ function parseModeChange(promptRaw, options) {
       if (arg === 'off' || arg === 'stop' || arg === 'disable') return { action: 'clear' };
       if (arg === 'wenyan-full') return { action: 'set', mode: 'wenyan' };
       if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) return { action: 'set', mode: arg };
-      return null; // unknown/bogus level — leave flag untouched (#602)
+      // Unknown level — flag untouched (#602), but SAY so: silence here reads
+      // as success and the session keeps running at the level it already had.
+      return { action: 'unresolved' };
     }
   }
 
@@ -134,7 +160,7 @@ function parseModeChange(promptRaw, options) {
     // "be brief/terse", "fewer tokens", "shorter answers") — but not when
     // scoped to a single section ("be brief in the summary"), which is a
     // one-off instruction, not a session-wide mode switch.
-    if (!isQuestion) {
+    if (isCommandLike && !isQuestion) {
       if (/\b(activate|enable|start|turn on|use|switch to|want|give me)\b[^.]{0,40}\bcaveman\b/.test(prompt) ||
           /\btalk like\b[^.]{0,40}\bcaveman\b/.test(prompt) ||
           /\bcaveman\s+mode\s+(on|please|now)\b/.test(prompt) ||
@@ -155,7 +181,7 @@ function parseModeChange(promptRaw, options) {
   if (prompt.startsWith('/caveman')) {
     const parts = prompt.split(/\s+/);
     const cmd = parts[0]; // /caveman, /caveman-commit, /caveman-review, etc.
-    const arg = parts[1] || '';
+    const arg = stripArgPunctuation(parts[1]);
 
     if (cmd === '/caveman-commit' || cmd === '/caveman:caveman-commit') {
       return { action: 'set', mode: 'commit' };
@@ -175,8 +201,10 @@ function parseModeChange(promptRaw, options) {
       if (arg === 'off' || arg === 'stop' || arg === 'disable') return { action: 'clear' };
       if (arg === 'wenyan-full') return { action: 'set', mode: 'wenyan' }; // canonical alias — config stores as 'wenyan'
       if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) return { action: 'set', mode: arg };
-      // Unknown arg → no-op, flag untouched (no silent overwrite with default)
-      return null;
+      // Unknown arg → flag untouched (no silent overwrite with default), and
+      // reported rather than swallowed. Consumers that act only on
+      // 'set'/'clear' ignore this verdict, so it is additive.
+      return { action: 'unresolved' };
     }
   }
 

--- a/tests/test_caveman_parse.js
+++ b/tests/test_caveman_parse.js
@@ -66,12 +66,15 @@ test('wenyan-full alias stores as "wenyan"', () => {
   assert.deepStrictEqual(parseModeChange('/caveman wenyan-full', defaultFull), { action: 'set', mode: 'wenyan' });
 });
 
-test('bogus level returns null — never falls through to the default', () => {
-  assert.strictEqual(parseModeChange('/caveman not-a-real-level', defaultFull), null);
+test('bogus level is unresolved — never falls through to the default', () => {
+  // Contract change: was null, now a reported no-op. The danger this guards
+  // against is unchanged — a bogus level must never activate the default —
+  // but the tracker can now tell the user the level did not move.
+  assert.deepStrictEqual(parseModeChange('/caveman not-a-real-level', defaultFull), { action: 'unresolved' });
 });
 
 test('independent modes are not reachable via /caveman <arg>', () => {
-  assert.strictEqual(parseModeChange('/caveman commit', defaultFull), null);
+  assert.deepStrictEqual(parseModeChange('/caveman commit', defaultFull), { action: 'unresolved' });
 });
 
 test('/caveman-commit, /caveman-review, /caveman-compress set independent modes', () => {
@@ -178,10 +181,10 @@ test('expandedTpl: empty level (bare "/caveman", multi-line template head) uses 
   );
 });
 
-test('expandedTpl: bogus level in the template returns null, not the default (#602 drift)', () => {
-  assert.strictEqual(
+test('expandedTpl: bogus level in the template is unresolved, not the default (#602 drift)', () => {
+  assert.deepStrictEqual(
     parseModeChange('Activate caveman mode: not-a-real-level', { ...defaultFull, expandedTpl: true }),
-    null
+    { action: 'unresolved' }
   );
 });
 
@@ -231,14 +234,78 @@ function runTracker(prompt, presetFlag) {
   }
 }
 
+// ---------- punctuation glued to the mode ----------
+
+test('trailing semicolon does not defeat the mode match', () => {
+  assert.deepStrictEqual(
+    parseModeChange('/caveman ultra; still too verbose', defaultFull),
+    { action: 'set', mode: 'ultra' }
+  );
+});
+
+test('trailing period and comma do not defeat the mode match', () => {
+  assert.deepStrictEqual(parseModeChange('/caveman lite.', defaultFull), { action: 'set', mode: 'lite' });
+  assert.deepStrictEqual(parseModeChange('/caveman:caveman ultra,', defaultFull), { action: 'set', mode: 'ultra' });
+});
+
+test('punctuation-only difference still resolves off', () => {
+  assert.deepStrictEqual(parseModeChange('/caveman off.', defaultFull), { action: 'clear' });
+});
+
+test('unknown argument reports unresolved instead of returning null', () => {
+  assert.deepStrictEqual(parseModeChange('/caveman blorptastic', defaultFull), { action: 'unresolved' });
+});
+
+// ---------- phrase triggers must not fire on prose that quotes them ----------
+
+const HELP_CARD_EXCERPT =
+  '| **Ultra** | `/caveman ultra` | Extreme compression. Bare fragments. | ' +
+  'Mode stick until changed or session end. ## Deactivate ' +
+  'Say "stop caveman" or "normal mode". Resume anytime with `/caveman`.';
+
+test('help-card text does not deactivate', () => {
+  assert.strictEqual(parseModeChange(HELP_CARD_EXCERPT, defaultFull), null);
+});
+
+test('long prose quoting the deactivation phrases does not deactivate', () => {
+  const report =
+    'fix these bugs. bug 2, bigger - opening /caveman-help switched caveman off. ' +
+    'the card\'s own line "say stop caveman or normal mode" matched the deactivation ' +
+    'regex, which runs over the whole prompt.';
+  assert.strictEqual(parseModeChange(report, defaultFull), null);
+});
+
+test('long prose describing activation does not activate', () => {
+  const doc =
+    'the readme says users can turn on caveman mode by typing activate caveman, ' +
+    'and that phrasing is what the natural language matcher keys on. document that ' +
+    'in the contributing guide please.';
+  assert.strictEqual(parseModeChange(doc, defaultFull), null);
+});
+
+test('short deactivation and activation still fire (control)', () => {
+  assert.deepStrictEqual(parseModeChange('stop caveman', defaultFull), { action: 'clear' });
+  assert.deepStrictEqual(parseModeChange('activate caveman', defaultFull), { action: 'set', mode: 'full' });
+});
+
+test('/caveman off still works inside a long prompt', () => {
+  const long =
+    '/caveman off and then walk me through why the deactivation regex used to run ' +
+    'over the entire prompt body, including documentation text that quoted the ' +
+    'trigger phrases verbatim.';
+  assert.deepStrictEqual(parseModeChange(long, defaultFull), { action: 'clear' });
+});
+
 const parityCases = [
   { prompt: '/caveman ultra', preset: null },
   { prompt: '/caveman off', preset: 'full' },
   { prompt: '/caveman not-a-real-level', preset: 'ultra' },
+  { prompt: '/caveman ultra; still too verbose', preset: 'full' },
   { prompt: 'be brief', preset: null },
   { prompt: 'activate caveman', preset: null },
   { prompt: 'stop caveman', preset: 'full' },
   { prompt: 'what is caveman mode?', preset: null },
+  { prompt: HELP_CARD_EXCERPT, preset: 'full' },
 ];
 
 for (const { prompt, preset } of parityCases) {
@@ -247,6 +314,9 @@ for (const { prompt, preset } of parityCases) {
     const verdict = parseModeChange(normalized, { getDefaultMode: () => 'full' });
     const expected =
       verdict === null ? (preset || null) :
+      // 'unresolved' leaves the flag exactly where it was, same as null — it
+      // differs only in that the tracker now says so out loud.
+      verdict.action === 'unresolved' ? (preset || null) :
       verdict.action === 'clear' ? null :
       verdict.mode;
     assert.strictEqual(runTracker(prompt, preset), expected);

--- a/tests/test_mode_tracker.py
+++ b/tests/test_mode_tracker.py
@@ -227,6 +227,52 @@ class ModeTrackerTests(unittest.TestCase):
         self.send("stop caveman")
         self.assertIsNone(self.flag_value())
 
+    # ── the injected reminder must differ by level ──────────────────────
+
+    def test_reinforcement_differs_between_levels(self):
+        # Pre-fix: lite, full, ultra and all three wenyan variants injected the
+        # same sentence, so a mid-session switch changed the badge and nothing
+        # else.
+        self.flag.write_text("lite", encoding="utf-8")
+        lite = self.send("ordinary prompt").stdout
+        self.flag.write_text("ultra", encoding="utf-8")
+        ultra = self.send("ordinary prompt").stdout
+        self.assertIn("CAVEMAN MODE ACTIVE (lite)", lite)
+        self.assertIn("CAVEMAN MODE ACTIVE (ultra)", ultra)
+        self.assertIn("Keep articles", lite)
+        self.assertIn("Fragments only", ultra)
+
+    def test_level_switch_reemits_that_levels_rules(self):
+        self.flag.write_text("full", encoding="utf-8")
+        r = self.send("/caveman ultra")
+        self.assertEqual(self.flag_value(), "ultra")
+        self.assertIn("CAVEMAN LEVEL NOW ultra", r.stdout)
+        self.assertIn("Strip conjunctions", r.stdout)
+        self.assertNotIn("Professional but tight", r.stdout)
+
+    def test_ordinary_turn_does_not_reemit_rules(self):
+        # The ruleset costs ~1k tokens; it belongs on the switch turn only.
+        self.flag.write_text("ultra", encoding="utf-8")
+        r = self.send("ordinary prompt")
+        self.assertIn("CAVEMAN MODE ACTIVE (ultra)", r.stdout)
+        self.assertNotIn("CAVEMAN LEVEL NOW", r.stdout)
+
+    def test_reswitching_to_the_same_level_does_not_reemit(self):
+        self.flag.write_text("ultra", encoding="utf-8")
+        r = self.send("/caveman ultra")
+        self.assertNotIn("CAVEMAN LEVEL NOW", r.stdout)
+
+    def test_reinforcement_exempts_fixed_format_blocks(self):
+        self.flag.write_text("full", encoding="utf-8")
+        r = self.send("ordinary prompt")
+        self.assertIn("Verbatim, never compressed", r.stdout)
+        self.assertIn("fixed-format block", r.stdout)
+
+    def test_wenyan_reports_canonical_label(self):
+        self.flag.write_text("wenyan", encoding="utf-8")
+        r = self.send("ordinary prompt")
+        self.assertIn("CAVEMAN MODE ACTIVE (wenyan-full)", r.stdout)
+
     def test_deactivation_clears_saved_prev(self):
         self.flag.write_text("ultra", encoding="utf-8")
         self.send("/caveman-commit")

--- a/tests/test_mode_tracker.py
+++ b/tests/test_mode_tracker.py
@@ -182,6 +182,51 @@ class ModeTrackerTests(unittest.TestCase):
         r = self.send("/caveman-commit")
         self.assertNotIn("CAVEMAN MODE ACTIVE", r.stdout)
 
+    # ── unresolved /caveman argument is reported, not swallowed ─────────
+
+    def test_glued_punctuation_still_switches(self):
+        self.flag.write_text("full", encoding="utf-8")
+        self.send("/caveman ultra; this feature does not seem to be working")
+        self.assertEqual(self.flag_value(), "ultra")
+
+    def test_unresolved_arg_is_announced_without_echo(self):
+        self.flag.write_text("full", encoding="utf-8")
+        r = self.send("/caveman blorptastic")
+        self.assertEqual(self.flag_value(), "full", "level must not change")
+        self.assertIn("not recognized", r.stdout)
+        for mode in ("lite", "full", "ultra", "wenyan-lite", "wenyan-ultra"):
+            self.assertIn(mode, r.stdout, f"notice must name {mode}")
+        self.assertNotIn(
+            "blorptastic", r.stdout,
+            "untrusted argument must never be echoed into model context",
+        )
+
+    def test_unresolved_arg_notice_when_caveman_off(self):
+        r = self.send("/caveman blorptastic")
+        self.assertIsNone(self.flag_value())
+        self.assertIn("not recognized", r.stdout)
+        self.assertNotIn("blorptastic", r.stdout)
+
+    def test_help_card_body_does_not_deactivate(self):
+        # The card documents the deactivation phrases; quoting them is not
+        # issuing them. The envelope unwrap (#537) covers the slash path; this
+        # covers the body arriving as plain prose.
+        self.flag.write_text("full", encoding="utf-8")
+        self.send(
+            '| **Ultra** | `/caveman ultra` | Extreme compression. |\n\n'
+            '## Deactivate\n\n'
+            'Say "stop caveman" or "normal mode". Resume anytime with `/caveman`.\n\n'
+            "## Language\n\nKeep user's language by default."
+        )
+        self.assertEqual(self.flag_value(), "full")
+
+    def test_short_deactivation_still_works(self):
+        # Control for the case above: the same regexes still fire on a real
+        # command, so the silence there is the scoping and not the harness.
+        self.flag.write_text("ultra", encoding="utf-8")
+        self.send("stop caveman")
+        self.assertIsNone(self.flag_value())
+
     def test_deactivation_clears_saved_prev(self):
         self.flag.write_text("ultra", encoding="utf-8")
         self.send("/caveman-commit")


### PR DESCRIPTION
**Stacks on #838.** Rebased onto `c72984e`; the diff shows #838's commit too until it merges. Review the second commit only.

## Problem

Switching level mid-session moves the statusline badge and changes nothing about the output.

Two causes:

1. Every level injects the same per-turn line — `CAVEMAN MODE ACTIVE (<level>) — session ruleset applies.` Only the label differs, so `lite`, `full`, `ultra` and the three wenyan variants are indistinguishable to the model.
2. The level-specific ruleset is emitted only by the SessionStart hook, so only for whatever level the session opened at. `/caveman ultra` on turn 40 never re-emits ultra's rules.

Net effect: a user switches to ultra, sees the badge change, sees output stay the same, reports the feature as broken. That is exactly how this was found.

## Change

Per-level directive lines, drawn from the intensity table in `skills/caveman/SKILL.md`.

On a level CHANGE, re-emit that level's filtered rows once. Ordinary turns still cost one short line. The read is best-effort with the same candidate paths the SessionStart hook uses, and returns empty when no skills dir is present, so a standalone hook install never breaks on it.

## Also: the exemptions, restated per turn

The reminder now names what stays verbatim — code, commit messages, security warnings, error strings, and fixed-format blocks required by whatever else is instructing the model (protocol blocks, gates, checklists, audit blocks).

This is where caveman loses in practice. Another instruction set demands structured multi-line output, caveman demands compression, and the model resolves the clash by dropping one of them. They govern different things; a required block is a structured artifact like a code block, and the prose around it still compresses.

Wording is generic — no host-specific tooling named. Happy to drop this half if you would rather keep the reminder purely about prose.

## Tests

6 new cases in `tests/test_mode_tracker.py`: levels inject different text, a switch re-emits that level's row and no other level's, an ordinary turn does not re-emit, re-switching to the same level does not re-emit, the exemption clause is present, and `wenyan` reports its canonical `wenyan-full` label.

4 of the 6 fail against the parent commit. The 2 that pass are absence-assertions whose positive control is the re-emission test.

Suites green: 34 mode-tracker, 44 parse, 11 stdin.
