### PR TITLE
fix(installer): use cmd.exe-compatible quoting for Windows hook commands

### DIFF
--- a/bin/lib/platform-paths.js
+++ b/bin/lib/platform-paths.js
@@ -6,9 +6,18 @@ function powershellQuote(value) {
   return `'${String(value).replace(/'/g, "''")}'`;
 }
 
+// cmd.exe-safe quoting: Claude Code spawns hook commands through cmd.exe on
+// Windows (not PowerShell), so the `& 'exe' 'arg'` PowerShell call-operator
+// form this used to emit fails every hook invocation with "& was unexpected
+// at this time" — the hook exits 1 silently and its ruleset/flag writes never
+// happen. cmd.exe needs plain double-quoted tokens, no leading `&`.
+function cmdQuote(value) {
+  return `"${String(value).replace(/"/g, '""')}"`;
+}
+
 function hookCommand(executable, args, platform = process.platform) {
   if (platform === 'win32') {
-    return `& ${[executable, ...args].map(powershellQuote).join(' ')}`;
+    return [executable, ...args].map(cmdQuote).join(' ');
   }
   return [executable, ...args]
     .map(value => `"${String(value).replace(/(["\\$`])/g, '\\$1')}"`)

--- a/bin/lib/settings.js
+++ b/bin/lib/settings.js
@@ -21,6 +21,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
+const { hookCommand } = require('./platform-paths.js');
 
 // ── stripJsonComments ──────────────────────────────────────────────────────
 // Hand-rolled state machine. Tracks string state + backslash escape so a
@@ -267,9 +268,7 @@ function rewriteLegacyManagedHookCommands(settings, absoluteNode, platform = pro
         const scriptPath = m[2] || m[3] || m[4];
         const basename = path.basename(scriptPath);
         if (!MANAGED_HOOK_BASENAMES.has(basename)) continue;
-        h.command = platform === 'win32'
-          ? `& '${String(absoluteNode).replace(/'/g, "''")}' '${String(scriptPath).replace(/'/g, "''")}'`
-          : `"${absoluteNode}" "${scriptPath}"`;
+        h.command = hookCommand(absoluteNode, [scriptPath], platform);
         rewritten++;
       }
     }

--- a/tests/installer/platform-paths.test.mjs
+++ b/tests/installer/platform-paths.test.mjs
@@ -6,14 +6,26 @@ import test from 'node:test';
 const require = createRequire(import.meta.url);
 const { hookCommand, jetbrainsRoots } = require('../../bin/lib/platform-paths.js');
 
-test('Windows hook commands invoke quoted executables through PowerShell', () => {
+test('Windows hook commands use cmd.exe-compatible quoting, not PowerShell', () => {
+  // Claude Code spawns hook commands through cmd.exe on Windows, not
+  // PowerShell — a leading `&` call operator makes cmd.exe fail every
+  // invocation with "& was unexpected at this time" (issue: /caveman set
+  // the mode flag but never actually changed responses, because
+  // SessionStart's ruleset injection silently crashed every session).
   assert.equal(
     hookCommand(
       "C:\\Program Files\\nodejs\\node.exe",
       ["C:\\Users\\O'Brien\\.claude\\hooks\\caveman-activate.js"],
       'win32',
     ),
-    "& 'C:\\Program Files\\nodejs\\node.exe' 'C:\\Users\\O''Brien\\.claude\\hooks\\caveman-activate.js'",
+    '"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\O\'Brien\\.claude\\hooks\\caveman-activate.js"',
+  );
+});
+
+test('Windows hook commands escape embedded double quotes for cmd.exe', () => {
+  assert.equal(
+    hookCommand('node.exe', ['C:\\path\\has "quote".js'], 'win32'),
+    '"node.exe" "C:\\path\\has ""quote"".js"',
   );
 });
 

--- a/tests/installer/unit.settings.test.mjs
+++ b/tests/installer/unit.settings.test.mjs
@@ -234,7 +234,9 @@ test('rewriteLegacyManagedHookCommands rewrites bare-node managed scripts', () =
   assert.equal(s.hooks.SessionStart[0].hooks[1].command, 'node /abs/hooks/some-user-hook.js');
 });
 
-test('rewriteLegacyManagedHookCommands emits PowerShell invocation on Windows', () => {
+test('rewriteLegacyManagedHookCommands emits cmd.exe-compatible invocation on Windows', () => {
+  // Claude Code spawns hook commands through cmd.exe on Windows, not
+  // PowerShell — a leading `&` call operator fails every invocation.
   const s = {
     hooks: {
       SessionStart: [{ hooks: [{ type: 'command', command: "node \"C:/Users/O'Brien/.claude/hooks/caveman-activate.js\"" }] }],
@@ -244,7 +246,7 @@ test('rewriteLegacyManagedHookCommands emits PowerShell invocation on Windows', 
   assert.equal(n, 1);
   assert.equal(
     s.hooks.SessionStart[0].hooks[0].command,
-    "& 'C:/Program Files/nodejs/node.exe' 'C:/Users/O''Brien/.claude/hooks/caveman-activate.js'",
+    '"C:/Program Files/nodejs/node.exe" "C:/Users/O\'Brien/.claude/hooks/caveman-activate.js"',
   );
 });
 


### PR DESCRIPTION
## Summary
- Claude Code spawns hook commands through `cmd.exe` on Windows, not PowerShell, but `hookCommand()` in `bin/lib/platform-paths.js` emitted PowerShell call-operator syntax (`& 'exe' 'arg'`). `cmd.exe` fails on the leading `&` with `"& was unexpected at this time"`, so `SessionStart` silently crashed every session — the caveman ruleset never loaded even though the `/caveman` mode flag got set correctly by `UserPromptSubmit`.
- `rewriteLegacyManagedHookCommands` in `bin/lib/settings.js` had the same broken quoting inline, and was actively converting working bare-`node` hook commands into the broken `&`-form on reinstall/self-heal. It now reuses the fixed `hookCommand()`.
- Verified by replaying the exact broken command through `cmd.exe` (fails) vs. the fixed cmd-quoted form (succeeds, prints the full ruleset).

## Test plan
- [x] `node --test tests/installer/platform-paths.test.mjs` — updated + new tests pass
- [x] `node --test tests/installer/unit.settings.test.mjs` — updated test passes
- [x] `node --test tests/installer/*.mjs` — full installer suite: 164 pass, 6 skipped (no `claude` CLI on PATH for e2e), 0 fail
- [x] Manually reproduced the bug and confirmed the fix against a live Windows `cmd.exe` invocation of both the hook and statusline command shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)