### PR TITLE
feat(hooks): add CAVEMAN_STATUSLINE_NUDGE env opt-out

### DIFF
--- a/skills/caveman-help/SKILL.md
+++ b/skills/caveman-help/SKILL.md
@@ -47,6 +47,9 @@ Default mode = `full`. Change it:
 **Environment variable** (highest priority):
 ```bash
 export CAVEMAN_DEFAULT_MODE=ultra
+
+# Never ask about the statusline badge
+export CAVEMAN_STATUSLINE_NUDGE=0
 ```
 
 **Config file** (`~/.config/caveman/config.json`):

--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -361,6 +361,18 @@ if (skillContent) {
 // One-shot (#661): the nudge costs ~90 tokens per session, so a marker file
 // gates it to the first session only. Users who declined stop paying for it.
 const nudgeMarkerPath = path.join(claudeDir, '.caveman-nudge-shown');
+
+// Explicit opt-out (#923): the one-shot marker still spends a first session on
+// users who will never want a statusline, and it does not survive a fresh
+// CLAUDE_CONFIG_DIR. An env var is settable from a dotfile, so the nudge can be
+// declined before it is ever shown. Accepts the usual falsy spellings; any
+// other value (including unset) leaves the existing behaviour untouched.
+function nudgeDisabledByEnv() {
+  const raw = process.env.CAVEMAN_STATUSLINE_NUDGE;
+  if (raw === undefined) return false;
+  return ['0', 'false', 'off', 'no'].indexOf(String(raw).trim().toLowerCase()) !== -1;
+}
+
 try {
   let hasStatusline = false;
   if (fs.existsSync(settingsPath)) {
@@ -376,7 +388,7 @@ try {
     }
   }
 
-  if (!hasStatusline && !fs.existsSync(nudgeMarkerPath)) {
+  if (!hasStatusline && !nudgeDisabledByEnv() && !fs.existsSync(nudgeMarkerPath)) {
     safeWriteFlag(nudgeMarkerPath, '1');
     const isWindows = process.platform === 'win32';
     const scriptName = isWindows ? 'caveman-statusline.ps1' : 'caveman-statusline.sh';

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -179,6 +179,48 @@ class HookScriptTests(unittest.TestCase):
             self.assertNotIn("STATUSLINE SETUP NEEDED", result.stdout)
             self.assertEqual((claude_dir / ".caveman-active").read_text(encoding="utf-8"), "full")
 
+    # #923: CAVEMAN_STATUSLINE_NUDGE=0 declines the badge outright. The one-shot
+    # marker must stay unwritten, because the env var is the gate and consuming
+    # the marker would silently re-enable the nudge if the var were removed.
+    def test_activate_env_opt_out_suppresses_statusline_nudge(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-nudge-env-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+
+            result = self.run_cmd(
+                ["node", "src/hooks/caveman-activate.js"],
+                home,
+                extra_env={"CAVEMAN_STATUSLINE_NUDGE": "0"},
+            )
+
+            self.assertNotIn("STATUSLINE SETUP NEEDED", result.stdout)
+            self.assertFalse((claude_dir / ".caveman-nudge-shown").exists())
+
+    def test_activate_still_nudges_without_env_opt_out(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-nudge-default-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+
+            result = self.run_cmd(["node", "src/hooks/caveman-activate.js"], home)
+
+            self.assertIn("STATUSLINE SETUP NEEDED", result.stdout)
+
+    def test_activate_env_opt_out_ignores_unrecognised_value(self):
+        with tempfile.TemporaryDirectory(prefix="caveman-hooks-nudge-junk-") as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+
+            result = self.run_cmd(
+                ["node", "src/hooks/caveman-activate.js"],
+                home,
+                extra_env={"CAVEMAN_STATUSLINE_NUDGE": "1"},
+            )
+
+            self.assertIn("STATUSLINE SETUP NEEDED", result.stdout)
+
     # Regression for #587/#589 — hook at <root>/src/hooks/ must resolve SKILL.md
     # at <root>/skills/caveman/, not the nonexistent <root>/src/skills/.
     def test_activate_emits_skill_md_not_fallback_from_repo_layout(self):


### PR DESCRIPTION
Closes #923 (one of two alternatives, see below).

### What this does

Adds `CAVEMAN_STATUSLINE_NUDGE`. Setting it to `0`, `false`, `off`, or `no` suppresses the statusline badge nudge outright. Any other value, including unset, keeps today's behaviour exactly.

The check runs *before* the `.caveman-nudge-shown` marker is written, so opting out does not consume the one-shot. If the variable is later removed, the user gets the normal first-session nudge rather than silence they never asked for.

### Why, given #661 already landed the one-shot

The one-shot marker fixed the recurring cost, and it is the right default. Two gaps remain for users who want no statusline at all:

- It still spends a first session emitting the nudge, including the "Proactively offer to set this up" instruction, before it can be declined.
- The marker lives in `CLAUDE_CONFIG_DIR`. A fresh config dir, a second machine, or a relocated Claude config brings the nudge back with no way to pre-empt it.

Shape mirrors `CAVEMAN_DEFAULT_MODE`, which is already the highest precedence source in `getDefaultMode()`, so an env var is the established way to state a machine-wide caveman preference from a dotfile.

### Tests

Three added to `tests/test_hooks.py`: opt-out suppresses the nudge and leaves the marker unwritten, the nudge still fires with no variable set, and an unrecognised value (`1`) is ignored rather than treated as falsy. Full `tests/test_hooks.py` suite passes.

### These two PRs are alternatives, merge only one

Both implement the same opt-out from #923 by different mechanisms. They touch the same condition and will conflict with each other by design.

**Preference order:**

1. **This PR, the env var.** Smallest surface, no new config surface area, settable from a dotfile, and covers a fresh `CLAUDE_CONFIG_DIR` where the marker file cannot help.
2. **#925, the `statuslineNudge` config key.** Better if you would rather the preference be checked into a repo next to `defaultMode` and survive independently of the environment. Costs a new config key and a new exported function.

A third idea from the issue, suppressing after one showing, turned out to be already shipped in #661. The issue text was written against an older cached plugin build that predates it, and I have corrected the issue accordingly. Only the two opt-out options above remain open.

Happy to close whichever one you do not want, or to rework either if you would prefer a different name or precedence.
