### PR TITLE
fix(compress): isolate claude --print subprocess from caller's hooks/MCP

### DIFF
--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -298,10 +298,19 @@ def call_claude(prompt: str) -> str:
     # shutil.which returns the same absolute path as the implicit lookup,
     # so this is a no-op there. Falls back to bare "claude" if not found
     # on PATH so subprocess raises a clear FileNotFoundError.
+    # --setting-sources "" and --strict-mcp-config keep this a plain text
+    # completion. Without them, `claude --print` boots a full session that
+    # inherits the caller's ~/.claude/settings.json hooks and MCP servers —
+    # a UserPromptSubmit hook injecting unrelated context, or the subprocess
+    # reaching for an inherited MCP tool and hitting a permission wall it
+    # can't resolve non-interactively, both leak narrated commentary into
+    # what is supposed to be pure compressed markdown. --bare would isolate
+    # more but requires ANTHROPIC_API_KEY/apiKeyHelper auth, unusable for
+    # OAuth-only desktop installs, which is exactly what this fallback is for.
     claude_bin = shutil.which("claude") or "claude"
     try:
         result = subprocess.run(
-            [claude_bin, "--print"],
+            [claude_bin, "--print", "--setting-sources", "", "--strict-mcp-config"],
             input=prompt,
             text=True,
             capture_output=True,


### PR DESCRIPTION
Fixes #920

## Summary
- \`call_claude()\`'s \`claude --print\` fallback boots a full Claude Code session, inheriting the caller's \`~/.claude/settings.json\` hooks and MCP server list.
- Two observed leaks: a \`UserPromptSubmit\` hook injecting unrelated context that the subprocess narrates about instead of silently ignoring, and the subprocess reaching for an inherited MCP tool, hitting a non-interactive permission wall, and narrating that instead of compressing.
- \`--setting-sources ""\` + \`--strict-mcp-config\` isolate the call to a plain text completion, no auth change needed. \`--bare\` was considered but requires \`ANTHROPIC_API_KEY\`/\`apiKeyHelper\`, which isn't available on OAuth-only desktop installs — exactly the case this fallback exists for.

## Test plan
- [x] Reproduced the leak by piping \`build_compress_prompt(text)\` output straight to \`claude --print\` on a machine with hooks configured
- [x] Confirmed clean output with \`--setting-sources "" --strict-mcp-config\` added, same machine, same previously-leaky inputs
- [x] Ran the patched \`compress.py\` end-to-end on 3 files that leaked before the fix — all compressed cleanly with real byte reductions, no injected commentary