### PR TITLE
fix(plugin): prefix agents paths with ./ so plugin install works on current Claude Code

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,9 +6,9 @@
     "url": "https://github.com/JuliusBrussee"
   },
   "agents": [
-    "agents/cavecrew-builder.md",
-    "agents/cavecrew-investigator.md",
-    "agents/cavecrew-reviewer.md"
+    "./agents/cavecrew-builder.md",
+    "./agents/cavecrew-investigator.md",
+    "./agents/cavecrew-reviewer.md"
   ],
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
## Problem

`claude plugin install caveman@caveman` fails on current Claude Code (2.1.x):

```
✘ Failed to install plugin "caveman@caveman": Plugin temp_local_... has an
  invalid manifest file at .../.claude-plugin/plugin.json.

Validation errors: agents: Invalid input
```

This blocks the plugin install path for every user on current CC. The standalone
hook install (`--with-hooks`) still succeeds, which is why the failure is easy to
miss — hooks work, but the skills and cavecrew agents never load.

## Cause

The CC manifest validator requires plugin-relative paths to start with `./`.
`plugin.json` lists the cavecrew agents as bare relative paths.

The same rule already governs the `skills` field — the repo's own `CLAUDE.md`
documents it under the ClawHub publishing constraints ("all paths must be
relative to the plugin root and start with `./`"; CC returns
`Validation errors: skills: Invalid input` otherwise). `agents` is subject to the
same validator and was missed.

## Fix

Prefix the three `agents` entries with `./`.

## Verification

Tested against a real marketplace copy under
`~/.claude/plugins/marketplaces/caveman/`, reinstalling between each variant:

| `agents` value | Result |
| --- | --- |
| `["agents/cavecrew-builder.md", ...]` (current) | ✘ `agents: Invalid input` |
| `"./agents"` (string dir) | ✘ `agents: Invalid input` |
| `["./agents/cavecrew-builder.md", ...]` (this PR) | ✔ installs cleanly |

After the fix, `claude plugin install caveman@caveman` succeeds and the plugin
loads its skills plus all three cavecrew agents (builder, investigator, reviewer).

Environment: Windows 11, Claude Code 2.1.x, Node v24.19.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
