### PR TITLE
fix(plugin): prefix agents paths with ./ so the manifest validates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,9 +6,9 @@
     "url": "https://github.com/JuliusBrussee"
   },
   "agents": [
-    "agents/cavecrew-builder.md",
-    "agents/cavecrew-investigator.md",
-    "agents/cavecrew-reviewer.md"
+    "./agents/cavecrew-builder.md",
+    "./agents/cavecrew-investigator.md",
+    "./agents/cavecrew-reviewer.md"
   ],
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
`claude plugin validate .` currently fails on `main`:

```
Validating marketplace manifest: .claude-plugin/marketplace.json
✘ Found 1 error:
  ❯ plugins[0] plugin.json → agents: Invalid input
✘ Validation failed
```

Claude Code's plugin manifest schema requires component paths to be relative paths beginning with `./`. The three `agents` entries use bare `agents/cavecrew-*.md`, which is rejected, and the plugin then fails to load when installed from the marketplace (it shows up in `/plugin` with a load error).

This PR adds the `./` prefix to those three entries. Nothing else changes.

After:

```
✔ Validation passed with warnings
```

(The remaining warning is the unrelated missing `version` field.)