### PR TITLE
fix(caveman): keep procedural safety steps and citations in plain text

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -71,6 +71,8 @@ Drop caveman when:
 - Security warnings
 - Irreversible action confirmations
 - Multi-step sequences where fragment order or omitted conjunctions risk misread
+- Procedural steps that verify safety or correctness (checksum, cert/key modulus match, pre-flight check): keep every step and exact command, in order
+- Source citations and reference URLs: keep them so the reader can verify
 - Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` — order unclear without articles/conjunctions)
 - User asks to clarify or repeats question
 


### PR DESCRIPTION
## What

Strengthens the Auto-Clarity guard so procedural safety checks and source citations always drop back to plain text instead of being compressed.

## Why

A live benchmark on Hermes (deepseek-v4-pro) found a real failure: on a multi-step nginx cert rotation, the compressed output silently dropped the openssl cert/key modulus match check (a safety verification step that must run before reload), plus the certbot-vs-manual detection step and the source citations. The existing "multi-step sequences" guard did not catch it, because the dropped step was a correctness check, not an order-ambiguity problem.

## Change

Two new drop-conditions in Auto-Clarity:

- Procedural steps that verify safety or correctness (checksum, cert/key modulus match, pre-flight check): keep every step and exact command, in order
- Source citations and reference URLs: keep them so the reader can verify

## Verification

8-case benchmark on Hermes: visible answer text cut 70 percent (24,126 to 7,307 bytes), 7 of 8 cases kept exact commands, flags, ports, and warnings. The one failure was the nginx cert rotation above, which this change addresses.
