### PR TITLE
Fix invalid agents paths in plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,9 +6,9 @@
     "url": "https://github.com/JuliusBrussee"
   },
   "agents": [
-    "agents/cavecrew-builder.md",
-    "agents/cavecrew-investigator.md",
-    "agents/cavecrew-reviewer.md"
+    "./agents/cavecrew-builder.md",
+    "./agents/cavecrew-investigator.md",
+    "./agents/cavecrew-reviewer.md"
   ],
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
## Summary
- `.claude-plugin/plugin.json`'s `agents` array uses bare paths (`agents/cavecrew-*.md`). Claude Code's plugin manifest schema requires component paths to be relative to the plugin root and start with `./`, so these fail validation with `agents: Invalid input`, blocking install/load of the plugin entirely.
- Fix: prefix each path with `./` (`./agents/cavecrew-builder.md`, etc.), matching the schema's documented path requirements.

## Test plan
- [x] `claude plugin validate .` passes with only the pre-existing "no version specified" warning.
- [x] Reinstalling the plugin from the patched manifest no longer surfaces the "invalid manifest file" / "agents: Invalid input" error.