### PR TITLE
fix(install): install Cursor skills globally

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -210,6 +210,8 @@ function checkNodeVersion() {
 // install when the user passes `--only <id>`. This stops the installer from
 // firing `npx skills add ...` against agents the user has never installed
 // just because some other tool created `~/.foo` along the way.
+const CURSOR_GLOBAL_SKILLS_DIR = ['.cursor', 'skills'];
+const GLOBAL_SKILLS_FLAG = '-g';
 const PROVIDERS = [
   { id: 'claude',     label: 'Claude Code',         mech: 'claude plugin install',         detect: 'command:claude' },
   { id: 'gemini',     label: 'Gemini CLI',          mech: 'gemini extensions install',     detect: 'command:gemini' },
@@ -220,7 +222,7 @@ const PROVIDERS = [
   // IDE / VS Code-family — extension probes are precise. Cursor/Windsurf also
   // ship CLI binaries; we drop the dir fallback because the dir lingers after
   // uninstall and false-positives heavily.
-  { id: 'cursor',     label: 'Cursor',              mech: 'npx skills add (cursor)',       detect: 'command:cursor||macapp:Cursor', profile: 'cursor' },
+  { id: 'cursor',     label: 'Cursor',              mech: 'npx skills add (cursor)',       detect: 'command:cursor||macapp:Cursor', profile: 'cursor', globalSkillsDir: CURSOR_GLOBAL_SKILLS_DIR },
   { id: 'windsurf',   label: 'Windsurf',            mech: 'npx skills add (windsurf)',     detect: 'command:windsurf||macapp:Windsurf', profile: 'windsurf' },
   { id: 'cline',      label: 'Cline',               mech: 'npx skills add (cline)',        detect: 'vscode-ext:cline',        profile: 'cline' },
   { id: 'continue',   label: 'Continue',            mech: 'npx skills add (continue)',     detect: 'vscode-ext:continue.continue||vscode-ext:continue', profile: 'continue' },
@@ -568,7 +570,7 @@ function installGemini(ctx) {
 }
 
 function installViaSkills(ctx, prov) {
-  const { say, opts, results } = ctx;
+  const { say, note, warn, opts, results } = ctx;
   results.detected++;
   say(`→ ${prov.label} detected`);
   // --skill '*' --yes: skip the upstream skill-selection TUI and confirmation
@@ -582,6 +584,22 @@ function installViaSkills(ctx, prov) {
   // every agent adapter (see issue #389). `--skill '*' -a <agent>` is the
   // documented form for "install every skill into a specific agent".
   const args = ['-y', 'skills', 'add', REPO, '--skill', '*', '-a', prov.profile, '--yes'];
+  if (prov.globalSkillsDir) {
+    const globalSkillsDir = path.join(os.homedir(), ...prov.globalSkillsDir);
+    if (opts.dryRun) {
+      note(`  would mkdir -p ${globalSkillsDir}`);
+    } else {
+      try {
+        fs.mkdirSync(globalSkillsDir, { recursive: true });
+      } catch (error) {
+        warn(`  failed to create ${globalSkillsDir}: ${error.message}`);
+        results.failed.push([prov.id, 'global skills directory creation failed']);
+        process.stdout.write('\n');
+        return;
+      }
+    }
+    args.push(GLOBAL_SKILLS_FLAG);
+  }
   const r = runSpawn('npx', args, null, opts.dryRun);
   if (spawnOk(r)) results.installed.push(prov.id);
   else results.failed.push([prov.id, `npx skills add (${prov.profile}) failed`]);

--- a/tests/installer/cursor-global-install.test.mjs
+++ b/tests/installer/cursor-global-install.test.mjs
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const INSTALLER = path.resolve(HERE, '..', '..', 'bin', 'install.js');
+const TEST_PREFIX = 'caveman-cursor-global-';
+const FAKE_BIN_DIR = 'bin';
+const FAKE_NPX = 'npx';
+const ARGS_LOG = 'npx-args.json';
+const CURSOR_SKILLS_PATH = path.join('.cursor', 'skills');
+const GLOBAL_FLAG = '-g';
+
+test('Cursor installs skills globally into its user skills directory', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), TEST_PREFIX));
+  const home = path.join(root, 'home');
+  const binDir = path.join(root, FAKE_BIN_DIR);
+  const argsLog = path.join(root, ARGS_LOG);
+  fs.mkdirSync(binDir, { recursive: true });
+
+  const fakeNpx = path.join(binDir, FAKE_NPX);
+  fs.writeFileSync(fakeNpx, `#!/bin/sh\nprintf '%s\\n' "$@" | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>require('fs').writeFileSync(process.env.ARGS_LOG,JSON.stringify(d.trim().split('\\n'))))"\n`);
+  fs.chmodSync(fakeNpx, 0o755);
+
+  try {
+    const result = spawnSync(process.execPath, [INSTALLER, '--only', 'cursor', '--non-interactive'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH || ''}`,
+        ARGS_LOG: argsLog,
+        NO_COLOR: '1',
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.ok(fs.existsSync(path.join(home, CURSOR_SKILLS_PATH)));
+    assert.ok(JSON.parse(fs.readFileSync(argsLog, 'utf8')).includes(GLOBAL_FLAG));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Create Cursor's global skills directory before invoking the skills CLI, then install with -g so Cursor can discover the installed skills.

## Test verification (RED → GREEN)

With the fix reverted, the new test fails (RED):

```
TAP version 13
# Subtest: Cursor installs skills globally into its user skills directory
not ok 1 - Cursor installs skills globally into its user skills directory
  ---
  duration_ms: 193.510563
  type: 'test'
  location: '/home/ousama/www/public/ousamabenyounes/caveman/tests/installer/cursor-global-install.test.mjs:18:1'
  failureType: 'testCodeFailure'
  error: |-
    The expression evaluated to a falsy value:
    
      assert.ok(fs.existsSync(path.join(home, CURSOR_SKILLS_PATH)))
    
  code: 'ERR_ASSERTION'
  name: 'AssertionError'
  expected: true
  actual: false
  operator: '=='
  stack: |-
    TestContext.<anonymous> (file:///home/ousama/www/public/ousamabenyounes/caveman/tests/installer/cursor-global-install.test.mjs:43:12)
    Test.runInAsyncScope (node:async_hooks:214:14)
    Test.run (node:internal/test_runner/test:1047:25)
    Test.start (node:internal/test_runner/test:944:17)
    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
  ...
1..1
# tests 1
# suites 0
# pass 0
# fail 1
# cancelled 0
# skipped 0
# todo 0
# duration_ms 296.525909
```

With the fix applied, the test passes (GREEN):

```
TAP version 13
# Subtest: Cursor installs skills globally into its user skills directory
ok 1 - Cursor installs skills globally into its user skills directory
  ---
  duration_ms: 180.791918
  type: 'test'
  ...
1..1
# tests 1
# suites 0
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 270.716245
```

## Full local suite

Command: `npm test && node --test tests/*.js && python3 -m unittest discover -s tests -p 'test_*.py' && (cd mem/py && python3 -m pytest -q tests) && python3 tests/verify_repo.py`

```
Processing: /tmp/tmp45kyw0ca/task.md
Compressing with Claude...

Validation attempt 1
Validation passed
Processing: /tmp/tmpgtycqtl8/task.md
Compressing with Claude...
❌ Compression aborted: Claude returned an empty response.
   Original file is untouched (no backup created).
.....                                                                    [100%]
5 passed in 0.05s

== License Boundaries ==
9 BSL directories carry canonical license; MIT installer boundary preserved

== Skill Frontmatter Upload Compatibility ==
Skill frontmatter descriptions avoid XML-like tags

== Synced Files ==
Synced copies, caveman.skill zip, and installer entrypoints OK

== Manifests And Syntax ==
JSON manifests and available script syntax OK

== Package Contents ==
Launch tarball contains 153 files with no Python cache artifacts

== PowerShell Static Checks ==
Windows install path statically wired

== Compress Fixtures ==
Validated 5 caveman-compress fixture pairs

== Compress CLI ==
Compress CLI skip/error paths OK

== Claude Hook Flow ==
Claude hook install/uninstall flow OK

All local verification checks passed
```

Fix #836
