### PR TITLE
fix(compress): block sensitive directory names

### DIFF
--- a/plugins/caveman/skills/caveman-compress/scripts/compress.py
+++ b/plugins/caveman/skills/caveman-compress/scripts/compress.py
@@ -67,7 +67,10 @@ SENSITIVE_BASENAME_REGEX = re.compile(
     r")$"
 )
 
-SENSITIVE_PATH_COMPONENTS = frozenset({".ssh", ".aws", ".gnupg", ".kube", ".docker"})
+SENSITIVE_PATH_COMPONENTS = frozenset({
+    ".ssh", ".aws", ".gnupg", ".kube", ".docker",
+    "credentials", "secrets",
+})
 
 SENSITIVE_NAME_TOKENS = (
     "secret", "credential", "password", "passwd",

--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -67,7 +67,10 @@ SENSITIVE_BASENAME_REGEX = re.compile(
     r")$"
 )
 
-SENSITIVE_PATH_COMPONENTS = frozenset({".ssh", ".aws", ".gnupg", ".kube", ".docker"})
+SENSITIVE_PATH_COMPONENTS = frozenset({
+    ".ssh", ".aws", ".gnupg", ".kube", ".docker",
+    "credentials", "secrets",
+})
 
 SENSITIVE_NAME_TOKENS = (
     "secret", "credential", "password", "passwd",

--- a/tests/test_compress_safety.py
+++ b/tests/test_compress_safety.py
@@ -230,6 +230,13 @@ class CompressSafetyTests(unittest.TestCase):
             backup_dir = compress_mod.backup_dir_for(path)
             self.assertFalse((backup_dir / "task.original.md").exists())
 
+    def test_sensitive_directory_names_are_blocked(self):
+        self.assertTrue(
+            compress_mod.is_sensitive_path(Path("C:/dev/CREDENTIALS/hetzner/webhosting.md"))
+        )
+        self.assertTrue(compress_mod.is_sensitive_path(Path("project/secrets/service-notes.md")))
+        self.assertFalse(compress_mod.is_sensitive_path(Path("project/docs/service-notes.md")))
+
     def test_crlf_line_endings_survive_the_round_trip(self):
         """Reading with universal newlines and writing back "\n" rewrote every
         line ending in every file the tool touched (issue #762)."""


### PR DESCRIPTION
## Summary
- block files located under credentials/ or secrets/ directories in caveman-compress
- keep the shipped plugin copy in sync with the source script
- add a regression test for uppercase CREDENTIALS paths and non-sensitive docs paths

Fixes #858.

## Validation
- uv run --python 3.11 python -m unittest tests.test_compress_safety
- cmp -s skills/caveman-compress/scripts/compress.py plugins/caveman/skills/caveman-compress/scripts/compress.py
- git diff --check