### PR TITLE
fix(cli): support documented version flag

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caveman-ai/cli",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Caveman CLI — wrap coding agents with recoverable local context compression and truthful metering (`caveman claude`), then drive Caveman Cloud from terminal. Compression and metering run in companion Go binaries: run `caveman setup` to see install state. Local savings stay inferred until verified.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -383,6 +383,7 @@ function printDiscovery(group: CommandGroup, all = false): void {
 function resolveInvocation(raw: string[]): ResolvedInvocation {
   const top = raw[0] ?? "help";
   if (top === "--help") return { verb: "help", argv: [], handler: help };
+  if (top === "--version") return { verb: "version", argv: [], handler: LEGACY_HANDLERS.version! };
   if ((top === "tools" || top === "cloud") && raw.length === 1) {
     return { verb: top, argv: [], group: top, handler: () => printDiscovery(top) };
   }

--- a/packages/cli/tests/porcelain.runtime.mjs
+++ b/packages/cli/tests/porcelain.runtime.mjs
@@ -35,6 +35,19 @@ test("bare caveman and --help render byte-equal compact fixture", async () => {
   }
 });
 
+test("--version matches the version command", async () => {
+  const isolated = isolatedCliEnv();
+  try {
+    const command = await runCli(["version"], { env: isolated.env });
+    const flag = await runCli(["--version"], { env: isolated.env });
+    assert.equal(command.code, 0, command.stderr);
+    assert.equal(flag.code, 0, flag.stderr);
+    assert.equal(flag.stdout, command.stdout);
+  } finally {
+    isolated.cleanup();
+  }
+});
+
 test("missing required binary adds only setup install pointer", async () => {
   const isolated = isolatedCliEnv({ CAVEMAN_PROXY_BIN: "/definitely/missing/caveman-proxy" });
   try {


### PR DESCRIPTION
## Summary

- support the documented caveman --version release smoke command
- make flag output byte-identical to caveman version
- bump CLI to 1.3.1 because 1.3.0 was already published before the smoke exposed this gap

## Proof

- pnpm --dir packages/cli build
- node --test --test-force-exit packages/cli/tests/porcelain.runtime.mjs packages/cli/tests/binary-pin.runtime.mjs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/juliusbrussee/caveman/pull/930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->