### PR TITLE
fix(opencode): strip bare model aliases

### DIFF
--- a/bin/lib/opencode-agent.js
+++ b/bin/lib/opencode-agent.js
@@ -1,7 +1,7 @@
 'use strict';
 
-// Strip the `tools:` field from a Claude-Code-style subagent frontmatter so
-// the file is valid for opencode, whose schema rejects the YAML array form
+// Strip Claude-Code-only fields from subagent frontmatter so the file is valid
+// for opencode, whose schema rejects the YAML array form
 // (`tools: [Read, Grep, Bash]`) with:
 //
 //   Configuration is invalid at .../agents/cavecrew-reviewer.md
@@ -12,8 +12,13 @@
 // which is what the cavecrew subagent prompts already self-restrict against
 // in their body ("Read-only locator", "No `Bash` available", etc.), so
 // dropping the array form is safe.
+//
+// Claude's bare model aliases (`haiku`, `sonnet`, `opus`) are also invalid in
+// opencode, which expects `provider/model-id`. Omitting them makes the subagent
+// inherit the invoking model while preserving qualified opencode model IDs.
 
 const TOOLS_FIELD_RE = /^tools[ \t]*:/;
+const CLAUDE_MODEL_ALIAS_RE = /^model[ \t]*:[ \t]*(?:haiku|sonnet|opus)[ \t]*$/;
 const CONTINUATION_RE = /^[ \t]/;
 const FRONTMATTER_FENCE = '---\n';
 
@@ -33,6 +38,7 @@ function stripOpencodeAgentTools(content) {
       dropping = false;
     }
     if (TOOLS_FIELD_RE.test(line)) { dropping = true; continue; }
+    if (CLAUDE_MODEL_ALIAS_RE.test(line)) continue;
     out.push(line);
   }
 

--- a/tests/installer/opencode-agent.test.mjs
+++ b/tests/installer/opencode-agent.test.mjs
@@ -6,9 +6,9 @@
 //   Configuration is invalid at .../cavecrew-reviewer.md
 //   ↳ Expected object | undefined, got ["Read","Grep","Bash"] tools
 //
-// Fix: strip the `tools:` field on copy. These tests prove the helper
-// strips the field, preserves every other frontmatter key and the body,
-// and handles both the inline array form and the multi-line YAML list form.
+// Fix: strip Claude-only fields on copy. These tests prove the helper strips
+// the fields, preserves opencode-compatible frontmatter and the body, and
+// handles both the inline array form and the multi-line YAML list form.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -46,7 +46,7 @@ body line two
   assert.doesNotMatch(fm, /^tools:/m, '`tools` field must be absent');
   assert.match(fm, /^name: test-agent$/m, '`name` preserved');
   assert.match(fm, /^description: short description$/m, '`description` preserved');
-  assert.match(fm, /^model: haiku$/m, '`model` preserved');
+  assert.doesNotMatch(fm, /^model:/m, 'bare Claude `model` alias must be absent');
   assert.match(out, /^body line one$/m, 'body preserved');
   assert.match(out, /^body line two$/m, 'body preserved');
 });
@@ -68,7 +68,7 @@ body
   assert.doesNotMatch(fm, /^tools:/m, '`tools` field must be absent');
   assert.doesNotMatch(fm, /^\s+- Read$/m, '`tools` list items must be absent');
   assert.match(fm, /^name: test-agent$/m, '`name` preserved');
-  assert.match(fm, /^model: haiku$/m, '`model` preserved');
+  assert.doesNotMatch(fm, /^model:/m, 'bare Claude `model` alias must be absent');
 });
 
 // ── Folded `description: >` block must NOT be eaten ──────────────────────
@@ -89,7 +89,31 @@ body
   assert.match(fm, /^description: >$/m, 'folded scalar header preserved');
   assert.match(fm, /Diff\/branch\/file reviewer/, 'folded scalar body preserved');
   assert.match(fm, /no scope creep/, 'second folded line preserved');
-  assert.match(fm, /^model: haiku$/m);
+  assert.doesNotMatch(fm, /^model:/m);
+});
+
+test('strips bare Claude model alias from frontmatter', () => {
+  const src = `---
+name: test-agent
+model \t: \thaiku \t
+---
+body
+`;
+  const out = stripOpencodeAgentTools(src);
+  const fm = frontmatter(out);
+  assert.doesNotMatch(fm, /^model[ \t]*:/m, '`model` field must be absent');
+  assert.match(fm, /^name: test-agent$/m, '`name` preserved');
+  assert.match(out, /^body$/m, 'body preserved');
+});
+
+test('preserves provider-qualified opencode model ID', () => {
+  const src = `---
+name: test-agent
+model: anthropic/claude-haiku-4-5
+---
+body
+`;
+  assert.equal(stripOpencodeAgentTools(src), src);
 });
 
 // ── No frontmatter: pass content through untouched ───────────────────────
@@ -98,11 +122,11 @@ test('returns input unchanged when no frontmatter fence', () => {
   assert.equal(stripOpencodeAgentTools(src), src);
 });
 
-// ── No `tools:` field: pass content through untouched ────────────────────
-test('returns input unchanged when frontmatter has no `tools:` field', () => {
+// ── No Claude-only fields: pass content through untouched ────────────────
+test('returns input unchanged when frontmatter has no Claude-only fields', () => {
   const src = `---
 name: x
-model: haiku
+model: anthropic/claude-haiku-4-5
 ---
 body
 `;
@@ -135,6 +159,7 @@ test('all shipped cavecrew agent files become opencode-safe after transform (GRE
     const fm = frontmatter(out);
 
     assert.doesNotMatch(fm, /^tools:/m, `${f}: tools field still present after transform`);
+    assert.doesNotMatch(fm, /^model[ \t]*:[ \t]*(?:haiku|sonnet|opus)[ \t]*$/m, `${f}: bare Claude model alias still present after transform`);
     assert.match(fm, /^name: cavecrew-/m, `${f}: name field preserved`);
     assert.match(fm, /^description:/m, `${f}: description field preserved`);
 
@@ -161,6 +186,7 @@ test('installer-equivalent copy writes opencode-safe agent file (issue 386 end-t
       const fm = frontmatter(installed);
       assert.doesNotMatch(fm, /^tools:\s*\[/m, `${f}: array form survived in installed file`);
       assert.doesNotMatch(fm, /^tools:/m, `${f}: tools field survived in installed file`);
+      assert.doesNotMatch(fm, /^model[ \t]*:[ \t]*(?:haiku|sonnet|opus)[ \t]*$/m, `${f}: bare Claude model alias survived in installed file`);
     }
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Symptom

OpenCode 1.18.18 parses cavecrew agents with `model: haiku` as provider `haiku` plus an empty model ID, then fails at runtime with `Model not found: haiku/`.

## Cause

The OpenCode installer transform strips Claude-style `tools:` frontmatter but leaves Claude-only bare model aliases. OpenCode model references require `provider/model-id`.

## Fix

Strip exact bare Claude aliases (`haiku`, `sonnet`, `opus`) while copying agent frontmatter for OpenCode. With `model` omitted, subagents inherit the invoking primary model. Slash-qualified IDs such as `anthropic/claude-haiku-4-5` remain byte-identical.

## Tests

- `node --test tests/installer/opencode-agent.test.mjs` (11 passed)
- `pnpm test` (158 passed)
- `pnpm test:windows` (passed: CLI/agent builds, 35 Node tests passed + 1 platform skip, Go Windows amd64/arm64 compile)