### PR TITLE
fix(installer): avoid CLI bin collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/JuliusBrussee/caveman/issues"
   },
   "bin": {
-    "caveman": "./bin/install.js"
+    "caveman-install": "./bin/install.js"
   },
   "engines": {
     "node": ">=18"

--- a/tests/installer/package-bin.test.mjs
+++ b/tests/installer/package-bin.test.mjs
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function readPackage(...parts) {
+  return JSON.parse(fs.readFileSync(path.join(ROOT, ...parts, 'package.json'), 'utf8'));
+}
+
+function packageBins(pkg) {
+  if (typeof pkg.bin === 'string') {
+    return { [pkg.name.replace(/^@[^/]+\//, '')]: pkg.bin };
+  }
+  return pkg.bin ?? {};
+}
+
+test('installer bin does not collide with the bundled CLI', () => {
+  const installer = readPackage();
+  const cli = readPackage('packages', 'cli');
+  const installerBins = Object.entries(packageBins(installer));
+
+  assert.deepEqual(
+    installerBins.map(([, target]) => target),
+    ['./bin/install.js'],
+    'the GitHub package must expose only the unified installer',
+  );
+
+  const cliBinNames = new Set(Object.keys(packageBins(cli)));
+  for (const [name] of installerBins) {
+    assert.equal(
+      cliBinNames.has(name),
+      false,
+      `installer bin ${name} is overwritten by @caveman-ai/cli during npm exec`,
+    );
+  }
+});


### PR DESCRIPTION
Fixes #881.

The installer package and @caveman-ai/cli both exposed a caveman bin, so npm linked the dependency's CLI over the installer in its temporary environment. This renames the installer's sole bin to caveman-install and adds a regression that prevents future dependency-bin overlap.

Tests:
- `node --test tests/installer/package-bin.test.mjs`
- `pnpm run test:windows`
- `python tests/verify_repo.py`

I also verified the packed package with npm 11.17.0 and pnpm 10.14.0. The full installer suite passed 165 tests and skipped 10; its only local failure was the unchanged Git Bash parser test because Bash is not installed on this machine.