### PR TITLE
fix: prefix agent paths with ./ in plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,9 +6,9 @@
     "url": "https://github.com/JuliusBrussee"
   },
   "agents": [
-    "agents/cavecrew-builder.md",
-    "agents/cavecrew-investigator.md",
-    "agents/cavecrew-reviewer.md"
+    "./agents/cavecrew-builder.md",
+    "./agents/cavecrew-investigator.md",
+    "./agents/cavecrew-reviewer.md"
   ],
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
## Problem

Installing the plugin on Claude Code 2.1.235 (Windows) fails:

```
× Failed to install plugin "caveman@caveman": Plugin temp_local_..._y584k3 has an invalid manifest file at ...\.claude-plugin\plugin.json.

Validation errors: agents: Invalid input
```

The manifest's `agents` entries are bare relative paths (`agents/cavecrew-builder.md`). Current Claude Code validates plugin manifest paths as *explicitly* relative, so they must start with `./`.

## Fix

Prefix the three `agents` entries with `./`. No other change.

## Verification

With this patch applied locally, `claude plugin install caveman@caveman` succeeds and the plugin lists as enabled, with the three cavecrew agents available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)