### PR TITLE
fix(cli): honour HTTP_PROXY/HTTPS_PROXY for outbound requests

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,6 +35,7 @@ import {
   BINARY_RELEASE_BASE_DEFAULT,
   BINARY_SIGNING_PUBKEY,
 } from "./binaries.generated.js";
+import { installProxyAwareFetch } from "./proxy-fetch.js";
 import { RECIPES, type IntegrationRecipe } from "./recipes.generated.js";
 import { PRACTICE_REGISTRY } from "./practices.generated.js";
 import { RESERVED_VERBS } from "./reserved-verbs.generated.js";
@@ -500,6 +501,9 @@ let telemetryCommandSent = false;
 let telemetryEphemeralId = "";
 
 async function main() {
+  // Node's fetch does not read HTTP_PROXY/HTTPS_PROXY, so do it here before any
+  // request is made; without this every call fails on a proxy-only host.
+  installProxyAwareFetch();
   await ensureTelemetryDefault();
   try {
     await dispatch();

--- a/packages/cli/src/proxy-fetch.ts
+++ b/packages/cli/src/proxy-fetch.ts
@@ -1,0 +1,310 @@
+/**
+ * Proxy support for the CLI's outbound HTTP.
+ *
+ * Node's global `fetch` ignores the conventional proxy variables, so on a host
+ * where egress only leaves through a proxy every `fetch` in this CLI fails even
+ * though `curl` and `npm` — which do read those variables — succeed. The most
+ * visible symptom is `caveman setup --install` reporting the release download as
+ * unreachable, with no hint that a proxy is involved.
+ *
+ * Node 24 can opt in via `NODE_USE_ENV_PROXY=1` and 22 carries the same switch
+ * behind an experimental warning, but it is off by default and a process cannot
+ * turn it on for itself after start-up. This module implements the variables
+ * directly on `node:http`/`node:https`, adds no dependencies, and stays out of
+ * the way when the runtime is already handling them.
+ */
+import { request as httpRequest, type OutgoingHttpHeaders } from "node:http";
+import { request as httpsRequest, type RequestOptions } from "node:https";
+import { Readable } from "node:stream";
+import { connect as tlsConnect } from "node:tls";
+import type { Socket } from "node:net";
+
+/** Redirect hops to follow before giving up, matching the fetch spec's limit. */
+const MAX_REDIRECTS = 20;
+
+const DEFAULT_PORTS: Record<string, string> = { "http:": "80", "https:": "443" };
+
+/**
+ * Reads the first non-empty variable in `names`.
+ *
+ * Lower case wins over upper case: `http_proxy` is the older spelling and stays
+ * authoritative where both are set, which is what curl and the Python and Go
+ * toolchains do.
+ */
+function readEnv(env: NodeJS.ProcessEnv, names: readonly string[]): string | null {
+  for (const name of names) {
+    const value = env[name]?.trim();
+    if (value) return value;
+  }
+  return null;
+}
+
+/** Accepts `http://host:port`, `host:port`, and credentialed forms alike. */
+function parseProxyUrl(value: string): URL | null {
+  const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(value) ? value : `http://${value}`;
+  try {
+    const url = new URL(candidate);
+    return url.hostname ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function portOf(url: URL): string {
+  return url.port || DEFAULT_PORTS[url.protocol] || "";
+}
+
+/**
+ * Applies one `NO_PROXY` entry to a target.
+ *
+ * Entries match a host exactly or as a domain suffix, with or without a leading
+ * dot, and may pin a port. `*` disables proxying outright.
+ */
+function entryMatches(entry: string, target: URL): boolean {
+  if (entry === "*") return true;
+
+  const [rawHost, rawPort] = entry.startsWith("[")
+    ? [entry.slice(0, entry.indexOf("]") + 1), entry.slice(entry.indexOf("]") + 1).replace(/^:/, "")]
+    : entry.split(":");
+  if (rawPort && rawPort !== portOf(target)) return false;
+
+  const host = (rawHost ?? "").replace(/^\.+/, "").toLowerCase();
+  if (!host) return false;
+
+  const targetHost = target.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  const bareHost = host.replace(/^\[|\]$/g, "");
+  return targetHost === bareHost || targetHost.endsWith(`.${bareHost}`);
+}
+
+/** True when `NO_PROXY` exempts this target from proxying. */
+export function shouldBypassProxy(target: URL, noProxy: string | null | undefined): boolean {
+  if (!noProxy) return false;
+  return noProxy
+    .split(/[,\s]+/)
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean)
+    .some((entry) => entryMatches(entry, target));
+}
+
+/**
+ * Resolves the proxy for one target, or null when it should be reached directly.
+ *
+ * `ALL_PROXY` is the fallback for both schemes, so a single variable can cover a
+ * host that only has one way out.
+ */
+export function resolveProxyUrl(target: URL, env: NodeJS.ProcessEnv = process.env): URL | null {
+  if (target.protocol !== "http:" && target.protocol !== "https:") return null;
+  if (shouldBypassProxy(target, readEnv(env, ["no_proxy", "NO_PROXY"]))) return null;
+
+  const names =
+    target.protocol === "https:"
+      ? ["https_proxy", "HTTPS_PROXY", "all_proxy", "ALL_PROXY"]
+      : ["http_proxy", "HTTP_PROXY", "all_proxy", "ALL_PROXY"];
+  const configured = readEnv(env, names);
+  return configured ? parseProxyUrl(configured) : null;
+}
+
+function proxyAuthHeader(proxy: URL): OutgoingHttpHeaders {
+  if (!proxy.username && !proxy.password) return {};
+  const credentials = `${decodeURIComponent(proxy.username)}:${decodeURIComponent(proxy.password)}`;
+  return { "proxy-authorization": `Basic ${Buffer.from(credentials).toString("base64")}` };
+}
+
+function abortError(): Error {
+  return new DOMException("This operation was aborted", "AbortError") as unknown as Error;
+}
+
+/**
+ * Opens a CONNECT tunnel so TLS is negotiated with the target, not the proxy.
+ *
+ * Terminating TLS at the proxy would hand it the request and, for a signed
+ * release download, the bytes we are about to trust.
+ */
+function openTunnel(target: URL, proxy: URL, signal: AbortSignal | null): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const request = httpRequest({
+      host: proxy.hostname,
+      port: portOf(proxy),
+      method: "CONNECT",
+      path: `${target.hostname}:${portOf(target)}`,
+      headers: { host: `${target.hostname}:${portOf(target)}`, ...proxyAuthHeader(proxy) },
+    });
+
+    const onAbort = () => {
+      request.destroy(abortError());
+      reject(abortError());
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    request.once("connect", (response, socket) => {
+      signal?.removeEventListener("abort", onAbort);
+      if (response.statusCode !== 200) {
+        socket.destroy();
+        reject(new Error(`proxy refused CONNECT to ${target.host}: ${response.statusCode} ${response.statusMessage ?? ""}`.trim()));
+        return;
+      }
+      resolve(socket);
+    });
+    request.once("error", (error) => {
+      signal?.removeEventListener("abort", onAbort);
+      reject(error);
+    });
+    request.end();
+  });
+}
+
+interface ProxiedRequest {
+  readonly method: string;
+  readonly url: URL;
+  readonly headers: OutgoingHttpHeaders;
+  readonly body: Uint8Array | null;
+  readonly signal: AbortSignal | null;
+}
+
+function sendThroughProxy(request: ProxiedRequest, proxy: URL): Promise<Response> {
+  const { method, url, headers, body, signal } = request;
+
+  return new Promise<Response>((resolve, reject) => {
+    const finish = async (options: RequestOptions, send: typeof httpsRequest) => {
+      const outbound = send(options, (response) => {
+        const status = response.statusCode ?? 502;
+        const empty = status === 204 || status === 304 || method === "HEAD";
+        resolve(
+          new Response(empty ? null : (Readable.toWeb(response) as ReadableStream<Uint8Array>), {
+            status,
+            statusText: response.statusMessage ?? "",
+            headers: Object.entries(response.headers).flatMap(([name, value]) =>
+              value === undefined ? [] : [[name, Array.isArray(value) ? value.join(", ") : value] as [string, string]],
+            ),
+          }),
+        );
+      });
+
+      const onAbort = () => outbound.destroy(abortError());
+      signal?.addEventListener("abort", onAbort, { once: true });
+      outbound.once("error", reject);
+      outbound.once("close", () => signal?.removeEventListener("abort", onAbort));
+
+      if (body) outbound.write(body);
+      outbound.end();
+    };
+
+    if (url.protocol === "http:") {
+      // Plain HTTP is proxied in absolute form; no tunnel needed.
+      void finish(
+        {
+          host: proxy.hostname,
+          port: portOf(proxy),
+          method,
+          path: url.toString(),
+          headers: { ...headers, host: url.host, ...proxyAuthHeader(proxy) },
+        },
+        httpRequest,
+      );
+      return;
+    }
+
+    openTunnel(url, proxy, signal)
+      .then((socket) =>
+        finish(
+          {
+            method,
+            path: `${url.pathname}${url.search}`,
+            headers: { ...headers, host: url.host },
+            createConnection: () => tlsConnect({ socket, servername: url.hostname }),
+          },
+          httpsRequest,
+        ),
+      )
+      .catch(reject);
+  });
+}
+
+/** `BodyInit` in the bundled DOM types predates byte-array request bodies. */
+function asBodyInit(body: Uint8Array | null): BodyInit | null {
+  return body as unknown as BodyInit | null;
+}
+
+/** Per the fetch spec, these statuses continue as GET without a body. */
+function nextMethod(status: number, method: string): string {
+  if (status === 303) return method === "HEAD" ? "HEAD" : "GET";
+  if ((status === 301 || status === 302) && method === "POST") return "GET";
+  return method;
+}
+
+/**
+ * Wraps a fetch implementation so proxied targets go through the proxy and
+ * everything else keeps its existing path.
+ *
+ * The proxy is resolved per hop, so a redirect that crosses into a bypassed host
+ * is followed directly instead of being forced back through the proxy.
+ */
+export function createProxyAwareFetch(baseFetch: typeof fetch, env: NodeJS.ProcessEnv = process.env): typeof fetch {
+  return async function proxyAwareFetch(input, init) {
+    const request = new Request(input as RequestInfo, init);
+    const target = new URL(request.url);
+    const proxy = resolveProxyUrl(target, env);
+    if (!proxy) return baseFetch(input as RequestInfo, init);
+
+    const headers: OutgoingHttpHeaders = {};
+    request.headers.forEach((value, name) => {
+      headers[name] = value;
+    });
+    const buffered = ["GET", "HEAD"].includes(request.method) ? null : new Uint8Array(await request.arrayBuffer());
+
+    let current: ProxiedRequest = {
+      method: request.method,
+      url: target,
+      headers,
+      body: buffered,
+      signal: request.signal ?? null,
+    };
+    let hop = resolveProxyUrl(current.url, env);
+
+    for (let redirects = 0; ; redirects += 1) {
+      const response = hop ? await sendThroughProxy(current, hop) : await baseFetch(current.url, {
+        method: current.method,
+        headers: current.headers as HeadersInit,
+        body: asBodyInit(current.body),
+        signal: current.signal,
+        redirect: "follow",
+      });
+
+      const location = response.headers.get("location");
+      const redirectable = [301, 302, 303, 307, 308].includes(response.status);
+      if (!redirectable || !location || request.redirect === "manual") return response;
+      if (redirects >= MAX_REDIRECTS) throw new TypeError("fetch failed: too many redirects");
+      if (request.redirect === "error") throw new TypeError("fetch failed: unexpected redirect");
+
+      const next = new URL(location, current.url);
+      const method = nextMethod(response.status, current.method);
+      void response.body?.cancel();
+      current = {
+        method,
+        url: next,
+        headers: current.headers,
+        body: method === current.method ? current.body : null,
+        signal: current.signal,
+      };
+      hop = resolveProxyUrl(next, env);
+    }
+  } as typeof fetch;
+}
+
+/**
+ * Routes `globalThis.fetch` through the environment's proxy when one is set.
+ *
+ * Returns whether the wrapper was installed. It is skipped when nothing is
+ * configured and when `NODE_USE_ENV_PROXY` is set, because the runtime then owns
+ * proxy selection and wrapping on top of it would proxy twice.
+ */
+export function installProxyAwareFetch(
+  env: NodeJS.ProcessEnv = process.env,
+  scope: { fetch: typeof fetch } = globalThis,
+): boolean {
+  if (env.NODE_USE_ENV_PROXY) return false;
+  if (!readEnv(env, ["https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY", "all_proxy", "ALL_PROXY"])) return false;
+
+  scope.fetch = createProxyAwareFetch(scope.fetch.bind(scope), env);
+  return true;
+}

--- a/packages/cli/tests/proxy-fetch.runtime.mjs
+++ b/packages/cli/tests/proxy-fetch.runtime.mjs
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import {
+  createProxyAwareFetch,
+  installProxyAwareFetch,
+  resolveProxyUrl,
+  shouldBypassProxy,
+} from "../dist/proxy-fetch.js";
+
+const PROXY = "http://proxy.internal:912";
+
+function listen(server) {
+  server.listen(0, "127.0.0.1");
+  return once(server, "listening").then(() => `http://127.0.0.1:${server.address().port}`);
+}
+
+/** Proxy that serves absolute-form requests itself and counts what it saw. */
+async function startCountingProxy(handler) {
+  const seen = [];
+  const server = createServer((request, response) => {
+    seen.push(request.url);
+    handler(request, response);
+  });
+  const origin = await listen(server);
+  return { origin, seen, close: () => server.close() };
+}
+
+test("resolveProxyUrl picks the variable matching the target scheme", () => {
+  const env = { HTTP_PROXY: "http://plain:912", HTTPS_PROXY: "http://secure:912" };
+  assert.equal(resolveProxyUrl(new URL("http://example.test/x"), env).host, "plain:912");
+  assert.equal(resolveProxyUrl(new URL("https://example.test/x"), env).host, "secure:912");
+});
+
+test("resolveProxyUrl prefers the lower case spelling", () => {
+  const env = { http_proxy: "http://lower:912", HTTP_PROXY: "http://upper:912" };
+  assert.equal(resolveProxyUrl(new URL("http://example.test"), env).host, "lower:912");
+});
+
+test("resolveProxyUrl falls back to ALL_PROXY for either scheme", () => {
+  const env = { ALL_PROXY: "http://catch-all:912" };
+  assert.equal(resolveProxyUrl(new URL("http://example.test"), env).host, "catch-all:912");
+  assert.equal(resolveProxyUrl(new URL("https://example.test"), env).host, "catch-all:912");
+});
+
+test("resolveProxyUrl accepts a bare host:port and credentials", () => {
+  assert.equal(resolveProxyUrl(new URL("https://example.test"), { HTTPS_PROXY: "proxy.internal:912" }).port, "912");
+  const withAuth = resolveProxyUrl(new URL("https://example.test"), { HTTPS_PROXY: "http://user:pass@proxy:912" });
+  assert.equal(withAuth.username, "user");
+});
+
+test("resolveProxyUrl returns null with nothing configured or for other schemes", () => {
+  assert.equal(resolveProxyUrl(new URL("https://example.test"), {}), null);
+  assert.equal(resolveProxyUrl(new URL("ftp://example.test"), { ALL_PROXY: PROXY }), null);
+});
+
+test("shouldBypassProxy honours exact hosts, domain suffixes, ports, and the wildcard", () => {
+  const target = new URL("https://api.example.test/v1");
+  assert.equal(shouldBypassProxy(target, "api.example.test"), true);
+  assert.equal(shouldBypassProxy(target, ".example.test"), true);
+  assert.equal(shouldBypassProxy(target, "example.test"), true);
+  assert.equal(shouldBypassProxy(target, "*"), true);
+  assert.equal(shouldBypassProxy(target, "other.test, API.EXAMPLE.TEST"), true);
+  assert.equal(shouldBypassProxy(target, "api.example.test:443"), true);
+
+  assert.equal(shouldBypassProxy(target, "api.example.test:8443"), false);
+  assert.equal(shouldBypassProxy(target, "notexample.test"), false);
+  assert.equal(shouldBypassProxy(target, ""), false);
+  assert.equal(shouldBypassProxy(new URL("https://example.test.evil.test"), ".example.test"), false);
+});
+
+test("proxied requests reach the origin through the proxy", async () => {
+  const proxy = await startCountingProxy((request, response) => {
+    response.writeHead(200, { "content-type": "text/plain" });
+    response.end(`proxied ${request.url}`);
+  });
+  try {
+    const proxyFetch = createProxyAwareFetch(fetch, { HTTP_PROXY: proxy.origin });
+    const response = await proxyFetch("http://example.test/asset.bin");
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "proxied http://example.test/asset.bin");
+    assert.deepEqual(proxy.seen, ["http://example.test/asset.bin"]);
+  } finally {
+    proxy.close();
+  }
+});
+
+test("bypassed targets skip the proxy entirely", async () => {
+  const origin = createServer((_request, response) => response.end("direct"));
+  const originUrl = await listen(origin);
+  const proxy = await startCountingProxy((_request, response) => response.end("proxied"));
+  try {
+    const proxyFetch = createProxyAwareFetch(fetch, { HTTP_PROXY: proxy.origin, NO_PROXY: "127.0.0.1" });
+    assert.equal(await (await proxyFetch(originUrl)).text(), "direct");
+    assert.deepEqual(proxy.seen, []);
+  } finally {
+    proxy.close();
+    origin.close();
+  }
+});
+
+test("redirects are followed and re-resolved per hop", async () => {
+  const proxy = await startCountingProxy((request, response) => {
+    if (request.url.endsWith("/start")) {
+      response.writeHead(302, { location: "http://example.test/final" });
+      response.end();
+      return;
+    }
+    response.end("landed");
+  });
+  try {
+    const proxyFetch = createProxyAwareFetch(fetch, { HTTP_PROXY: proxy.origin });
+    const response = await proxyFetch("http://example.test/start");
+
+    assert.equal(await response.text(), "landed");
+    assert.deepEqual(proxy.seen, ["http://example.test/start", "http://example.test/final"]);
+  } finally {
+    proxy.close();
+  }
+});
+
+test("a request body and method survive the proxy hop", async () => {
+  let received = "";
+  const proxy = await startCountingProxy((request, response) => {
+    const chunks = [];
+    request.on("data", (chunk) => chunks.push(chunk));
+    request.on("end", () => {
+      received = Buffer.concat(chunks).toString();
+      response.writeHead(201);
+      response.end(request.method);
+    });
+  });
+  try {
+    const proxyFetch = createProxyAwareFetch(fetch, { HTTP_PROXY: proxy.origin });
+    const response = await proxyFetch("http://example.test/api", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hello: "cave" }),
+    });
+
+    assert.equal(response.status, 201);
+    assert.equal(await response.text(), "POST");
+    assert.equal(received, '{"hello":"cave"}');
+  } finally {
+    proxy.close();
+  }
+});
+
+test("an aborted request rejects instead of hanging", async () => {
+  const proxy = await startCountingProxy(() => {
+    /* never responds */
+  });
+  try {
+    const proxyFetch = createProxyAwareFetch(fetch, { HTTP_PROXY: proxy.origin });
+    await assert.rejects(proxyFetch("http://example.test/slow", { signal: AbortSignal.timeout(50) }));
+  } finally {
+    proxy.close();
+  }
+});
+
+test("installProxyAwareFetch only wraps when it should", () => {
+  const untouched = { fetch };
+  assert.equal(installProxyAwareFetch({}, untouched), false);
+  assert.equal(untouched.fetch, fetch);
+
+  const runtimeHandled = { fetch };
+  assert.equal(installProxyAwareFetch({ NODE_USE_ENV_PROXY: "1", HTTP_PROXY: PROXY }, runtimeHandled), false);
+  assert.equal(runtimeHandled.fetch, fetch);
+
+  const wrapped = { fetch };
+  assert.equal(installProxyAwareFetch({ HTTPS_PROXY: PROXY }, wrapped), true);
+  assert.notEqual(wrapped.fetch, fetch);
+});


### PR DESCRIPTION
Node's global `fetch` ignores the conventional proxy variables. On a host whose egress only leaves through an HTTP proxy, that means every request the CLI makes fails while `curl` and `npm` — which do read those variables — work fine.

First thing a new user hits:

```
$ caveman setup --install
binary download unreachable — agents still launch; traffic is NOT compressed or metered
fix: caveman setup --install
```

The fix points back at the command that just failed, and nothing in the message suggests a proxy is involved. I lost a while to it before checking whether `fetch` reads the variables at all. The same blind spot affects the npm version check, `login`, and every cloud call.

Node 24 can opt in with `NODE_USE_ENV_PROXY=1`, and 22 has the same switch behind an experimental warning, but it is off by default and a process cannot turn it on for itself after start-up — so the CLI has to implement the variables.

## What this does

New `packages/cli/src/proxy-fetch.ts`, no dependencies added:

- `resolveProxyUrl(target, env)` — `HTTPS_PROXY`/`HTTP_PROXY` by scheme with `ALL_PROXY` as fallback, lower case winning over upper (curl's precedence), bare `host:port` and credentialed forms accepted.
- `shouldBypassProxy(target, noProxy)` — `NO_PROXY` with `*`, exact host, domain suffix with or without leading dot, and optional port pinning.
- `createProxyAwareFetch(baseFetch, env)` — CONNECT tunnel for https so TLS still terminates at the target rather than the proxy, absolute-form for http. Redirects are followed with the proxy re-resolved per hop, so a hop into a `NO_PROXY` host goes direct instead of being forced back through the proxy.
- `installProxyAwareFetch()` — called at the top of `main()`, before any request. No-ops when nothing is configured, and when `NODE_USE_ENV_PROXY` is set, so a runtime already handling proxying is not proxied twice.

Wrapping `globalThis.fetch` once at start-up rather than editing ~20 call sites keeps proxy semantics in one module and leaves the call sites alone.

## Verification

A/B on a proxy-only host, `NODE_USE_ENV_PROXY` deliberately unset, clean `HOME`:

| | `setup --install` |
|---|---|
| before | `binary download unreachable` |
| after | six binaries downloaded, `checksum verified` each |

`packages/cli/tests/proxy-fetch.runtime.mjs` adds 12 tests: variable precedence and scheme selection, `ALL_PROXY` fallback, bare host and credentials, `NO_PROXY` matching including the suffix false-positive case (`example.test.evil.test` must not match `.example.test`), tunnelling through a real local proxy, bypass, redirect chains with per-hop resolution, POST bodies and methods surviving the hop, abort, and the install guard.

`npm run test:fast` and `tsc --noEmit` are clean.

## Notes for review

- I kept `Response` construction on `Readable.toWeb` so streaming downloads still stream; the release download hashes as it goes and that path is unchanged.
- Redirect cap is 20, matching the fetch spec rather than inventing a number.
- One documented cast (`asBodyInit`) because `BodyInit` in the bundled DOM types predates byte-array bodies.
- Happy to split the module into resolution and transport files if you would rather keep transport separate.