### PR TITLE
fix(compress): validate candidates before touching the live file

### DIFF
--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -663,35 +663,37 @@ def _compress_file_locked(filepath: Path) -> bool:
         except OSError:
             pass
         return False
-    _write_target(filepath, compressed, backup_path, newline)
-
-    # Step 2: Validate + Retry
+    # Step 2: Validate + Retry. Each candidate is staged and validated next
+    # to the source; the live file is written only once one passes (#544).
+    staging_path = filepath.with_name(filepath.name + ".caveman-staged")
     for attempt in range(MAX_RETRIES):
         print(f"\nValidation attempt {attempt + 1}")
 
-        result = validate(backup_path, filepath)
+        _write_target(staging_path, compressed, backup_path, newline)
+        result = validate(backup_path, staging_path)
 
         if result.is_valid:
             print("Validation passed")
-            break
+            _write_target(filepath, compressed, backup_path, newline)
+            staging_path.unlink(missing_ok=True)
+            return True
 
         print("❌ Validation failed:")
         for err in result.errors:
             print(f"   - {err}")
 
         if attempt == MAX_RETRIES - 1:
-            # Restore original on failure
-            _write_target(filepath, original_raw, backup_path, newline)
+            staging_path.unlink(missing_ok=True)
             backup_path.unlink(missing_ok=True)
-            print("❌ Failed after retries — original restored")
+            print("Failed after retries: original left untouched")
             return False
 
         print("Fixing with Claude...")
-        compressed = call_claude(
+        fixed = call_claude(
             build_fix_prompt(original_text, compressed, result.errors)
         )
 
-        if compressed is None or not compressed.strip():
+        if fixed is None or not fixed.strip():
             print("❌ Fix attempt aborted: Claude returned an empty response.")
             print("   Skipping this attempt.")
             continue
@@ -702,11 +704,11 @@ def _compress_file_locked(filepath: Path) -> bool:
         # first lines get legitimately rewritten by compression, and requiring
         # them verbatim would reject every valid fix.
         anchor = first_nonblank_line(original_text)
-        if anchor.startswith(("---", "#")) and first_nonblank_line(compressed) != anchor:
+        if anchor.startswith(("---", "#")) and first_nonblank_line(fixed) != anchor:
             print("❌ Fix attempt aborted: output does not start with the original's first line.")
             print("   Possible preamble leak. Skipping this attempt.")
             continue
 
-        _write_target(filepath, compressed, backup_path, newline)
+        compressed = fixed
 
-    return True
+    return False

--- a/tests/test_compress_safety.py
+++ b/tests/test_compress_safety.py
@@ -182,8 +182,8 @@ class CompressSafetyTests(unittest.TestCase):
 
     def test_retry_preamble_output_rejected_and_not_written(self):
         # A fix-retry response with a prose preamble ahead of the real content
-        # must never reach disk — only the restore-on-failure write should
-        # land, and it must restore the original (issue #588).
+        # must never reach disk, staging included, and the live file must be
+        # left holding the original (issue #588).
         with tempfile.TemporaryDirectory() as tmp, \
              tempfile.TemporaryDirectory() as data_home, \
              mock.patch.dict(os.environ, {"XDG_DATA_HOME": data_home, "LOCALAPPDATA": data_home}):
@@ -209,6 +209,55 @@ class CompressSafetyTests(unittest.TestCase):
             self.assertFalse(ok)
             self.assertNotIn(preamble_fix, written_texts)
             self.assertEqual(path.read_text(encoding="utf-8"), original)
+
+    def test_live_file_never_holds_unvalidated_output_before_validation_passes(self):
+        # validate() must never see the live file already holding the
+        # un-validated candidate (issue #544).
+        with tempfile.TemporaryDirectory() as tmp, \
+             tempfile.TemporaryDirectory() as data_home, \
+             mock.patch.dict(os.environ, {"XDG_DATA_HOME": data_home, "LOCALAPPDATA": data_home}):
+            original = "# Heading\n\nProse to compress, long enough to pass the identity check here.\n"
+            compressed = "# Heading\n\nProse.\n"
+            path = self._file_with(Path(tmp), original)
+
+            seen_live_contents = []
+
+            def spy_validate(orig_path, comp_path):
+                seen_live_contents.append(path.read_text(encoding="utf-8"))
+                return mock.Mock(is_valid=True, errors=[], warnings=[])
+
+            with mock.patch.object(compress_mod, "call_claude", return_value=compressed), \
+                 mock.patch.object(compress_mod, "validate", side_effect=spy_validate):
+                ok = compress_mod.compress_file(path)
+
+            self.assertTrue(ok)
+            self.assertEqual(seen_live_contents, [original])
+            self.assertEqual(path.read_text(encoding="utf-8"), compressed)
+            self.assertFalse((Path(tmp) / (path.name + ".caveman-staged")).exists())
+
+    def test_live_file_untouched_when_all_validation_attempts_fail(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+             tempfile.TemporaryDirectory() as data_home, \
+             mock.patch.dict(os.environ, {"XDG_DATA_HOME": data_home, "LOCALAPPDATA": data_home}):
+            original = "# Heading\n\nProse to compress, long enough to pass the identity check here.\n"
+            compressed = "# Heading\n\nProse.\n"
+            path = self._file_with(Path(tmp), original)
+
+            invalid = mock.Mock(is_valid=False, errors=["some validation error"], warnings=[])
+            seen_live_contents = []
+
+            def spy_validate(orig_path, comp_path):
+                seen_live_contents.append(path.read_text(encoding="utf-8"))
+                return invalid
+
+            with mock.patch.object(compress_mod, "call_claude", return_value=compressed), \
+                 mock.patch.object(compress_mod, "validate", side_effect=spy_validate):
+                ok = compress_mod.compress_file(path)
+
+            self.assertFalse(ok)
+            self.assertEqual(seen_live_contents, [original] * compress_mod.MAX_RETRIES)
+            self.assertEqual(path.read_text(encoding="utf-8"), original)
+            self.assertFalse((Path(tmp) / (path.name + ".caveman-staged")).exists())
 
     def test_non_utf8_input_refused_before_anything_is_written(self):
         """errors="ignore" used to drop the undecodable byte, write the mangled


### PR DESCRIPTION
## Summary

`compress_file()` wrote each candidate straight to the live source file and
validated it there. An interruption between that write and a passing
validation (Ctrl-C, SIGTERM, OOM, a harness killing the process) left the
live file holding un-validated or garbage output, with the out-of-tree
backup as the only recovery path.

Each candidate is now staged next to the source (`<file>.caveman-staged`)
and validated there. The live file is written only once a candidate passes,
and is left untouched if every attempt fails, so there is nothing to
restore.

Out of scope: the issue's secondary point (a pre-write heuristic to catch a
conversational summary standing in for the compressed body) is a separate,
optional guard and isn't part of this change.

## Verification

- New regression tests fail on unmodified main and pass on this branch:
  `python -m unittest tests.test_compress_safety.CompressSafetyTests.test_live_file_never_holds_unvalidated_output_before_validation_passes tests.test_compress_safety.CompressSafetyTests.test_live_file_untouched_when_all_validation_attempts_fail`
- Full suite green on Python 3.11 and 3.13 (Linux): `python -m unittest discover -s tests`, plus `tests/verify_repo.py`'s Compress Fixtures and Compress CLI checks.
- Not verified: Windows and macOS runtime behavior beyond what the Linux suite covers.

Fixes #544
