### PR TITLE
engine: unwrap agent <file> wrappers before content detection

### DIFF
--- a/engine/detect.go
+++ b/engine/detect.go
@@ -41,12 +41,9 @@ var (
 // fail-open: anything it is not confident about is "text", which routes to a
 // conservative compressor. The order is strict-JSON, diff, code, log, search.
 func (e *Engine) Detect(input []byte) string {
-	// A read tool's line-number gutter is presentation, not content: it wraps
-	// JSON, source, logs and CSV alike, and every signal below reads the first
-	// bytes of a line. Classify what the file IS, not how the agent printed it.
-	if source, _, ok := compressors.SplitLineNumberedListing(input); ok {
-		input = source
-	}
+	// Agent file tags and read-tool line-number gutters are presentation, not
+	// content. Classify what the file is, not how the agent printed it.
+	input, _ = unwrapInput(input)
 	trimmed := bytes.TrimSpace(input)
 	if len(trimmed) == 0 {
 		return TypeText

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -67,6 +67,7 @@ func defaultRegistry(counter tokens.Counter) *compressors.Registry {
 // passes the original bytes through unchanged (no handle, zero ratio).
 func (e *Engine) Compress(input []byte, opts Options) (Result, error) {
 	body, listing := unwrapListing(input)
+	body, wrapper := unwrapFileWrapper(body)
 	ct := opts.Type
 	if ct == "" {
 		ct = e.Detect(body)
@@ -106,6 +107,7 @@ func (e *Engine) Compress(input []byte, opts Options) (Result, error) {
 		return res, nil // parse problem → pass-through
 	}
 	out = listing.rewrap(out)
+	out = wrapper.rewrap(out)
 	after := e.counter.Count(out)
 	if after >= before || bytes.Equal(out, input) {
 		return res, nil // not actually smaller → pass-through, claim nothing
@@ -152,6 +154,7 @@ func (e *Engine) Compress(input []byte, opts Options) (Result, error) {
 // SafetyClass/Recoverable; the number is a token count of compressor output.
 func (e *Engine) Simulate(input []byte, opts Options) SimResult {
 	body, listing := unwrapListing(input)
+	body, wrapper := unwrapFileWrapper(body)
 	ct := opts.Type
 	if ct == "" {
 		ct = e.Detect(body)
@@ -182,6 +185,7 @@ func (e *Engine) Simulate(input []byte, opts Options) SimResult {
 		return res // parse problem → pass-through
 	}
 	out = listing.rewrap(out)
+	out = wrapper.rewrap(out)
 	after := e.counter.Count(out)
 	if after >= before || bytes.Equal(out, input) {
 		return res // not actually smaller → claim nothing

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -66,8 +66,7 @@ func defaultRegistry(counter tokens.Counter) *compressors.Registry {
 // result is not smaller, or when a lossy result cannot be made recoverable, it
 // passes the original bytes through unchanged (no handle, zero ratio).
 func (e *Engine) Compress(input []byte, opts Options) (Result, error) {
-	body, listing := unwrapListing(input)
-	body, wrapper := unwrapFileWrapper(body)
+	body, wrappers := unwrapInput(input)
 	ct := opts.Type
 	if ct == "" {
 		ct = e.Detect(body)
@@ -106,8 +105,7 @@ func (e *Engine) Compress(input []byte, opts Options) (Result, error) {
 	if !ok || out == nil {
 		return res, nil // parse problem → pass-through
 	}
-	out = listing.rewrap(out)
-	out = wrapper.rewrap(out)
+	out = wrappers.rewrap(out)
 	after := e.counter.Count(out)
 	if after >= before || bytes.Equal(out, input) {
 		return res, nil // not actually smaller → pass-through, claim nothing
@@ -153,8 +151,7 @@ func (e *Engine) Compress(input []byte, opts Options) (Result, error) {
 // before the transform can be emitted. The caller buckets by
 // SafetyClass/Recoverable; the number is a token count of compressor output.
 func (e *Engine) Simulate(input []byte, opts Options) SimResult {
-	body, listing := unwrapListing(input)
-	body, wrapper := unwrapFileWrapper(body)
+	body, wrappers := unwrapInput(input)
 	ct := opts.Type
 	if ct == "" {
 		ct = e.Detect(body)
@@ -184,8 +181,7 @@ func (e *Engine) Simulate(input []byte, opts Options) SimResult {
 	if !ok || out == nil {
 		return res // parse problem → pass-through
 	}
-	out = listing.rewrap(out)
-	out = wrapper.rewrap(out)
+	out = wrappers.rewrap(out)
 	after := e.counter.Count(out)
 	if after >= before || bytes.Equal(out, input) {
 		return res // not actually smaller → claim nothing

--- a/engine/filewrap.go
+++ b/engine/filewrap.go
@@ -1,6 +1,9 @@
 package engine
 
-import "bytes"
+import (
+	"bytes"
+	"unicode"
+)
 
 // Coding agents wrap file references handed to the model: pi turns a @file
 // argument into `<file name="...">…</file>`, and other agents use the same
@@ -26,7 +29,10 @@ type fileWrapper struct {
 // contain non-whitespace content. Anything else returns the input unchanged and
 // a no-op wrapper, so callers need no branches.
 func unwrapFileWrapper(input []byte) ([]byte, fileWrapper) {
-	trimmed := bytes.TrimSpace(input)
+	leftTrimmed := bytes.TrimLeftFunc(input, unicode.IsSpace)
+	start := len(input) - len(leftTrimmed)
+	end := len(bytes.TrimRightFunc(input, unicode.IsSpace))
+	trimmed := input[start:end]
 	if len(trimmed) < 9 {
 		return input, fileWrapper{}
 	}
@@ -47,15 +53,42 @@ func unwrapFileWrapper(input []byte) ([]byte, fileWrapper) {
 	if bytes.Count(trimmed, []byte("<file")) != 1 || bytes.Count(trimmed, []byte("</file>")) != 1 {
 		return input, fileWrapper{}
 	}
-	openEnd := bytes.Index(trimmed, []byte(">"))
+	openEnd := fileOpeningTagEnd(trimmed)
 	if openEnd < 0 {
 		return input, fileWrapper{}
 	}
-	inner := trimmed[openEnd+1 : len(trimmed)-len("</file>")]
+	closeStart := len(trimmed) - len("</file>")
+	inner := trimmed[openEnd+1 : closeStart]
 	if len(bytes.TrimSpace(inner)) == 0 {
 		return input, fileWrapper{}
 	}
-	return inner, fileWrapper{prefix: trimmed[:openEnd+1], suffix: []byte("</file>"), present: true}
+	return inner, fileWrapper{
+		prefix:  input[:start+openEnd+1],
+		suffix:  input[start+closeStart:],
+		present: true,
+	}
+}
+
+// fileOpeningTagEnd finds the closing angle bracket without mistaking one in
+// a quoted attribute value for the end of the tag. An unterminated quote makes
+// the wrapper invalid and leaves the original untouched.
+func fileOpeningTagEnd(input []byte) int {
+	var quote byte
+	for i := len("<file"); i < len(input); i++ {
+		switch input[i] {
+		case '\'', '"':
+			if quote == 0 {
+				quote = input[i]
+			} else if quote == input[i] {
+				quote = 0
+			}
+		case '>':
+			if quote == 0 {
+				return i
+			}
+		}
+	}
+	return -1
 }
 
 // rewrap puts the wrapper back on compressed output so the model still sees the
@@ -70,4 +103,39 @@ func (w fileWrapper) rewrap(out []byte) []byte {
 	b.Write(out)
 	b.Write(w.suffix)
 	return b.Bytes()
+}
+
+type inputWrapper interface {
+	rewrap([]byte) []byte
+}
+
+type inputWrappers []inputWrapper
+
+// unwrapInput removes supported presentation wrappers in outer-to-inner order.
+// Four layers cover known agent compositions while bounding repeated scans of
+// attacker-controlled input. rewrap applies them in reverse order.
+func unwrapInput(input []byte) ([]byte, inputWrappers) {
+	body := input
+	wrappers := make(inputWrappers, 0, 2)
+	for range 4 {
+		if inner, wrapper := unwrapListing(body); wrapper.present {
+			body = inner
+			wrappers = append(wrappers, wrapper)
+			continue
+		}
+		if inner, wrapper := unwrapFileWrapper(body); wrapper.present {
+			body = inner
+			wrappers = append(wrappers, wrapper)
+			continue
+		}
+		break
+	}
+	return body, wrappers
+}
+
+func (w inputWrappers) rewrap(out []byte) []byte {
+	for i := len(w) - 1; i >= 0; i-- {
+		out = w[i].rewrap(out)
+	}
+	return out
 }

--- a/engine/filewrap.go
+++ b/engine/filewrap.go
@@ -1,0 +1,73 @@
+package engine
+
+import "bytes"
+
+// Coding agents wrap file references handed to the model: pi turns a @file
+// argument into `<file name="...">…</file>`, and other agents use the same
+// single-element wrapper convention. That wrapper is presentation, not content —
+// the same way a read tool's line-number gutter is (see listing.go). Left in
+// place it defeats Detect on the way in: the payload no longer starts with its
+// real first bytes, so source never parses and JSON never validates; both fall
+// through to `text` and compress nothing.
+//
+// Unwrapping belongs here rather than inside a compressor, for the same reason
+// the listing gutter lives here: the wrapper is orthogonal to content type, and
+// each compressor has to be routed on what the content actually is.
+type fileWrapper struct {
+	prefix  []byte
+	suffix  []byte
+	present bool
+}
+
+// unwrapFileWrapper separates a single whole-content `<file …>…</file>` wrapper
+// from the content it decorates. It is deliberately conservative: it requires
+// the wrapper to be the outermost element, to open with the literal `<file` tag
+// (attributes allowed), to close with exactly one `</file>` at the end, and to
+// contain non-whitespace content. Anything else returns the input unchanged and
+// a no-op wrapper, so callers need no branches.
+func unwrapFileWrapper(input []byte) ([]byte, fileWrapper) {
+	trimmed := bytes.TrimSpace(input)
+	if len(trimmed) < 9 {
+		return input, fileWrapper{}
+	}
+	if !bytes.HasPrefix(trimmed, []byte("<file")) {
+		return input, fileWrapper{}
+	}
+	switch trimmed[5] {
+	case ' ', '\t', '>':
+	default:
+		return input, fileWrapper{}
+	}
+	if !bytes.HasSuffix(trimmed, []byte("</file>")) {
+		return input, fileWrapper{}
+	}
+	// Exactly one opening and one closing tag: a stray "<file" inside a string
+	// literal or a nested element means this is not a plain wrapper, and the
+	// original bytes win.
+	if bytes.Count(trimmed, []byte("<file")) != 1 || bytes.Count(trimmed, []byte("</file>")) != 1 {
+		return input, fileWrapper{}
+	}
+	openEnd := bytes.Index(trimmed, []byte(">"))
+	if openEnd < 0 {
+		return input, fileWrapper{}
+	}
+	inner := trimmed[openEnd+1 : len(trimmed)-len("</file>")]
+	if len(bytes.TrimSpace(inner)) == 0 {
+		return input, fileWrapper{}
+	}
+	return inner, fileWrapper{prefix: trimmed[:openEnd+1], suffix: []byte("</file>"), present: true}
+}
+
+// rewrap puts the wrapper back on compressed output so the model still sees the
+// file reference the agent supplied, now wrapping the compressed bytes.
+func (w fileWrapper) rewrap(out []byte) []byte {
+	if !w.present {
+		return out
+	}
+	var b bytes.Buffer
+	b.Grow(len(w.prefix) + len(out) + len(w.suffix))
+	b.Write(w.prefix)
+	b.Write(out)
+	b.Write(w.suffix)
+	return b.Bytes()
+}

--- a/engine/filewrap_test.go
+++ b/engine/filewrap_test.go
@@ -1,0 +1,97 @@
+package engine
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/JuliusBrussee/caveman/engine/ccr"
+)
+
+func TestUnwrapFileWrapper(t *testing.T) {
+	goSrc := []byte("package main\n\nfunc add(a, b int) int {\n\treturn a + b\n}\n")
+	wrapped := []byte(`<file name="C:\x\main.go">` + "\n" + string(goSrc) + "\n</file>\n")
+
+	inner, w := unwrapFileWrapper(wrapped)
+	if !w.present {
+		t.Fatal("wrapper not detected")
+	}
+	if !bytes.Equal(bytes.TrimSpace(inner), bytes.TrimSpace(goSrc)) {
+		t.Fatalf("inner mismatch:\n%s", inner)
+	}
+	rewrapped := w.rewrap([]byte("compressed"))
+	if !bytes.HasPrefix(rewrapped, []byte(`<file name="C:\x\main.go">`)) || !bytes.HasSuffix(rewrapped, []byte("</file>")) {
+		t.Fatalf("rewrap lost wrapper: %q", rewrapped)
+	}
+
+	// Non-wrapper inputs must pass through untouched.
+	for _, in := range [][]byte{
+		[]byte("plain text"),
+		[]byte("package main\nfunc f() {}\n"),
+		[]byte(`<html><body>x</body></html>`),
+		[]byte(`<file>` + "\n" + string(goSrc) + "\n</file>\n<file>second</file>"),
+		[]byte(`<file name="a">`),
+		[]byte(`</file>`),
+		[]byte(`<files>x</files>`),
+	} {
+		got, ww := unwrapFileWrapper(in)
+		if ww.present {
+			t.Fatalf("false positive wrapper on %q", in)
+		}
+		if !bytes.Equal(got, in) {
+			t.Fatalf("no-op path changed bytes: %q", in)
+		}
+	}
+}
+
+func TestCompressFileWrappedGo(t *testing.T) {
+	store, err := ccr.OpenMemory()
+	if err != nil {
+		t.Fatalf("memory store: %v", err)
+	}
+	defer store.Close()
+	eng := New(store, nil)
+	input := []byte(`<file name="main.go">
+package main
+
+import "fmt"
+
+func handler000(w *Widget) string {
+	body := fmt.Sprintf("widget %s costs %.2f", w.Name, w.Price)
+	if w.Price > 100.0 {
+		body += " (expensive)"
+	}
+	return fmt.Sprintf("000: %s", body)
+}
+
+func handler001(w *Widget) string {
+	body := fmt.Sprintf("widget %s costs %.2f", w.Name, w.Price)
+	if w.Price > 100.0 {
+		body += " (expensive)"
+	}
+	return fmt.Sprintf("001: %s", body)
+}
+</file>`)
+	res, err := eng.Compress(input, Options{Mode: ModeCompress})
+	if err != nil {
+		t.Fatalf("compress: %v", err)
+	}
+	if res.TokensAfter >= res.TokensBefore {
+		t.Fatalf("wrapped Go did not compress: before=%d after=%d", res.TokensBefore, res.TokensAfter)
+	}
+	if !bytes.HasPrefix(res.Output, []byte("<file")) || !bytes.HasSuffix(res.Output, []byte("</file>")) {
+		t.Fatalf("compressed output lost wrapper: %q", res.Output[:60])
+	}
+	if !bytes.Contains(res.Output, []byte("func handler000")) || !bytes.Contains(res.Output, []byte("func handler001")) {
+		t.Fatalf("compressed output lost signatures: %q", res.Output)
+	}
+	if res.RecoveryHandle == "" {
+		t.Fatal("no recovery handle minted")
+	}
+	got, err := eng.Retrieve(res.RecoveryHandle)
+	if err != nil {
+		t.Fatalf("retrieve: %v", err)
+	}
+	if !bytes.Equal(got, input) {
+		t.Fatal("retrieved bytes differ from wrapped original")
+	}
+}

--- a/engine/filewrap_test.go
+++ b/engine/filewrap_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestUnwrapFileWrapper(t *testing.T) {
 	goSrc := []byte("package main\n\nfunc add(a, b int) int {\n\treturn a + b\n}\n")
-	wrapped := []byte(`<file name="C:\x\main.go">` + "\n" + string(goSrc) + "\n</file>\n")
+	wrapped := []byte(" \n" + `<file name="C:\x\a>b.go">` + "\n" + string(goSrc) + "\n</file>\n\t")
 
 	inner, w := unwrapFileWrapper(wrapped)
 	if !w.present {
@@ -19,8 +19,9 @@ func TestUnwrapFileWrapper(t *testing.T) {
 		t.Fatalf("inner mismatch:\n%s", inner)
 	}
 	rewrapped := w.rewrap([]byte("compressed"))
-	if !bytes.HasPrefix(rewrapped, []byte(`<file name="C:\x\main.go">`)) || !bytes.HasSuffix(rewrapped, []byte("</file>")) {
-		t.Fatalf("rewrap lost wrapper: %q", rewrapped)
+	want := []byte(" \n" + `<file name="C:\x\a>b.go">compressed</file>` + "\n\t")
+	if !bytes.Equal(rewrapped, want) {
+		t.Fatalf("rewrap lost wrapper bytes:\n got %q\nwant %q", rewrapped, want)
 	}
 
 	// Non-wrapper inputs must pass through untouched.
@@ -40,6 +41,55 @@ func TestUnwrapFileWrapper(t *testing.T) {
 		if !bytes.Equal(got, in) {
 			t.Fatalf("no-op path changed bytes: %q", in)
 		}
+	}
+}
+
+func TestDetectSeesThroughFileWrapper(t *testing.T) {
+	eng := New(nil, nil)
+	input := []byte(`<file name="main.go">
+package main
+
+func alpha() int { return 1 }
+func beta() int { return 2 }
+func gamma() int { return 3 }
+</file>`)
+	if got := eng.Detect(input); got != TypeCode {
+		t.Fatalf("wrapped source detected as %q, want %q", got, TypeCode)
+	}
+}
+
+func TestNestedFileAndListingWrappers(t *testing.T) {
+	eng := New(nil, nil)
+	source := `package sample
+
+import "fmt"
+
+func alpha(a int) int {
+	total := a * 3
+	fmt.Println(total)
+	return total
+}
+
+func beta(b int) int {
+	total := b * 5
+	fmt.Println(total)
+	return total
+}
+`
+	cases := map[string][]byte{
+		"file outside listing": []byte("<file name=\"sample.go\">\n" + gutterLines(source) + "</file>"),
+		"listing outside file": []byte(gutterLines("<file name=\"sample.go\">\n" + source + "</file>\n")),
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			res := eng.Simulate(input, Options{Mode: ModeCompress})
+			if res.ContentType != TypeCode {
+				t.Fatalf("nested wrapped source detected as %q, want %q", res.ContentType, TypeCode)
+			}
+			if res.TokensSaved == 0 {
+				t.Fatal("nested wrapped source compressed nothing")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

Coding agents wrap file references handed to the model. pi (pi.dev) turns a `@file` argument into `<file name="...">...</file>`; other agents use the same single-element wrapper convention.

Left in place, the wrapper defeats `Detect`: the payload no longer starts with its real first bytes, so Go source never parses (`code_nocgo.go` only accepts files `go/parser` can parse), JSON never validates, and everything falls through to the `text` compressor, which compresses nothing. Result: pass-through at ratio 0 for every wrapped file the agent sends.

Verified on Windows 11 ARM64 with a real agent: pi sends a 142,409-byte `<file>`-wrapped Go payload; the no-cgo build's code compressor returned ratio 0 → the request went upstream unchanged.

## Fix

`unwrapFileWrapper` is deliberately conservative, mirroring the `listing.go` gutter approach:
- wrapper must be the outermost element
- must open with the literal `<file` tag (attributes allowed)
- exactly one `<file` and exactly one `</file>` (a stray tag inside a string literal = not a plain wrapper)
- must contain non-whitespace content
- anything else returns the input unchanged (no-op wrapper, no caller branches)

`Compress` and `Simulate` unwrap before `Detect` and rewrap compressed output so the model still sees the file reference the agent supplied. Original bytes remain in the CCR store unchanged.

## Tests

- `TestUnwrapFileWrapper`: detection + rewrap round-trip, plus negative cases (plain text, bare Go, HTML, multi-element, truncated wrappers).
- Full `go test ./engine/...` passes.

## End-to-end measurement (real agent)

pi coding agent → caveman proxy → DeepSeek, same task A/B:
- record mode (pass-through): 64,310 input tokens
- compress mode with this fix: 18,478 input tokens (**-71.3%**), answer exact-correct

## License

Engine directory change; signed per DCO.