### PR TITLE
feat(hooks): add statuslineNudge config opt-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,7 @@ All hooks honor `CLAUDE_CONFIG_DIR` for non-default Claude Code config locations
 
 Exports:
 - `getDefaultMode()` — resolves default mode in order: `CAVEMAN_DEFAULT_MODE` env var → repo-local config (`<cwd>/.caveman/config.json` or `<cwd>/.caveman.json`, walking up to the filesystem root) → user config (`$XDG_CONFIG_HOME/caveman/config.json` / `~/.config/caveman/config.json` / `%APPDATA%\caveman\config.json`) → `'full'`. The env var short-circuits before any cwd walk. Repo-local config lets a team check in a per-project default without polluting every contributor's env or user config.
+- `statuslineNudgeEnabled()`: resolves whether the statusline badge nudge may be emitted, reading `statuslineNudge` (boolean) from repo-local config then user config, same files as `getDefaultMode()` minus the env layer. Absent or malformed returns `true`, so the nudge only goes quiet on an explicit opt-out.
 - `findRepoConfigPath(start)` — walks up from `start` (default `process.cwd()`) looking for the first `.caveman/config.json` or `.caveman.json`. Bounded to 64 ancestors. Refuses symlinked files (symmetric with `safeWriteFlag` / `readFlag`).
 - `safeWriteFlag(flagPath, content)` — symlink-safe flag write. Refuses if flag target or its immediate parent is a symlink. Opens with `O_NOFOLLOW` where supported. Atomic temp + rename. Creates with `0600`. Protects against local attackers replacing the predictable flag path with a symlink to clobber files writable by the user. Used by both write hooks. Silent-fails on all filesystem errors.
 

--- a/src/hooks/caveman-activate.js
+++ b/src/hooks/caveman-activate.js
@@ -135,6 +135,15 @@ const { getDefaultMode, safeWriteFlag, recordModeChange, readFlag, VALID_MODES }
   VALID_MODES: FALLBACK_VALID_MODES,
 };
 
+// Resolved separately from the destructure above rather than folded into the
+// isUsable check: an older sibling that predates this key is still perfectly
+// usable for everything else, and demanding the function would demote the whole
+// module to the degraded stubs over one optional preference.
+const statuslineNudgeEnabled =
+  (cavemanConfig && typeof cavemanConfig.statuslineNudgeEnabled === 'function')
+    ? cavemanConfig.statuslineNudgeEnabled
+    : () => true;
+
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const flagPath = path.join(claudeDir, '.caveman-active');
 const settingsPath = path.join(claudeDir, 'settings.json');
@@ -376,7 +385,7 @@ try {
     }
   }
 
-  if (!hasStatusline && !fs.existsSync(nudgeMarkerPath)) {
+  if (!hasStatusline && statuslineNudgeEnabled() && !fs.existsSync(nudgeMarkerPath)) {
     safeWriteFlag(nudgeMarkerPath, '1');
     const isWindows = process.platform === 'win32';
     const scriptName = isWindows ? 'caveman-statusline.ps1' : 'caveman-statusline.sh';

--- a/src/hooks/caveman-config.js
+++ b/src/hooks/caveman-config.js
@@ -73,6 +73,28 @@ function findRepoConfigPath(start) {
   return null;
 }
 
+// #923: opt out of the statusline badge nudge from config, for users who want no
+// statusline at all. Resolution mirrors getDefaultMode's file order (repo-local
+// first, then user config) minus the env layer, so a team can check the
+// preference in alongside defaultMode. Absent or malformed leaves the nudge on:
+// erring toward the current behaviour keeps this from silently swallowing the
+// nudge for users who never opted out.
+function statuslineNudgeEnabled(startDir) {
+  const candidates = [findRepoConfigPath(startDir), getConfigPath()];
+  for (const configPath of candidates) {
+    if (!configPath) continue;
+    try {
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      if (config && typeof config.statuslineNudge === 'boolean') {
+        return config.statuslineNudge;
+      }
+    } catch (e) {
+      // Missing / unreadable / invalid JSON, try the next candidate
+    }
+  }
+  return true;
+}
+
 function readModeFromConfigFile(configPath) {
   try {
     const raw = fs.readFileSync(configPath, 'utf8');
@@ -401,4 +423,4 @@ function readHistory(filePath) {
   }
 }
 
-module.exports = { getDefaultMode, getConfigDir, getConfigPath, findRepoConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory, recordModeChange, MODE_LOG_BASENAME };
+module.exports = { statuslineNudgeEnabled, getDefaultMode, getConfigDir, getConfigPath, findRepoConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory, recordModeChange, MODE_LOG_BASENAME };

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -179,6 +179,47 @@ class HookScriptTests(unittest.TestCase):
             self.assertNotIn("STATUSLINE SETUP NEEDED", result.stdout)
             self.assertEqual((claude_dir / ".caveman-active").read_text(encoding="utf-8"), "full")
 
+    # #923: "statuslineNudge": false in caveman's own config declines the badge.
+    # The one-shot marker must stay unwritten so the config key remains the only
+    # gate; consuming it would silently re-enable the nudge if the key were removed.
+    def _run_activate_with_nudge_config(self, tmp_prefix, config):
+        with tempfile.TemporaryDirectory(prefix=tmp_prefix) as tmp:
+            home = Path(tmp)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+            config_dir = home / ".config" / "caveman"
+            config_dir.mkdir(parents=True)
+            if config is not None:
+                (config_dir / "config.json").write_text(
+                    json.dumps(config) + "\n", encoding="utf-8"
+                )
+
+            result = self.run_cmd(
+                ["node", "src/hooks/caveman-activate.js"],
+                home,
+                extra_env={"XDG_CONFIG_HOME": str(home / ".config")},
+            )
+            return result, claude_dir
+
+    def test_activate_config_opt_out_suppresses_statusline_nudge(self):
+        result, claude_dir = self._run_activate_with_nudge_config(
+            "caveman-hooks-nudge-cfg-off-", {"statuslineNudge": False}
+        )
+        self.assertNotIn("STATUSLINE SETUP NEEDED", result.stdout)
+        self.assertFalse((claude_dir / ".caveman-nudge-shown").exists())
+
+    def test_activate_nudges_when_config_opts_in(self):
+        result, _ = self._run_activate_with_nudge_config(
+            "caveman-hooks-nudge-cfg-on-", {"statuslineNudge": True}
+        )
+        self.assertIn("STATUSLINE SETUP NEEDED", result.stdout)
+
+    def test_activate_nudges_when_config_omits_key(self):
+        result, _ = self._run_activate_with_nudge_config(
+            "caveman-hooks-nudge-cfg-absent-", {"defaultMode": "full"}
+        )
+        self.assertIn("STATUSLINE SETUP NEEDED", result.stdout)
+
     # Regression for #587/#589 — hook at <root>/src/hooks/ must resolve SKILL.md
     # at <root>/skills/caveman/, not the nonexistent <root>/src/skills/.
     def test_activate_emits_skill_md_not_fallback_from_repo_layout(self):


### PR DESCRIPTION
Closes #923 (one of two alternatives, see below).

### What this does

Adds a `statuslineNudge` boolean to caveman's own config. Setting it to `false` suppresses the statusline badge nudge.

Resolution lives in a new `statuslineNudgeEnabled()` in `caveman-config.js` and reuses `getDefaultMode()`'s file order: repo-local config (`.caveman/config.json` or `.caveman.json`, walking up) first, then user config (`$XDG_CONFIG_HOME/caveman/config.json` and friends). Absent, non-boolean, or unparseable config returns `true`, matching the module's existing habit of erring toward current behaviour rather than silently changing it.

Like the env-var alternative, the check runs before `.caveman-nudge-shown` is written, so opting out does not consume the one-shot.

### One implementation note worth a look

`caveman-activate.js` resolves the new function defensively:

```js
const statuslineNudgeEnabled =
  (cavemanConfig && typeof cavemanConfig.statuslineNudgeEnabled === 'function')
    ? cavemanConfig.statuslineNudgeEnabled
    : () => true;
```

rather than adding it to the `isUsable` predicate. An older `caveman-config.js` sibling that predates this key is still perfectly usable for mode resolution and flag writes, and demanding the new function there would demote the whole module to the degraded stubs over one optional preference. That seemed contrary to the intent of the #848 guard.

### Why, given #661 already landed the one-shot

The one-shot marker fixed the recurring cost and is the right default, but it still spends a first session on users who will never want a statusline, and the marker lives in `CLAUDE_CONFIG_DIR`, so a fresh config dir brings the nudge back with no way to pre-empt it.

### Tests

Three added to `tests/test_hooks.py`, driven through `XDG_CONFIG_HOME`: `false` suppresses the nudge and leaves the marker unwritten, `true` still nudges, and a config that omits the key still nudges. Full `tests/test_hooks.py` suite passes. `CLAUDE.md` documents the resolver next to `getDefaultMode()`.

### These two PRs are alternatives, merge only one

Both implement the same opt-out from #923 by different mechanisms. They touch the same condition and will conflict with each other by design.

**Preference order:**

1. **#924, the `CAVEMAN_STATUSLINE_NUDGE` env var.** Smallest surface, no new config surface area, settable from a dotfile, and covers a fresh `CLAUDE_CONFIG_DIR`.
2. **This PR, the config key.** Better if you would rather the preference be checked into a repo next to `defaultMode` and survive independently of the environment. Costs a new config key and a new exported function.

A third idea from the issue, suppressing after one showing, turned out to be already shipped in #661. The issue text was written against an older cached plugin build that predates it, and I have corrected the issue accordingly.

Happy to close whichever one you do not want, or to rework either if you would prefer a different name or precedence.
