### PR TITLE
feat(evals): make the prompt set language-selectable, add French

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -58,6 +58,35 @@ CAVEMAN_EVAL_MODEL=claude-haiku-4-5 uv run python evals/llm_run.py
 uv run --with tiktoken python evals/measure.py
 ```
 
+## Other languages
+
+The prompt set defaults to English. `CAVEMAN_EVAL_LANG` selects another one:
+
+```bash
+CAVEMAN_EVAL_LANG=fr uv run python evals/llm_run.py
+CAVEMAN_EVAL_LANG=fr uv run --with tiktoken python evals/measure.py
+```
+
+It reads `prompts/<lang>.txt` and writes `snapshots/results.<lang>.json`, so
+per-language snapshots never overwrite each other. `en` keeps the original
+`snapshots/results.json` path, so existing invocations are unchanged.
+
+The `__terse__` control arm is written in the prompt set's language
+(`TERSE_PREFIX_BY_LANG` in `llm_run.py`). This matters: an English
+"Answer concisely." in front of a French prompt measures a language switch on
+top of terseness, which is not the control the harness is trying to isolate.
+A language with no entry falls back to the English prefix — add one when you
+add a prompt set.
+
+`prompts/fr.txt` mirrors `prompts/en.txt` line for line, same ten topics in the
+same order, so the two sets are comparable arm by arm.
+
+## Adding a language
+
+1. Write `prompts/<lang>.txt`, ideally mirroring `en.txt` line for line.
+2. Add the language's terse instruction to `TERSE_PREFIX_BY_LANG`.
+3. Refresh with `CAVEMAN_EVAL_LANG=<lang> uv run python evals/llm_run.py`.
+
 ## Adding a prompt
 
 Append a line to `prompts/en.txt`, then refresh the snapshot.

--- a/evals/llm_run.py
+++ b/evals/llm_run.py
@@ -34,10 +34,25 @@ from pathlib import Path
 
 EVALS = Path(__file__).parent
 SKILLS = EVALS.parent / "skills"
-PROMPTS = EVALS / "prompts" / "en.txt"
-SNAPSHOT = EVALS / "snapshots" / "results.json"
 
-TERSE_PREFIX = "Answer concisely."
+# Language of the prompt set. Defaults to "en" so existing invocations and the
+# committed snapshot path are unchanged. Any other value reads
+# prompts/<lang>.txt and writes snapshots/results.<lang>.json, so per-language
+# snapshots never overwrite each other.
+LANG = os.environ.get("CAVEMAN_EVAL_LANG", "en")
+PROMPTS = EVALS / "prompts" / f"{LANG}.txt"
+SNAPSHOT = EVALS / "snapshots" / (
+    "results.json" if LANG == "en" else f"results.{LANG}.json"
+)
+
+# The terse control arm has to be written in the prompt set's language. An
+# English "Answer concisely." in front of a French prompt set measures a
+# language switch on top of terseness, which is not the control we want.
+TERSE_PREFIX_BY_LANG = {
+    "en": "Answer concisely.",
+    "fr": "Réponds de façon concise.",
+}
+TERSE_PREFIX = TERSE_PREFIX_BY_LANG.get(LANG, TERSE_PREFIX_BY_LANG["en"])
 
 
 def run_claude(prompt: str, system: str | None = None) -> str:
@@ -62,7 +77,13 @@ def claude_version() -> str:
 
 
 def main() -> None:
-    prompts = [p.strip() for p in PROMPTS.read_text().splitlines() if p.strip()]
+    if not PROMPTS.exists():
+        available = sorted(p.stem for p in (EVALS / "prompts").glob("*.txt"))
+        raise SystemExit(
+            f"No prompt set at {PROMPTS}. "
+            f"CAVEMAN_EVAL_LANG={LANG!r}; available: {', '.join(available)}"
+        )
+    prompts = [p.strip() for p in PROMPTS.read_text(encoding="utf-8").splitlines() if p.strip()]
     skills = sorted(p.name for p in SKILLS.iterdir() if (p / "SKILL.md").exists())
 
     print(
@@ -76,6 +97,7 @@ def main() -> None:
             "claude_cli_version": claude_version(),
             "model": os.environ.get("CAVEMAN_EVAL_MODEL", "default"),
             "n_prompts": len(prompts),
+            "lang": LANG,
             "terse_prefix": TERSE_PREFIX,
         },
         "prompts": prompts,

--- a/evals/measure.py
+++ b/evals/measure.py
@@ -17,13 +17,17 @@ Run: uv run --with tiktoken python evals/measure.py
 from __future__ import annotations
 
 import json
+import os
 import statistics
 from pathlib import Path
 
 import tiktoken
 
 ENCODING = tiktoken.get_encoding("o200k_base")
-SNAPSHOT = Path(__file__).parent / "snapshots" / "results.json"
+LANG = os.environ.get("CAVEMAN_EVAL_LANG", "en")
+SNAPSHOT = Path(__file__).parent / "snapshots" / (
+    "results.json" if LANG == "en" else f"results.{LANG}.json"
+)
 
 
 def count(text: str) -> int:

--- a/evals/prompts/fr.txt
+++ b/evals/prompts/fr.txt
@@ -1,0 +1,10 @@
+Pourquoi mon composant React se re-rend à chaque mise à jour du parent ?
+Explique le pooling de connexions à une base de données.
+Quelle est la différence entre TCP et UDP ?
+Comment corriger une fuite mémoire dans un processus Node.js de longue durée ?
+Que m'apprend la commande SQL EXPLAIN ?
+Comment une table de hachage gère-t-elle les collisions ?
+Pourquoi j'obtiens des erreurs CORS dans la console du navigateur ?
+À quoi sert un debouncer sur un champ de recherche ?
+En quoi git rebase diffère-t-il de git merge ?
+Quand utiliser une file plutôt qu'un topic dans un système de messagerie ?


### PR DESCRIPTION
## What this changes

`evals/llm_run.py` hardcoded `PROMPTS = EVALS / "prompts" / "en.txt"`. Every
published compression number therefore describes English, and nothing in the
repo measures caveman on another language — despite the README's "Speak your
tongue" claim and four open issues about non-English behaviour (#679, #680,
#701, #812).

- `CAVEMAN_EVAL_LANG` selects the prompt set. Defaults to `en` and keeps the
  existing `snapshots/results.json` path, so current invocations and the
  committed snapshot are untouched. Other languages write
  `snapshots/results.<lang>.json`.
- The `__terse__` control arm is now per-language. An English "Answer
  concisely." in front of a French prompt measures a language switch on top of
  terseness, which is not the control the harness isolates.
- `evals/prompts/fr.txt` mirrors `en.txt` line for line — same ten topics, same
  order — so the sets are comparable arm by arm.
- A missing prompt set now fails with the available languages listed rather than
  a bare `FileNotFoundError`.

I did **not** add French examples to `SKILL.md`. Per #812 the named-language
few-shot examples were themselves the attractor tokens driving language drift,
and `710173f` removed them. Adding French ones back would reintroduce that class
of bug for every user, which is why this PR is measurement only.

## Why: a French measurement that the English harness cannot see

Ten French prompts, one independent `claude -p` call each, three arms, plugin at
`766dce6`. Metric is the share of articles (`le/la/les/un/une/des/du`) in prose,
fenced and inline code removed — the most visible marker of French compression.

| Arm | Words | Article rate |
|---|---|---|
| `__baseline__` (`--safe-mode`) | 4478 | 11.84% |
| `__terse__` ("Réponds de façon concise.") | 2443 | 10.32% |
| caveman + a French rule block in user `CLAUDE.md` | 2748 | 5.75% |

Two things the English harness would not surface:

1. **Generic terseness barely touches French style.** `__terse__` cuts words
   45.4% but moves the article rate only −1.52 pt. Ordinary French prose sits
   around 12%. Shortening and compressing are separable in French in a way the
   token-count metric alone cannot show.
2. **On volume, caveman loses to the one-line control.** `__terse__` is −45.4%
   words against baseline; the caveman arm is −38.6%. That is +12.5% words for
   the same questions. This is consistent with `docs/HONEST-NUMBERS.md` and is
   the kind of workload that page invites people to report.

## What is not included

No `snapshots/results.fr.json`. On current `main` that is 10 prompts × (20
skills + 2 control arms) = 220 calls, and you regenerate snapshots as a
reviewable diff anyway. I did verify the write path end to end with `run_claude`
stubbed: `lang: "fr"` and the French `terse_prefix` land in the metadata, all 22
arms are populated, the file goes to `results.fr.json`, and `results.json` is
untouched. Happy to generate the real snapshot if you would rather the PR carry
it.

Environment: Windows 10, Claude Code 2.1.232, plugin `766dce6`, model Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Testing

- `python -m unittest discover -s tests` on this branch: 67 tests, 2 failures,
  1 skipped. The same two — `test_install_reconfigures_missing_statusline` and
  `test_install_upgrades_old_two_file_install` in `tests/test_hooks.py` — fail
  identically on clean `main` on this machine, so they are pre-existing and
  Windows-specific, not introduced here. No new failures.
- Write path exercised end to end with `run_claude` stubbed, for `en` (default)
  and `fr`: correct prompt file, correct snapshot file, correct per-language
  terse prefix, 22 arms populated, `results.json` untouched by the `fr` run.
- `evals/measure.py` still reads the committed English snapshot unchanged.
- A missing language now exits with `No prompt set at …; CAVEMAN_EVAL_LANG='de';
  available: en, fr` instead of a traceback.

Platform note: Windows 10, so the two installer failures above may not reproduce
for you.
