### PR TITLE
fix(stats): add Claude 5 model output pricing

### DIFF
--- a/src/hooks/caveman-stats.js
+++ b/src/hooks/caveman-stats.js
@@ -40,15 +40,13 @@ function ruleOverheadPerTurn() {
 // Most-specific prefixes MUST come first — priceForModel returns the first match.
 const MODEL_OUTPUT_PRICE_PER_M = [
   // Claude 5 family. Fable/Mythos (models.anthropic.com naming) sit at the
-  // top $50/M tier; Opus 5 dropped to $25/M. Sonnet 5 is on a $10/M intro
-  // rate through 2026-08-31 ($15/M standard from 2026-09-01) per
-  // shared/provider-catalog/catalog/current.yaml; the current-period value is
-  // listed so savings are not overstated during the intro window.
+  // top $50/M tier; Opus 5 dropped to $25/M. Sonnet 5's $10/M rate is the
+  // permanent standard price — the increase to $15/M planned for
+  // 2026-09-01 was cancelled (see anthropic.com/docs/en/about-claude/pricing).
   ['claude-fable-5',   50.00],
   ['claude-mythos-5',  50.00],
   ['claude-opus-5',    25.00],
   ['claude-sonnet-5',  10.00],
-  ['claude-haiku-5',    5.00],
   // Legacy Opus 4.0 / 4.1 (pre-4.5) billed at the old $75/M output tier,
   // including the dated ids (e.g. claude-opus-4-20250514).
   ['claude-opus-4-0',    75.00],

--- a/src/hooks/caveman-stats.js
+++ b/src/hooks/caveman-stats.js
@@ -39,6 +39,16 @@ function ruleOverheadPerTurn() {
 // https://www.anthropic.com/pricing if a release changes the tier.
 // Most-specific prefixes MUST come first — priceForModel returns the first match.
 const MODEL_OUTPUT_PRICE_PER_M = [
+  // Claude 5 family. Fable/Mythos (models.anthropic.com naming) sit at the
+  // top $50/M tier; Opus 5 dropped to $25/M. Sonnet 5 is on a $10/M intro
+  // rate through 2026-08-31 ($15/M standard from 2026-09-01) per
+  // shared/provider-catalog/catalog/current.yaml; the current-period value is
+  // listed so savings are not overstated during the intro window.
+  ['claude-fable-5',   50.00],
+  ['claude-mythos-5',  50.00],
+  ['claude-opus-5',    25.00],
+  ['claude-sonnet-5',  10.00],
+  ['claude-haiku-5',    5.00],
   // Legacy Opus 4.0 / 4.1 (pre-4.5) billed at the old $75/M output tier,
   // including the dated ids (e.g. claude-opus-4-20250514).
   ['claude-opus-4-0',    75.00],

--- a/tests/test_caveman_stats.js
+++ b/tests/test_caveman_stats.js
@@ -173,6 +173,7 @@ test('priceForModel matches by prefix across point releases', () => {
   assert.strictEqual(priceForModel('claude-mythos-5'), 50.00);
   assert.strictEqual(priceForModel('claude-opus-5[1m]'), 25.00);
   assert.strictEqual(priceForModel('claude-sonnet-5[1m]'), 10.00);
+  assert.strictEqual(priceForModel('claude-haiku-5'), null);
   assert.strictEqual(priceForModel(null), null);
   assert.strictEqual(priceForModel('gpt-4'), null);
 });

--- a/tests/test_caveman_stats.js
+++ b/tests/test_caveman_stats.js
@@ -169,7 +169,6 @@ test('priceForModel matches by prefix across point releases', () => {
   assert.strictEqual(priceForModel('claude-3-5-sonnet-20241022'), 15.00);
   assert.strictEqual(priceForModel('claude-opus-5'), 25.00);
   assert.strictEqual(priceForModel('claude-sonnet-5'), 10.00);
-  assert.strictEqual(priceForModel('claude-haiku-5'), 5.00);
   assert.strictEqual(priceForModel('claude-fable-5'), 50.00);
   assert.strictEqual(priceForModel('claude-mythos-5'), 50.00);
   assert.strictEqual(priceForModel('claude-opus-5[1m]'), 25.00);

--- a/tests/test_caveman_stats.js
+++ b/tests/test_caveman_stats.js
@@ -167,6 +167,13 @@ test('priceForModel matches by prefix across point releases', () => {
   assert.strictEqual(priceForModel('claude-sonnet-4-7-20260315'), 15.00);
   assert.strictEqual(priceForModel('claude-haiku-4-5'), 5.00);
   assert.strictEqual(priceForModel('claude-3-5-sonnet-20241022'), 15.00);
+  assert.strictEqual(priceForModel('claude-opus-5'), 25.00);
+  assert.strictEqual(priceForModel('claude-sonnet-5'), 10.00);
+  assert.strictEqual(priceForModel('claude-haiku-5'), 5.00);
+  assert.strictEqual(priceForModel('claude-fable-5'), 50.00);
+  assert.strictEqual(priceForModel('claude-mythos-5'), 50.00);
+  assert.strictEqual(priceForModel('claude-opus-5[1m]'), 25.00);
+  assert.strictEqual(priceForModel('claude-sonnet-5[1m]'), 10.00);
   assert.strictEqual(priceForModel(null), null);
   assert.strictEqual(priceForModel('gpt-4'), null);
 });


### PR DESCRIPTION
## Summary

`/caveman-stats` and the statusline previously showed no USD savings figure on any Claude 5 session: `priceForModel()` only matched Claude 3/4 prefixes, so `claude-*-5` model ids fell through to `null` and the `Est. saved (USD)` line, the `Pricing for <model>` footer, and the `(~$X)` parenthetical were silently omitted.

This adds the Claude 5 rate card to `MODEL_OUTPUT_PRICE_PER_M` (Fable 5 / Mythos 5 `$50`, Opus 5 `$25`, Sonnet 5 `$10` — the permanent standard price per Anthropic's pricing docs; the previously planned 2026-09-01 increase to `$15` was cancelled) and extends the prefix-match regression test, including the `[1m]` context variant Claude Code reports. A prior revision also added a `claude-haiku-5` row/assertion; that was removed after review confirmed no such model exists in Anthropic's current lineup (only Haiku 4.5 is shipped).

Fixes #744

Session-settled decisions carried from planning: price rows follow live Anthropic pricing docs, not the repo's internal catalog file, which still needs a follow-up fix for the same stale Sonnet 5 framing (user-approved); scope limited to the price-table gap and the two review-flagged corrections (user-directed).

## Validation

- `node tests/test_caveman_stats.js` — 46 passed, 0 failed
- `npm test` — 148 passed, 0 failed (4 pre-existing skips)
- `node --check src/hooks/caveman-stats.js` — clean
