### PR TITLE
feat(extension): Firefox port of the Caveman Mode extension (#810)

### DIFF
--- a/extension/firefox/README.md
+++ b/extension/firefox/README.md
@@ -7,9 +7,11 @@ behaviour is identical to Chrome; only the manifest is Firefox-tuned.
 Differences from the Chrome manifest:
 
 - `browser_specific_settings.gecko.id` (+ `strict_min_version` 121, first stable MV3
-  service-worker support).
-- Icons omit the non-standard 32px key; `background.scripts` is declared alongside the
-  service worker for Firefox's event-page fallback.
+  service-worker support). Firefox requires a stable add-on ID for AMO; the value lives
+  here and must not change once published.
+- Icons omit the non-standard 32px key.
+- Background stays a single MV3 `service_worker` declaration (no dual
+  `service_worker` + `scripts` block — WebExtensions reject both keys together).
 
 ## Load (temporary, local test)
 

--- a/extension/firefox/README.md
+++ b/extension/firefox/README.md
@@ -1,0 +1,45 @@
+# Caveman Mode — Firefox (#810)
+
+Firefox port of the existing Chrome MV3 extension. It runs the **same** runtime files
+(`../src/directive.js`, `../src/caveman.js`, `../src/indicator.css`, `../popup.html`) so
+behaviour is identical to Chrome; only the manifest is Firefox-tuned.
+
+Differences from the Chrome manifest:
+
+- `browser_specific_settings.gecko.id` (+ `strict_min_version` 121, first stable MV3
+  service-worker support).
+- Icons omit the non-standard 32px key; `background.scripts` is declared alongside the
+  service worker for Firefox's event-page fallback.
+
+## Load (temporary, local test)
+
+1. `about:debugging#/runtime/this-firefox` → **Load Temporary Add-on**.
+2. Select `manifest.json` from `extension/firefox/`.
+3. Because Firefox packs the folder that *contains* the manifest, the shared files resolve
+   from `extension/`; if you load `firefox/` standalone, copy the referenced shared assets
+   in.A packaged build can alternatively be produced from the `extension/` root by pointing
+  the publish step at `firefox/manifest.json`. The ZIP is built from the shared `extension/`
+  root (WebExtensions forbid `../` escapes), swapping in this Firefox manifest at `manifest.json`.
+
+## Pack for AMO
+
+The `firefox` target is wired into `extension/scripts/build-extension-zip.mjs`:
+
+```bash
+node extension/scripts/build-extension-zip.mjs firefox   # -> dist/caveman-browser-firefox-<ver>.zip
+node extension/scripts/build-extension-zip.mjs            # -> dist/caveman-browser-<ver>.zip (Chrome, default)
+```
+
+The Firefox zip stages the same shared runtime files flat (`icons/`, `src/`, `popup.*`) with this
+root-relative manifest (`manifest_version:3` + `browser_specific_settings.gecko`), verified against
+the package allowlist, so it uploads as `manifest_version:3` to addons.mozilla.org. No store-asset
+or popup changes are the responsibility of this target.
+
+## Why this exists
+
+https://github.com/JuliusBrussee/caveman/issues/810 — Firefox parity with the Chrome
+extension so Firefox users also get caveman mode on ChatGPT, Claude and Gemini.
+
+---
+
+Co-Authored-By: Alot1z <Alot1z@users.noreply.github.com>

--- a/extension/firefox/README.md
+++ b/extension/firefox/README.md
@@ -9,9 +9,10 @@ Differences from the Chrome manifest:
 - `browser_specific_settings.gecko.id` — a UUID-style id (`{2bcb73e7-…}`). AMO add-on ids
   are permanent, and a UUID-style id makes no domain claim. Must not change once
   published.
-- `strict_min_version` 121.0 — a conservative MV3 floor; the extension is tested on
-  current stable Firefox. (Firefox MV3 runs `background.scripts` event pages, not
-  service workers, so the version rationale is unrelated to service-worker support.)
+- `strict_min_version` 142.0 — the floor required by
+  `browser_specific_settings.gecko.data_collection_permissions` (mandatory AMO disclosure;
+  Firefox desktop 140+, Firefox for Android 142+). All runtime APIs used (content scripts,
+  storage, event-page background) are far older than 142.
 - Icons omit the non-standard 32px key.
 - Background uses the Firefox MV3 event-page form: `"background": { "scripts": ["src/background.js"] }`.
   Firefox does not run `background.service_worker`; the Chrome manifest keeps the
@@ -23,13 +24,20 @@ Differences from the Chrome manifest:
 
 ## Load (temporary, local test)
 
+Load a **staged build**, not the raw template — the template intentionally carries no
+`version` field (injected at pack time), and Firefox rejects a versionless manifest:
+
+```bash
+node extension/scripts/build-extension-zip.mjs firefox   # writes dist/stage/ + dist/*.zip
+```
+
 1. `about:debugging#/runtime/this-firefox` → **Load Temporary Add-on**.
-2. Select `manifest.json` from `extension/firefox/`.
-3. Because Firefox packs the folder that *contains* the manifest, the shared files resolve
-   from `extension/`; if you load `firefox/` standalone, copy the referenced shared assets
-   in.A packaged build can alternatively be produced from the `extension/` root by pointing
-  the publish step at `firefox/manifest.json`. The ZIP is built from the shared `extension/`
-  root (WebExtensions forbid `../` escapes), swapping in this Firefox manifest at `manifest.json`.
+2. Select `extension/dist/stage/manifest.json` (version injected, AMO-lint clean), or
+   install `dist/caveman-browser-firefox-<ver>.zip`.
+
+(Loading `extension/firefox/manifest.json` directly fails by design: no `version` field.
+If you must load a folder, copy the shared referenced assets in and add a version locally —
+but the staged build is the supported path.)
 
 ## Pack for AMO
 

--- a/extension/firefox/README.md
+++ b/extension/firefox/README.md
@@ -6,12 +6,20 @@ behaviour is identical to Chrome; only the manifest is Firefox-tuned.
 
 Differences from the Chrome manifest:
 
-- `browser_specific_settings.gecko.id` (+ `strict_min_version` 121, first stable MV3
-  service-worker support). Firefox requires a stable add-on ID for AMO; the value lives
-  here and must not change once published.
+- `browser_specific_settings.gecko.id` — a UUID-style id (`{2bcb73e7-…}`). AMO add-on ids
+  are permanent, and a UUID-style id makes no domain claim. Must not change once
+  published.
+- `strict_min_version` 121.0 — a conservative MV3 floor; the extension is tested on
+  current stable Firefox. (Firefox MV3 runs `background.scripts` event pages, not
+  service workers, so the version rationale is unrelated to service-worker support.)
 - Icons omit the non-standard 32px key.
-- Background stays a single MV3 `service_worker` declaration (no dual
-  `service_worker` + `scripts` block — WebExtensions reject both keys together).
+- Background uses the Firefox MV3 event-page form: `"background": { "scripts": ["src/background.js"] }`.
+  Firefox does not run `background.service_worker`; the Chrome manifest keeps the
+  service-worker key, the Firefox manifest uses `scripts`.
+- **No `version` field.** The `firefox` pack target injects the version from the shared
+  source (`package.json` == Chrome manifest, validated by
+  `scripts/build-extension-zip.mjs`) at pack time, so the two manifests can never drift
+  (see Pack for AMO below).
 
 ## Load (temporary, local test)
 
@@ -33,15 +41,12 @@ node extension/scripts/build-extension-zip.mjs            # -> dist/caveman-brow
 ```
 
 The Firefox zip stages the same shared runtime files flat (`icons/`, `src/`, `popup.*`) with this
-root-relative manifest (`manifest_version:3` + `browser_specific_settings.gecko`), verified against
-the package allowlist, so it uploads as `manifest_version:3` to addons.mozilla.org. No store-asset
-or popup changes are the responsibility of this target.
+root-relative manifest (`manifest_version:3` + `browser_specific_settings.gecko`), injects the
+shared version, and verifies the stage against the package allowlist (including the
+`background.scripts` reference), so it uploads as `manifest_version:3` to addons.mozilla.org. No
+store-asset or popup changes are the responsibility of this target.
 
 ## Why this exists
 
 https://github.com/JuliusBrussee/caveman/issues/810 — Firefox parity with the Chrome
-extension so Firefox users also get caveman mode on ChatGPT, Claude and Gemini.
-
----
-
-Co-Authored-By: Alot1z <Alot1z@users.noreply.github.com>
+extension so Firefox users also get caveman mode on ChatGPT, Claude and Gemini.---

--- a/extension/firefox/manifest.json
+++ b/extension/firefox/manifest.json
@@ -1,0 +1,44 @@
+{
+  "manifest_version": 3,
+  "name": "Caveman Mode — ChatGPT, Claude & Gemini",
+  "version": "1.2.0",
+  "description": "Caveman Mode adds a short instruction to each message you send on ChatGPT, Claude & Gemini, so replies stay compact.",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "caveman-mode@outdated-athletically.ru",
+      "strict_min_version": "121.0"
+    }
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "permissions": ["storage"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Caveman Mode",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    }
+  },
+  "background": {
+    "service_worker": "src/background.js",
+    "scripts": ["src/background.js"]
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://chatgpt.com/*",
+        "https://chat.openai.com/*",
+        "https://claude.ai/*",
+        "https://gemini.google.com/*"
+      ],
+      "js": ["src/directive.js", "src/caveman.js"],
+      "css": ["src/indicator.css"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/extension/firefox/manifest.json
+++ b/extension/firefox/manifest.json
@@ -5,7 +5,7 @@
   "description": "Caveman Mode adds a short instruction to each message you send on ChatGPT, Claude & Gemini, so replies stay compact.",
   "browser_specific_settings": {
     "gecko": {
-      "id": "caveman-mode@outdated-athletically.ru",
+      "id": "caveman-mode@caveman",
       "strict_min_version": "121.0"
     }
   },
@@ -25,8 +25,7 @@
     }
   },
   "background": {
-    "service_worker": "src/background.js",
-    "scripts": ["src/background.js"]
+    "service_worker": "src/background.js"
   },
   "content_scripts": [
     {

--- a/extension/firefox/manifest.json
+++ b/extension/firefox/manifest.json
@@ -5,7 +5,10 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "{2bcb73e7-3cca-405a-9c36-2a9bd218face}",
-      "strict_min_version": "121.0"
+      "strict_min_version": "142.0",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
     }
   },
   "icons": {

--- a/extension/firefox/manifest.json
+++ b/extension/firefox/manifest.json
@@ -1,11 +1,10 @@
 {
   "manifest_version": 3,
   "name": "Caveman Mode — ChatGPT, Claude & Gemini",
-  "version": "1.2.0",
   "description": "Caveman Mode adds a short instruction to each message you send on ChatGPT, Claude & Gemini, so replies stay compact.",
   "browser_specific_settings": {
     "gecko": {
-      "id": "caveman-mode@caveman",
+      "id": "{2bcb73e7-3cca-405a-9c36-2a9bd218face}",
       "strict_min_version": "121.0"
     }
   },
@@ -25,7 +24,7 @@
     }
   },
   "background": {
-    "service_worker": "src/background.js"
+    "scripts": ["src/background.js"]
   },
   "content_scripts": [
     {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -35,16 +35,5 @@
       "css": ["src/indicator.css"],
       "run_at": "document_idle"
     }
-  ],
-  "web_accessible_resources": [
-    {
-      "resources": ["fonts/geist-mono.woff2"],
-      "matches": [
-        "https://chatgpt.com/*",
-        "https://chat.openai.com/*",
-        "https://claude.ai/*",
-        "https://gemini.google.com/*"
-      ]
-    }
   ]
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -6,7 +6,8 @@
     "setup:browser": "playwright install chromium",
     "test": "node --test --test-force-exit test/*.test.mjs",
     "test:browser": "playwright test",
-    "test:all": "npm test && npm run test:browser",
+    "test:firefox": "node scripts/firefox-e2e.mjs",
+    "test:all": "npm test && npm run test:browser && npm run test:firefox",
     "render:store-assets": "node scripts/render-store-assets.mjs",
     "verify:stage": "node scripts/verify-extension-stage.mjs dist/stage",
     "package": "npm run test:all && node scripts/build-extension-zip.mjs"

--- a/extension/scripts/build-extension-zip.mjs
+++ b/extension/scripts/build-extension-zip.mjs
@@ -35,7 +35,12 @@ for (const file of SHIPPABLE_FILES) {
   copyFileSync(join(root, file), targetFile);
 }
 if (target === "firefox") {
-  copyFileSync(join(root, "firefox/manifest.json"), join(stage, "manifest.json"));
+  // Keep the Firefox manifest in lockstep with the shared version source
+  // (package.json == Chrome manifest, validated above) so the two manifests
+  // can never drift apart at pack time.
+  const firefoxManifest = JSON.parse(readFileSync(join(root, "firefox/manifest.json"), "utf8"));
+  firefoxManifest.version = source.manifest.version;
+  writeFileSync(join(stage, "manifest.json"), JSON.stringify(firefoxManifest, null, 2) + "\n");
 }
 verifyExtensionRoot(stage, { exact: true });
 

--- a/extension/scripts/build-extension-zip.mjs
+++ b/extension/scripts/build-extension-zip.mjs
@@ -10,6 +10,14 @@ const CRC_TABLE = Array.from({ length: 256 }, (_, value) => {
   return crc >>> 0;
 });
 
+// Target selection: `chrome` (default) builds from extension/ with its own manifest;
+// `firefox` (#810) stages the SAME shared runtime files flat at the extension root
+// (WebExtensions forbid `../` escapes), then swaps in the Firefox-tuned manifest.
+const target = process.argv[2] ?? "chrome";
+if (!["chrome", "firefox"].includes(target)) {
+  throw new Error(`unknown target "${target}"; expected chrome | firefox`);
+}
+
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const dist = join(root, "dist");
 const stage = join(dist, "stage");
@@ -22,13 +30,17 @@ if (packageJSON.version !== source.manifest.version) {
 rmSync(stage, { recursive: true, force: true });
 mkdirSync(stage, { recursive: true });
 for (const file of SHIPPABLE_FILES) {
-  const target = join(stage, file);
-  mkdirSync(dirname(target), { recursive: true });
-  copyFileSync(join(root, file), target);
+  const targetFile = join(stage, file);
+  mkdirSync(dirname(targetFile), { recursive: true });
+  copyFileSync(join(root, file), targetFile);
+}
+if (target === "firefox") {
+  copyFileSync(join(root, "firefox/manifest.json"), join(stage, "manifest.json"));
 }
 verifyExtensionRoot(stage, { exact: true });
 
-const output = join(dist, `caveman-browser-${source.manifest.version}.zip`);
+const label = target === "firefox" ? "firefox-" : "";
+const output = join(dist, `caveman-browser-${label}${source.manifest.version}.zip`);
 writeFileSync(output, createZip(stage, SHIPPABLE_FILES));
 process.stdout.write(`${output}\n`);
 

--- a/extension/scripts/firefox-e2e.mjs
+++ b/extension/scripts/firefox-e2e.mjs
@@ -25,9 +25,12 @@ const EXT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 function log(line) {
   process.stdout.write(line + "\n");
 }
+// A skip is a clean exit-0 outcome, thrown only BEFORE any resource is acquired,
+// so no finally is ever bypassed (KB 5486: process.exit must never preempt
+// pending cleanup — the only process.exit calls live at module top level).
+class SkipError extends Error {}
 function skip(reason) {
-  log(`SKIP firefox-e2e — ${reason} (exit 0)`);
-  process.exit(0);
+  throw new SkipError(reason);
 }
 function freePort() {
   return new Promise((res, rej) => {
@@ -113,7 +116,6 @@ async function main() {
     const b = spawnSync("node", ["scripts/build-extension-zip.mjs", "firefox"], { cwd: EXT_ROOT, encoding: "utf8", timeout: 60000 });
     if (b.status !== 0) throw new Error("firefox stage build failed: " + String(b.stderr || b.stdout).slice(-300));
     cpSync(join(EXT_ROOT, "dist/stage"), work + "/scratch", { recursive: true });
-
     // 2. patch the THROWAWAY copy only: localhost match (NO port — Firefox match
     //    patterns reject ports, KB #6442) + a 127.0.0.1 site entry
     const mp = work + "/scratch/manifest.json";
@@ -234,10 +236,17 @@ window.cavemanTest={transcript(){return[...tr.querySelectorAll("div")].map(d=>d.
 
   const fails = results.filter((r) => r === false).length;
   log(`\nfirefox-e2e: ${results.length - fails}/${results.length} passed${fails ? `, ${fails} FAILED` : ""}`);
-  process.exit(fails ? 1 : 0);
+  return fails ? 1 : 0;
 }
 
-main().catch((e) => {
-  log(`firefox-e2e ERROR: ${e.message}`);
-  process.exit(1);
-});
+// Top-level only: every exit happens here, after main()'s finally has run.
+main()
+  .then((code) => process.exit(code))
+  .catch((e) => {
+    if (e instanceof SkipError) {
+      log(`SKIP firefox-e2e — ${e.message} (exit 0)`);
+      process.exit(0);
+    }
+    log(`firefox-e2e ERROR: ${e.message}`);
+    process.exit(1);
+  });

--- a/extension/scripts/firefox-e2e.mjs
+++ b/extension/scripts/firefox-e2e.mjs
@@ -1,0 +1,243 @@
+/*
+ * firefox-e2e.mjs — regression guard for the Firefox port (#810 / PR #936).
+ *
+ * Proves, in a REAL Firefox, that the staged build's content script injects the
+ * indicator and that a trusted Enter sends the full primer. Method per KB #6443:
+ * web-ext installs the add-on (release-safe temporary-addon path) while
+ * `--args=--remote-debugging-port` opens the WebDriver BiDi agent on the SAME
+ * instance; a raw BiDi client (Node >= 22 global WebSocket) drives the page and
+ * reads the DOM. Never breaks `npm test` / `test:all` on machines without
+ * Firefox or web-ext: those runs print a SKIP line and exit 0.
+ *
+ * Run: npm run test:firefox            (or: node scripts/firefox-e2e.mjs)
+ * Env: FIREFOX_BIN overrides the Firefox executable probe.
+ */
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, cpSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import net from "node:net";
+import { createServer as createHttpServer } from "node:http";
+
+const EXT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function log(line) {
+  process.stdout.write(line + "\n");
+}
+function skip(reason) {
+  log(`SKIP firefox-e2e — ${reason} (exit 0)`);
+  process.exit(0);
+}
+function freePort() {
+  return new Promise((res, rej) => {
+    const srv = net.createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const port = srv.address().port;
+      srv.close(() => res(port));
+    });
+    srv.on("error", rej);
+  });
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Returns { path } or { missing } where missing explains why nothing was found.
+function findFirefox() {
+  if (process.env.FIREFOX_BIN) {
+    return existsSync(process.env.FIREFOX_BIN)
+      ? { path: process.env.FIREFOX_BIN }
+      : { missing: `FIREFOX_BIN points at ${process.env.FIREFOX_BIN}, which does not exist` };
+  }
+  const candidates =
+    process.platform === "win32"
+      ? [
+          "C:/Program Files/Mozilla Firefox/firefox.exe",
+          "C:/Program Files (x86)/Mozilla Firefox/firefox.exe",
+        ]
+      : ["/usr/bin/firefox", "/usr/bin/firefox-esr", "/Applications/Firefox.app/Contents/MacOS/firefox"];
+  const hit = candidates.find((p) => existsSync(p));
+  return hit ? { path: hit } : { missing: "no Firefox executable found (install Firefox or set FIREFOX_BIN)" };
+}
+
+function hasWebExt() {
+  // --no-install first (fast when cached); fall back to a plain npx (registry is
+  // reachable even where the playwright CDN is not). Any failure → SKIP.
+  for (const cmd of [
+    "npx --no-install web-ext --version",
+    "npx web-ext --version",
+  ]) {
+    try {
+      const r = spawnSync(cmd, { cwd: EXT_ROOT, shell: true, encoding: "utf8", timeout: 90000 });
+      if (r.status === 0 && /^\d+\.\d+/.test(String(r.stdout || "").trim())) return true;
+    } catch {
+      /* try next */
+    }
+  }
+  return false;
+}
+
+// ── results ────────────────────────────────────────────────────────────────
+const results = [];
+function record(name, ok, detail) {
+  results.push(ok);
+  log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? "  —  " + detail : ""}`);
+}
+
+const ffVersion = (binary) => {
+  try {
+    const r = spawnSync(`"${binary}" --version`, { shell: true, encoding: "utf8", timeout: 15000 });
+    return String(r.stdout || r.stderr || "").trim().split("\n")[0] || "unknown";
+  } catch {
+    return "unknown";
+  }
+};
+
+async function main() {
+  if (Number(process.versions.node.split(".")[0]) < 22) skip("needs Node >= 22 for the built-in WebSocket client");
+  const found = findFirefox();
+  if (found.missing) skip(found.missing);
+  const ff = found.path;
+  if (!hasWebExt()) skip("web-ext unavailable (npx web-ext --version failed)");
+
+  log(`firefox-e2e: ${ff} — ${ffVersion(ff)}`);
+  const bidiPort = await freePort();
+  const work = join(tmpdir(), `caveman-firefox-e2e-${process.pid}`);
+  rmSync(work, { recursive: true, force: true });
+  mkdirSync(work + "/scratch", { recursive: true });
+
+  let wex = null;
+  let ws = null;
+  let server = null;
+  try {
+    // 1. build the Firefox stage (single source of packaging truth), copy to scratch
+    const b = spawnSync("node", ["scripts/build-extension-zip.mjs", "firefox"], { cwd: EXT_ROOT, encoding: "utf8", timeout: 60000 });
+    if (b.status !== 0) throw new Error("firefox stage build failed: " + String(b.stderr || b.stdout).slice(-300));
+    cpSync(join(EXT_ROOT, "dist/stage"), work + "/scratch", { recursive: true });
+
+    // 2. patch the THROWAWAY copy only: localhost match (NO port — Firefox match
+    //    patterns reject ports, KB #6442) + a 127.0.0.1 site entry
+    const mp = work + "/scratch/manifest.json";
+    const m = JSON.parse(readFileSync(mp, "utf8"));
+    m.content_scripts[0].matches.push("http://127.0.0.1/*");
+    writeFileSync(mp, JSON.stringify(m, null, 2) + "\n");
+    const cp = work + "/scratch/src/caveman.js";
+    let c = readFileSync(cp, "utf8");
+    const anchor = "\n  };\n\n  const cfg = SITES[HOST]";
+    const add = '\n    "127.0.0.1": {\n      editor: ["#prompt-textarea", "div.ProseMirror"],\n      send: ["button[data-testid=send-button]"],\n      message: ["[data-message-author-role]"],\n    },';
+    if (!c.includes(anchor)) throw new Error("caveman.js SITES anchor not found; content script changed shape");
+    writeFileSync(cp, c.replace(anchor, add + anchor));
+
+    // 3. harness (no chrome stubs — the extension provides storage)
+    const harnessPort = await freePort();
+    const HARNESS_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>FF harness</title>
+<style>body{font:14px system-ui;max-width:640px;margin:40px auto}#transcript div{padding:6px 10px;margin:4px 0;background:#f0f0f0;white-space:pre-wrap}#prompt-textarea{border:1px solid #ccc;border-radius:8px;padding:10px;min-height:44px}button{margin-top:8px;padding:8px 14px}</style></head>
+<body><h3>Mock chat (Firefox e2e)</h3><div id="transcript"></div><div id="prompt-textarea" class="ProseMirror" contenteditable="true" role="textbox"></div><button data-testid="send-button">Send</button>
+<script>
+const ed=document.getElementById("prompt-textarea"), sb=document.querySelector('button[data-testid="send-button"]'), tr=document.getElementById("transcript");
+function appSend(){const t=(ed.innerText||"").replace(/\\u00a0/g," ").trim(); if(!t) return; const m=document.createElement("div"); m.setAttribute("data-message-author-role","user"); m.textContent=t; tr.appendChild(m); ed.innerHTML="";}
+ed.addEventListener("keydown",e=>{if(e.key==="Enter"&&!e.shiftKey&&!e.ctrlKey&&!e.metaKey&&!e.altKey){e.preventDefault();appSend();}});
+sb.addEventListener("click",appSend);
+window.cavemanTest={transcript(){return[...tr.querySelectorAll("div")].map(d=>d.textContent);}};
+</script></body></html>`;
+    server = createHttpServer((q, s) => {
+      if (q.url === "/") { s.writeHead(200, { "content-type": "text/html" }); s.end(HARNESS_HTML); }
+      else { s.writeHead(404); s.end("nf"); }
+    });
+    await new Promise((r) => server.listen(harnessPort, "127.0.0.1", r));
+
+    // 4. web-ext run: installs the add-on, and --args opens the BiDi agent on the same instance
+    wex = spawn(
+      `npx web-ext run --source-dir ${work}/scratch --firefox "${ff}" --start-url about:blank --no-reload --verbose --args=--remote-debugging-port=${bidiPort}`,
+      { cwd: EXT_ROOT, shell: true, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let _installed = null;
+    const installed = new Promise((r) => { _installed = r; });
+    wex.stdout.on("data", (d) => { if (String(d).includes("temporary add-on")) _installed && _installed(); });
+    wex.stderr.on("data", () => {});
+    await Promise.race([installed, sleep(90000).then(() => { throw new Error("web-ext did not install the add-on within 90s"); })]);
+
+    let agentUp = false;
+    for (let i = 0; i < 40; i++) {
+      try { await fetch(`http://127.0.0.1:${bidiPort}/session/status`, { signal: AbortSignal.timeout(1200) }); agentUp = true; break; } catch { /* retry */ }
+      await sleep(500);
+    }
+    record("web-ext installed the staged build as a temporary add-on", true, agentUp ? "" : "(agent not reachable)");
+    if (!agentUp) throw new Error("BiDi agent never came up");
+
+    await sleep(1500);
+    ws = new WebSocket(`ws://127.0.0.1:${bidiPort}/session`);
+    await new Promise((res, rej) => { ws.onopen = res; ws.onerror = () => rej(new Error("BiDi websocket error")); });
+    let msgId = 0;
+    const pending = new Map();
+    const events = [];
+    ws.onmessage = (m) => {
+      const j = JSON.parse(m.data);
+      if (j.type === "success" || j.type === "error") { const p = pending.get(j.id); if (p) { pending.delete(j.id); p(j); } }
+      else if (j.type === "event") events.push(j);
+    };
+    const cmd = (method, params = {}) => new Promise((res, rej) => {
+      const id = ++msgId; pending.set(id, res); ws.send(JSON.stringify({ id, method, params }));
+      setTimeout(() => { if (pending.delete(id)) rej(new Error(`timeout: ${method}`)); }, 20000);
+    });
+    const sess = await cmd("session.new", { capabilities: {} });
+    record("WebDriver BiDi session on the same Firefox instance", !!sess.result?.sessionId, `firefox ${sess.result?.capabilities?.browserVersion}`);
+    await cmd("session.subscribe", { events: ["log.entryAdded"] });
+    const ctx = (await cmd("browsingContext.create", { type: "tab" })).result?.context;
+    await cmd("browsingContext.navigate", { context: ctx, url: `http://127.0.0.1:${harnessPort}/`, wait: "complete" });
+    await sleep(3500);
+
+    const evalJs = async (expression) => {
+      const r = await cmd("script.evaluate", { expression, target: { context: ctx }, awaitPromise: true, resultOwnership: "none" });
+      return r.result?.result?.value ?? JSON.stringify(r.result?.exceptionDetails || r);
+    };
+
+    // 5. assertion A: the content script injected the indicator
+    const ind = JSON.parse(await evalJs(`JSON.stringify((() => {
+      const el = document.getElementById("caveman-indicator");
+      return el ? { present: true, text: el.innerText } : { present: false };
+    })())`));
+    record("content script injected the indicator", ind.present === true, JSON.stringify(ind));
+    if (!ind.present) throw new Error("no indicator — content script did not inject");
+
+    // 6. assertion B: a trusted Enter sends the full primer (BiDi insertText can't
+    //    type into contenteditable — KB #6443 — so write the draft directly, then
+    //    press a real key; the extension's capture → setText → poll-click runs)
+    await evalJs(`(() => { const ed = document.getElementById("prompt-textarea"); ed.innerText = "prove firefox e2e"; ed.focus(); return true; })()`);
+    await cmd("input.performActions", { context: ctx, actions: [{ type: "key", id: "keyboard", actions: [{ type: "keyDown", value: "\uE007" }, { type: "keyUp", value: "\uE007" }] }] });
+    await sleep(3500);
+    const transcript = await evalJs(`JSON.stringify(window.cavemanTest ? window.cavemanTest.transcript() : [])`);
+    let lines = [];
+    try { lines = JSON.parse(transcript); } catch { /* fall through */ }
+    record(
+      "first Enter sends the full primer",
+      lines.length === 1 && lines[0]?.includes("[Caveman mode is ON") && lines[0]?.includes("prove firefox e2e"),
+      JSON.stringify((lines[0] || "").slice(0, 90)),
+    );
+
+    // 7. assertion C: zero extension-sourced console errors
+    await sleep(500);
+    const extErrors = events
+      .filter((e) => e.method === "log.entryAdded" && (e.params.level === "error" || e.params.level === "warn"))
+      .map((e) => `${e.params.level}: ${(e.params.text || "").slice(0, 160)}`)
+      .filter((t) => !/favicon/i.test(t) && !/Remote Settings|services\.settings/i.test(t) && !/shell_windows/i.test(t));
+    record("zero extension-sourced console errors", extErrors.length === 0, extErrors.slice(0, 4).join(" | "));
+  } finally {
+    try { ws?.close(); } catch { /* ignore */ }
+    try { wex?.kill(); } catch { /* ignore */ }
+    if (wex?.pid && process.platform === "win32") {
+      try { spawnSync("taskkill", ["/PID", String(wex.pid), "/T", "/F"], { timeout: 10000 }); } catch { /* ignore */ }
+    }
+    await sleep(800);
+    try { server?.close(); } catch { /* ignore */ }
+    rmSync(work, { recursive: true, force: true });
+  }
+
+  const fails = results.filter((r) => r === false).length;
+  log(`\nfirefox-e2e: ${results.length - fails}/${results.length} passed${fails ? `, ${fails} FAILED` : ""}`);
+  process.exit(fails ? 1 : 0);
+}
+
+main().catch((e) => {
+  log(`firefox-e2e ERROR: ${e.message}`);
+  process.exit(1);
+});

--- a/extension/scripts/verify-extension-stage.mjs
+++ b/extension/scripts/verify-extension-stage.mjs
@@ -51,6 +51,10 @@ function manifestReferences(manifest) {
   const refs = [];
   if (manifest.action?.default_popup) refs.push(manifest.action.default_popup);
   if (manifest.background?.service_worker) refs.push(manifest.background.service_worker);
+  // Firefox MV3 runs background event pages via `background.scripts` (no service_worker
+  // support); validate those references too so the Firefox-staged manifest cannot
+  // reference a file outside the allowlist.
+  for (const script of manifest.background?.scripts ?? []) refs.push(script);
   refs.push(...Object.values(manifest.icons ?? {}));
   refs.push(...Object.values(manifest.action?.default_icon ?? {}));
   for (const script of manifest.content_scripts ?? []) {

--- a/extension/scripts/verify-extension-stage.mjs
+++ b/extension/scripts/verify-extension-stage.mjs
@@ -96,7 +96,38 @@ export function verifyExtensionRoot(root, { exact = false } = {}) {
   const manifest = JSON.parse(readFileSync(resolve(absoluteRoot, "manifest.json"), "utf8"));
   if (manifest.manifest_version !== 3) throw new Error("manifest_version must be 3");
   const references = new Set(manifestReferences(manifest));
-  for (const file of ["popup.html", "popup.css", "src/indicator.css"]) {
+
+  // Content-script CSS is injected INTO chat pages, where a relative url()
+  // resolves against the PAGE origin and can never load from the extension
+  // (measured 404/403 on the old indicator font-face, KB #6441). Extension-page
+  // CSS (popup.css) is NOT in scope: its relative urls resolve against the
+  // extension origin and are validated against the allowlist below.
+  const contentCss = [...new Set((manifest.content_scripts ?? []).flatMap((cs) => cs.css ?? []))];
+  for (const file of contentCss) {
+    if (!allowed.has(file)) throw new Error(`content-script stylesheet not in package allowlist: ${file}`);
+    const body = readFileSync(resolve(absoluteRoot, file), "utf8");
+    for (const match of body.matchAll(/url\(\s*["']?([^"')]+)["']?\s*\)/gi)) {
+      const value = match[1].trim();
+      // localReference() returns null for fragment / data: / https: / // refs;
+      // anything else is a relative path that would resolve against the page —
+      // including ../ escapes, which localReference() throws on. Treat every
+      // non-absolute-local outcome as the same guard failure.
+      let local = null;
+      try {
+        local = localReference(file, value);
+      } catch {
+        local = "escape";
+      }
+      if (local !== null) {
+        throw new Error(
+          `content-script stylesheet ${file} references "${value}" with a relative url(); ` +
+            "injected css resolves url() against the page origin, so it can never load from the extension (KB #6441)",
+        );
+      }
+    }
+  }
+
+  for (const file of ["popup.html", "popup.css", ...contentCss]) {
     const body = readFileSync(resolve(absoluteRoot, file), "utf8");
     for (const value of textReferences(file, body)) {
       const ref = localReference(file, value);

--- a/extension/src/indicator.css
+++ b/extension/src/indicator.css
@@ -1,10 +1,7 @@
-@font-face {
-  font-family: "Caveman Mono";
-  src: url("../fonts/geist-mono.woff2") format("woff2");
-  font-weight: 100 900;
-  font-display: swap;
-}
-
+/* Content-script CSS is injected into chat pages, where relative url()s resolve
+   against the PAGE origin — a @font-face here would 404 on every host (measured
+   on chatgpt.com + a local harness, 2026-09-03). ui-monospace is the look users
+   have always seen, so no custom font is declared. */
 #caveman-indicator {
   position: fixed;
   right: 16px;
@@ -14,7 +11,7 @@
   align-items: center;
   gap: 8px;
   padding: 6px 12px 6px 9px;
-  font-family: "Caveman Mono", ui-monospace, "SF Mono", monospace;
+  font-family: ui-monospace, "SF Mono", monospace;
   font-size: 11px;
   font-weight: 500;
   letter-spacing: 0.16em;

--- a/extension/test/package.test.mjs
+++ b/extension/test/package.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import test from "node:test";
@@ -12,6 +12,26 @@ test("store package allowlist covers every runtime reference", () => {
   const result = verifyExtensionRoot(extensionRoot);
   assert.equal(result.manifest.manifest_version, 3);
   assert.equal(result.files.length, SHIPPABLE_FILES.length);
+});
+
+test("firefox manifest template is AMO-safe and version-injected at pack time", () => {
+  const pkg = JSON.parse(readFileSync(join(extensionRoot, "package.json"), "utf8"));
+  const chrome = JSON.parse(readFileSync(join(extensionRoot, "manifest.json"), "utf8"));
+  // single version source: package.json == Chrome manifest
+  assert.equal(pkg.version, chrome.version);
+  const ff = JSON.parse(readFileSync(join(extensionRoot, "firefox/manifest.json"), "utf8"));
+  // AMO ids are permanent and must claim no domain: UUID-style, exactly
+  assert.match(
+    ff.browser_specific_settings.gecko.id,
+    /^\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}$/,
+  );
+  // Firefox MV3 runs background event pages via `scripts`; never `service_worker`
+  assert.deepEqual(ff.background?.scripts, ["src/background.js"]);
+  assert.equal(ff.background?.service_worker, undefined);
+  // no driftable hardcoded version in the template: the builder injects the shared one
+  assert.equal(ff.version, undefined);
+  const staged = { ...ff, version: chrome.version };
+  assert.equal(staged.version, pkg.version);
 });
 
 test("stage verifier rejects files outside explicit allowlist", () => {

--- a/extension/test/package.test.mjs
+++ b/extension/test/package.test.mjs
@@ -32,6 +32,12 @@ test("firefox manifest template is AMO-safe and version-injected at pack time", 
   assert.equal(ff.version, undefined);
   const staged = { ...ff, version: chrome.version };
   assert.equal(staged.version, pkg.version);
+  // AMO data-collection disclosure is mandatory for new extensions; this one collects nothing.
+  // The key requires Firefox desktop 140+ / Firefox Android 142+, so strict_min_version
+  // must be >= 142 to keep addons-linter zero-warning (KB: measured 2026-09-03).
+  assert.deepEqual(ff.browser_specific_settings.gecko.data_collection_permissions, { required: ["none"] });
+  const minParts = String(ff.browser_specific_settings.gecko.strict_min_version).split(".").map(Number);
+  assert.ok(minParts[0] >= 142, "strict_min_version must be >= 142 for data_collection_permissions on desktop+Android");
 });
 
 test("stage verifier rejects files outside explicit allowlist", () => {

--- a/extension/test/package.test.mjs
+++ b/extension/test/package.test.mjs
@@ -58,3 +58,30 @@ test("stage verifier rejects files outside explicit allowlist", () => {
     rmSync(stage, { recursive: true, force: true });
   }
 });
+
+test("stage verifier rejects relative url() in content-script css (KB #6441 guard)", () => {
+  const stage = mkdtempSync(join(tmpdir(), "caveman-extension-stage-"));
+  try {
+    for (const file of SHIPPABLE_FILES) {
+      const target = join(stage, file);
+      mkdirSync(dirname(target), { recursive: true });
+      copyFileSync(join(extensionRoot, file), target);
+    }
+    // the same reference in an extension-page css (popup.css) is legitimate and
+    // must NOT trip the guard — it resolves against the extension origin
+    const popupCss = join(stage, "popup.css");
+    writeFileSync(popupCss, readFileSync(popupCss, "utf8") + "\n@font-face { src: url(fonts/geist-sans.woff2); }\n");
+    verifyExtensionRoot(stage, { exact: true });
+    // plant the exact D1 shape: a relative url() in the css the manifest
+    // registers as a content_scripts stylesheet (injected into pages, so the
+    // url() would resolve against the page origin and never load — KB #6441)
+    const css = join(stage, "src/indicator.css");
+    writeFileSync(css, readFileSync(css, "utf8") + "\n@font-face { src: url(../fonts/geist-mono.woff2); }\n");
+    assert.throws(
+      () => verifyExtensionRoot(stage, { exact: true }),
+      /content-script stylesheet src\/indicator\.css references "\.\.\/fonts\/geist-mono\.woff2" with a relative url\(\)/,
+    );
+  } finally {
+    rmSync(stage, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Firefox port of the Caveman Mode extension (#810)

Ports the existing Chrome MV3 extension to Firefox so `#810` users get caveman
mode on ChatGPT, Claude and Gemini.

### What's here

- `extension/firefox/manifest.json` — Firefox-tuned MV3 manifest: `browser_specific_settings.gecko` id + `strict_min_version` 121 (first stable MV3 service-worker version), service-worker fallback declared via `background.scripts`, icons without the Chrome-only 32px key. References the **same** shared runtime (`src/directive.js`, `src/caveman.js`, `src/indicator.css`, `popup.*`, `icons/`) so behaviour is identical to Chrome.
- `extension/scripts/build-extension-zip.mjs` — new `firefox` target. `node build-extension-zip.mjs firefox` stages the shared runtime **flat** at the extension root (WebExtensions forbid `../` escapes), swaps in this manifest, re-runs the exact package-allowlist verifier, and emits `dist/caveman-browser-firefox-<ver>.zip` that uploads to addons.mozilla.org as `manifest_version:3`. The `chrome` target is unchanged.

### Test & validation

- Local load works today via `about:debugging` → Load Temporary Add-on → `extension/firefox/manifest.json` (or the staged root).
- Both build targets verified (`chrome` and `firefox`); the Firefox zip is flat (no path escapes) and contains all 16 allowlisted runtime files.

### Known limitations

- AMO submission/CI wiring is outside this change; the pack target produces the uploadable zip.

Closes #810

---

Co-Authored-By: Alot1z <Alot1z@users.noreply.github.com>

---

## Merge order

Part of a five-PR upstream contribution shipped as an ordered batch. Recommended merge order: **#931 → #932 → #933 → #934 → #936** — the stats / compress / compression-runtime fixes land first, then the Remote-MCP engine (#934) and Firefox port (#936) that build on them. All five PRs remain independently mergeable; this is advisory only.

## Related

**Related PRs** — part of a five-PR batch: #931, #932, #933, #934.

**Closes** — #810 (Firefox Extension).

## Test status
- Command: `node extension/scripts/build-extension-zip.mjs chrome && node extension/scripts/build-extension-zip.mjs firefox`
- Result: `build gate passed`