### PR TITLE
fix: update retired benchmark model

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -303,7 +303,7 @@ def main():
     parser.add_argument("--trials", type=int, default=3, help="Trials per prompt per mode (default: 3)")
     parser.add_argument("--dry-run", action="store_true", help="Print config, no API calls")
     parser.add_argument("--update-readme", action="store_true", help="Update README.md benchmark table")
-    parser.add_argument("--model", default="claude-sonnet-4-20250514", help="Model to use")
+    parser.add_argument("--model", default="claude-sonnet-4-6", help="Model to use")
     args = parser.parse_args()
 
     if args.trials < 1:

--- a/tests/test_benchmark_contract.py
+++ b/tests/test_benchmark_contract.py
@@ -1,4 +1,6 @@
 import importlib.util
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -12,6 +14,17 @@ SPEC.loader.exec_module(BENCHMARK)
 
 
 class BenchmarkContractTests(unittest.TestCase):
+    def test_dry_run_defaults_to_supported_model(self):
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "benchmarks" / "run.py"), "--dry-run", "--trials", "1"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.splitlines()[0], "Model:  claude-sonnet-4-6")
+
     def test_readme_has_one_replaceable_benchmark_region(self):
         readme = (ROOT / "README.md").read_text(encoding="utf-8")
         self.assertEqual(readme.count(BENCHMARK.BENCHMARK_START), 1)


### PR DESCRIPTION
## Summary

- Fixes: Running benchmarks/run.py without --model selects claude-sonnet-4-20250514, which Anthropic retired on 2026-06-15, so a live benchmark fails with a 404 before collecting results.
- Root cause: The argparse default remained pinned to the retired dated model even though Anthropic documents claude-sonnet-4-6 as its supported replacement.

Fixes #519. See Anthropic's [model deprecation table](https://platform.claude.com/docs/en/docs/about-claude/model-deprecations).

## Regression evidence

- Before: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_benchmark_contract.BenchmarkContractTests.test_dry_run_defaults_to_supported_model -v` exited `1`

- After: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_benchmark_contract.BenchmarkContractTests.test_dry_run_defaults_to_supported_model -v` exited `0`

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_benchmark_contract -v`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v`
- `npm test`
- `node --test --test-force-exit tests/*.js`
- `PYTHONDONTWRITEBYTECODE=1 python3 tests/verify_repo.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 benchmarks/run.py --dry-run --trials 1`

## Scope

- 2 files changed, +14 / -1 lines
