### PR TITLE
docs(readme): add community docs link to footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Caveman save you token, save you money. Star cost zero. Fair trade. ⭐
 <sub>
 <strong>Docs:</strong>
 <a href="./docs/README.md">Technical manual</a> ·
+<a href="https://caveman.sharonwang.me/">Community docs</a> ·
 <a href="./INSTALL.md">Install matrix</a> ·
 <a href="./docs/HONEST-NUMBERS.md">Honest numbers</a> ·
 <a href="./LICENSE">License</a> ·


### PR DESCRIPTION
### What 
Add a "Community docs" link to the README footer docs section. Provides an alternative with traditional setup navigation (sidebar layout, copy-paste blocks) while preserving the current README. Includes a native `llms.txt` endpoint.

### Files
`README.md` — one link added to the footer `<sub>` block, between "Technical manual" and "Install matrix"

### Notes

- Additive only, no original text removed or modified. Happy to move it elsewhere if you prefer. 
- Addresses #887.
- Currently hosted independently, but completely open to moving it to a Caveman subdomain in the future if you desire.
- Feel free to close if it doesn’t fit — no pressure.
