### PR TITLE
fix(codex): remove deprecated hooks alias

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,5 +1,2 @@
 [features]
-# Both keys: codex-cli renamed codex_hooks → hooks; old versions (<=0.120.0)
-# silently ignore unknown keys, so shipping both activates on either (#617).
 hooks = true
-codex_hooks = true


### PR DESCRIPTION
## Summary

- remove deprecated `[features].codex_hooks` configuration
- retain canonical `[features].hooks` configuration
- eliminate the Codex startup warning

## Verification

- confirmed no `codex_hooks` references remain under `.codex`
- `git diff --check` passes

Documentation: https://developers.openai.com/codex/config-basic#feature-flags