### PR TITLE
fix(pi): route opencode-go through compat mount

### DIFF
--- a/docs/technical/configuration.md
+++ b/docs/technical/configuration.md
@@ -143,6 +143,7 @@ ANTHROPIC_API_KEY
 OPENAI_API_KEY
 GEMINI_API_KEY
 AZURE_OPENAI_API_KEY
+OPENCODE_API_KEY
 ```
 
 Amazon Bedrock supports its native authentication paths, including AWS

--- a/docs/technical/proxy-and-providers.md
+++ b/docs/technical/proxy-and-providers.md
@@ -98,6 +98,11 @@ Each mount declares `base_url` and an environment-variable name containing its
 credential. Compatibility means HTTP shape, not guaranteed support for every
 provider extension.
 
+One mount is built in. The proxy registers `/compat/opencode-go/` with the
+upstream `https://opencode.ai/zen/go` and the credential variable
+`OPENCODE_API_KEY`. A `compat` entry with the name `opencode-go` in
+`caveman.yaml` replaces the built-in mount and can set another endpoint.
+
 ## Modes
 
 | Mode | Request behavior |

--- a/packages/pi-extension/src/protocol.ts
+++ b/packages/pi-extension/src/protocol.ts
@@ -76,9 +76,10 @@ export function outputReplacementOf(response: HookResponse | undefined): string 
   return replacement ? replacement : undefined;
 }
 
-// Route table: which Pi model API maps to which path under the local gateway.
-// APIs absent here (azure/bedrock/vertex/mistral/codex-responses/…) are
-// unsupported and must never be routed (honesty: no guessed protocol).
+// This route table maps each Pi model API to a path under the local gateway.
+// An API that is not in this table is unsupported, for example azure, bedrock,
+// vertex, mistral, and codex-responses. The extension never routes such an API,
+// because it does not guess a wire protocol.
 export const ROUTES_BY_API: Readonly<Record<string, string>> = {
   "anthropic-messages": "/w/pi",
   "openai-completions": "/w/pi/openai/v1",
@@ -86,7 +87,26 @@ export const ROUTES_BY_API: Readonly<Record<string, string>> = {
   "google-generative-ai": "/w/pi/v1beta",
 };
 
-export function routeForApi(gateway: string, api: string | undefined): string | undefined {
+// OpenCode Go uses the OpenAI and Anthropic wire protocols, but its upstream is
+// not api.openai.com. This provider mount gives the proxy the correct upstream.
+const ROUTES_BY_PROVIDER_API: Readonly<Record<string, Readonly<Record<string, string>>>> = {
+  "opencode-go": {
+    "anthropic-messages": "/w/pi/compat/opencode-go",
+    "openai-completions": "/w/pi/compat/opencode-go/v1",
+    "openai-responses": "/w/pi/compat/opencode-go/v1",
+  },
+};
+
+// If the caller gives a provider, this function routes only the providers that the
+// local proxy can resolve. If the caller gives no provider, the function keeps the
+// API-only behavior for existing callers.
+export function routeForApi(gateway: string, api: string | undefined, provider?: string): string | undefined {
+  const providerRoutes = provider ? ROUTES_BY_PROVIDER_API[provider] : undefined;
+  if (provider && providerRoutes) {
+    const path = api ? providerRoutes[api] : undefined;
+    return path ? joinUrl(gateway, path) : undefined;
+  }
+  if (provider && provider !== "anthropic" && provider !== "openai" && provider !== "google") return undefined;
   const path = api ? ROUTES_BY_API[api] : undefined;
   return path ? joinUrl(gateway, path) : undefined;
 }

--- a/packages/pi-extension/src/provider.ts
+++ b/packages/pi-extension/src/provider.ts
@@ -49,7 +49,7 @@ export class ProviderRouter {
   async apply(model: ExtensionContext["model"], ctx: ExtensionContext): Promise<void> {
     if (!this.gateOpen || this.applying || !this.gateway) return;
     if (!model) return;
-    const route = routeForApi(this.gateway, model.api);
+    const route = routeForApi(this.gateway, model.api, model.provider);
     let oauth = true;
     try {
       oauth = ctx.modelRegistry.isUsingOAuth(model);
@@ -61,7 +61,9 @@ export class ProviderRouter {
       const key = `${model.provider}/${model.id}`;
       if (!this.warnedModels.has(key)) {
         this.warnedModels.add(key);
-        const reason = oauth ? "OAuth/subscription credentials are not routed" : `unsupported API "${model.api}"`;
+        const reason = oauth
+          ? "OAuth/subscription credentials are not routed"
+          : `unsupported provider/API "${model.provider}/${model.api}"`;
         this.notify(`Caveman: pass-through for ${key} (${reason}); no compression`, "warning");
       }
       return;

--- a/packages/pi-extension/tests/fixtures/stub-provider-extension.mjs
+++ b/packages/pi-extension/tests/fixtures/stub-provider-extension.mjs
@@ -1,8 +1,9 @@
 // Registers a loopback test provider so integration runs never leave the
 // machine: direct (ungated) traffic fast-fails on a dead local port, and gated
-// traffic goes wherever the caveman extension routes it.
+// traffic goes wherever the caveman extension routes it. The provider id is
+// "openai" because routeForApi routes only allowlisted provider names.
 export default function (pi) {
-  pi.registerProvider("stubprov", {
+  pi.registerProvider("openai", {
     name: "Stub Provider",
     baseUrl: "http://127.0.0.1:1",
     apiKey: "dummy-key-for-stub",

--- a/packages/pi-extension/tests/integration.runtime.mjs
+++ b/packages/pi-extension/tests/integration.runtime.mjs
@@ -184,7 +184,7 @@ test("open gate: first request routes through /w/pi with Core in the system prom
     const out = await runPi(fx.env, [
       "--extension", stubProviderExtension, "--extension", extension,
       "--no-session", "--no-skills", "--no-context-files", "--no-prompt-templates", "--no-themes", "--no-extensions",
-      "--provider", "stubprov", "--model", "stub-model",
+      "--provider", "openai", "--model", "stub-model",
       "-p", "say hi",
     ]);
     assert.match(out.stdout, /CAVEMAN_STUB_OK/, `stdout: ${out.stdout}\nstderr: ${out.stderr}`);
@@ -209,7 +209,7 @@ test("closed gate (no run-state): zero proxy requests and a visible direct-mode 
     const out = await runPi(fx.env, [
       "--extension", stubProviderExtension, "--extension", extension,
       "--no-session", "--no-skills", "--no-context-files", "--no-prompt-templates", "--no-themes", "--no-extensions",
-      "--provider", "stubprov", "--model", "stub-model",
+      "--provider", "openai", "--model", "stub-model",
       "-p", "say hi",
     ]);
     // Direct mode points at the dead loopback port the stub provider declares —
@@ -230,7 +230,7 @@ test("published recovery=false: gate refuses even with a live proxy and working 
     const out = await runPi(fx.env, [
       "--extension", stubProviderExtension, "--extension", extension,
       "--no-session", "--no-skills", "--no-context-files", "--no-prompt-templates", "--no-themes", "--no-extensions",
-      "--provider", "stubprov", "--model", "stub-model",
+      "--provider", "openai", "--model", "stub-model",
       "-p", "say hi",
     ]);
     // Proxy is alive (health probe hits the stub) but published recovery is

--- a/packages/pi-extension/tests/protocol.runtime.mjs
+++ b/packages/pi-extension/tests/protocol.runtime.mjs
@@ -28,6 +28,15 @@ test("route table maps supported APIs and refuses everything else", () => {
   assert.equal(routeForApi(gw, "openai-completions"), `${gw}/w/pi/openai/v1`);
   assert.equal(routeForApi(gw, "openai-responses"), `${gw}/w/pi/openai/v1`);
   assert.equal(routeForApi(gw, "google-generative-ai"), `${gw}/w/pi/v1beta`);
+  assert.equal(routeForApi(gw, "openai-responses", "opencode-go"), `${gw}/w/pi/compat/opencode-go/v1`);
+  assert.equal(routeForApi(gw, "openai-completions", "opencode-go"), `${gw}/w/pi/compat/opencode-go/v1`);
+  assert.equal(routeForApi(gw, "anthropic-messages", "opencode-go"), `${gw}/w/pi/compat/opencode-go`);
+  assert.equal(routeForApi(gw, "openai-responses", "openrouter"), undefined, "unknown provider must not inherit OpenAI upstream");
+  assert.equal(routeForApi(gw, "anthropic-messages", "anthropic"), `${gw}/w/pi`);
+  assert.equal(routeForApi(gw, "openai-completions", "openai"), `${gw}/w/pi/openai/v1`);
+  assert.equal(routeForApi(gw, "openai-responses", "openai"), `${gw}/w/pi/openai/v1`);
+  assert.equal(routeForApi(gw, "google-generative-ai", "google"), `${gw}/w/pi/v1beta`);
+  assert.equal(routeForApi(gw, "openai-completions", "stubprov"), undefined, "provider outside allowlist must not route");
   for (const api of ["azure-openai-responses", "openai-codex-responses", "mistral-conversations", "google-vertex", "bedrock-converse-stream", "made-up", undefined]) {
     assert.equal(routeForApi(gw, api), undefined, `api ${api} must not route`);
   }

--- a/proxy/internal/config/config.go
+++ b/proxy/internal/config/config.go
@@ -306,11 +306,38 @@ func (c Config) Credential(provider string) providers.Credential {
 	return providers.Credential{Mode: "ephemeral_header"}
 }
 
-// CompatCredential returns the named OpenAI-compatible upstream key, plus
-// whether that upstream exists. An empty api_key_env intentionally means no
-// Authorization header for that named upstream.
+// builtinCompat holds the named OpenAI-compatible upstreams that work with no
+// user config. The standalone proxy mounts each one at /compat/<name>/, and
+// CompatCredential resolves its key. Thus one table gives a mount and its BYOK
+// policy. A caveman.yaml compat entry with the same name replaces the built-in
+// entry.
+var builtinCompat = map[string]CompatConfig{
+	// OpenCode Go uses the OpenAI and Anthropic wire protocols, but its upstream
+	// is not api.openai.com. Its key comes from OPENCODE_API_KEY, as in Pi.
+	"opencode-go": {BaseURL: "https://opencode.ai/zen/go", APIKeyEnv: "OPENCODE_API_KEY"},
+}
+
+// CompatUpstreams returns every named OpenAI-compatible upstream that the proxy
+// mounts. The result starts with the built-in table. Then the caveman.yaml
+// entries go on top, so a user entry with a built-in name replaces the built-in
+// entry. The result is a new map.
+func (c Config) CompatUpstreams() map[string]CompatConfig {
+	merged := make(map[string]CompatConfig, len(builtinCompat)+len(c.Compat))
+	for name, upstream := range builtinCompat {
+		merged[name] = upstream
+	}
+	for name, upstream := range c.Compat {
+		merged[name] = upstream
+	}
+	return merged
+}
+
+// CompatCredential returns the key of one named OpenAI-compatible upstream. The
+// second result is false if no built-in entry and no configured entry has this
+// name. An empty api_key_env means that the upstream needs no Authorization
+// header.
 func (c Config) CompatCredential(name string) (string, bool) {
-	upstream, ok := c.Compat[name]
+	upstream, ok := c.CompatUpstreams()[name]
 	if !ok {
 		return "", false
 	}

--- a/proxy/internal/config/config_test.go
+++ b/proxy/internal/config/config_test.go
@@ -3,7 +3,10 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/JuliusBrussee/caveman/proxy/providers/openaicompat"
 )
 
 func TestLoad_MissingFileYieldsRecordDefaults(t *testing.T) {
@@ -307,6 +310,57 @@ func TestCompatCredential_UsesPerNameEnvAndEmptyMeansNoAuth(t *testing.T) {
 	}
 	if got, ok := cfg.CompatCredential("missing"); ok || got != "" {
 		t.Errorf("missing credential = (%q,%v), want (\"\",false)", got, ok)
+	}
+}
+
+// A built-in compat mount has its own BYOK policy with no user config. Thus a
+// keyless request never uses the OPENAI_COMPAT_API_KEY secret.
+func TestCompatCredential_BuiltinMountReadsItsOwnEnv(t *testing.T) {
+	t.Setenv("OPENCODE_API_KEY", "sk-opencode")
+	t.Setenv("OPENAI_COMPAT_API_KEY", "sk-legacy")
+	if got, ok := (Config{}).CompatCredential("opencode-go"); !ok || got != "sk-opencode" {
+		t.Errorf("opencode-go credential = (%q,%v), want (sk-opencode,true)", got, ok)
+	}
+}
+
+func TestCompatUpstreams_UserEntryWins(t *testing.T) {
+	builtin := Config{}.CompatUpstreams()
+	if got := builtin["opencode-go"].BaseURL; got != "https://opencode.ai/zen/go" {
+		t.Fatalf("built-in opencode-go base_url = %q, want the OpenCode Go upstream", got)
+	}
+	user := CompatConfig{BaseURL: "https://opencode.example.test", APIKeyEnv: "OPENCODE_ZEN_API_KEY"}
+	cfg := Config{Compat: map[string]CompatConfig{
+		"opencode-go": user,
+		"openrouter":  {BaseURL: "https://openrouter.ai/api", APIKeyEnv: "OPENROUTER_API_KEY"},
+	}}
+	merged := cfg.CompatUpstreams()
+	if got := merged["opencode-go"]; got != user {
+		t.Errorf("opencode-go upstream = %+v, want the user entry %+v", got, user)
+	}
+	if _, ok := merged["openrouter"]; !ok {
+		t.Errorf("user-only upstream openrouter missing from %v", merged)
+	}
+	if len(merged) != 2 {
+		t.Errorf("merged upstreams = %v, want exactly the built-in and user names", merged)
+	}
+	if _, ok := cfg.Compat["opencode-go"]; !ok || len(cfg.Compat) != 2 {
+		t.Errorf("CompatUpstreams must not mutate cfg.Compat: %v", cfg.Compat)
+	}
+}
+
+// buildAdapters panics on a compat entry that fails validation. Only config.Load
+// validates the user entries. This test validates the built-in entries.
+func TestBuiltinCompat_EntriesPassValidation(t *testing.T) {
+	for name, upstream := range builtinCompat {
+		if err := openaicompat.ValidateName(name); err != nil {
+			t.Errorf("built-in compat %q: %v", name, err)
+		}
+		if err := openaicompat.ValidateBaseURL(upstream.BaseURL); err != nil {
+			t.Errorf("built-in compat %q base_url: %v", name, err)
+		}
+		if strings.TrimSpace(upstream.APIKeyEnv) == "" {
+			t.Errorf("built-in compat %q has no api_key_env", name)
+		}
 	}
 }
 

--- a/proxy/internal/standalone/standalone.go
+++ b/proxy/internal/standalone/standalone.go
@@ -85,7 +85,7 @@ func (c Creds) Resolve(provider string, r *http.Request) providers.Credential {
 func (c Creds) authFallbackEnv(provider string, r *http.Request) string {
 	if provider == "openai_compatible" {
 		if name := compatNameFromPath(r.URL.Path); name != "" {
-			if upstream, ok := c.cfg.Compat[name]; ok {
+			if upstream, ok := c.cfg.CompatUpstreams()[name]; ok {
 				return strings.TrimSpace(upstream.APIKeyEnv)
 			}
 		}
@@ -267,11 +267,13 @@ func (c *engineCompressor) RetrieveOriginal(handle, query string) ([]byte, error
 	return c.eng.RetrieveQuery(handle, query)
 }
 
-// buildAdapters constructs the provider adapters. Anthropic, OpenAI, and Gemini
-// always get sensible public defaults so a bare `caveman start` works. Bedrock's
-// standard Runtime endpoint is derived from the resolved AWS region; operators
-// only need a raw URL for advanced/custom endpoints. Azure, Vertex, and
-// OpenAI-compatible remain opt-in because they have no universal endpoint.
+// buildAdapters makes the provider adapters. Anthropic, OpenAI, and Gemini
+// always get their public default upstream, so a bare `caveman start` works.
+// Bedrock gets the Runtime endpoint of the resolved AWS region. An operator gives
+// a raw Bedrock URL only for a custom endpoint. Azure, Vertex, and the legacy
+// OpenAI-compatible adapter stay opt-in because they have no universal endpoint.
+// The named compat mounts come from Config.CompatUpstreams, which includes the
+// built-in OpenCode Go mount.
 func buildAdapters(cfg config.Config) []providers.Adapter {
 	adapters := []providers.Adapter{
 		anthropic.New(cfg.BaseURL("anthropic", "https://api.anthropic.com")),
@@ -285,17 +287,19 @@ func buildAdapters(cfg config.Config) []providers.Adapter {
 	if u := cfg.BaseURL("vertex", ""); u != "" {
 		adapters = append(adapters, vertex.New(u))
 	}
-	compatNames := make([]string, 0, len(cfg.Compat))
-	for name := range cfg.Compat {
+	compat := cfg.CompatUpstreams()
+	compatNames := make([]string, 0, len(compat))
+	for name := range compat {
 		compatNames = append(compatNames, name)
 	}
 	sort.Strings(compatNames)
 	for _, name := range compatNames {
-		adapter, err := openaicompat.NewNamed(name, cfg.Compat[name].BaseURL)
+		adapter, err := openaicompat.NewNamed(name, compat[name].BaseURL)
 		if err != nil {
-			// Unreachable via config.Load, which pre-validates every compat entry
-			// with the same ValidateName/ValidateBaseURL. Callers constructing a
-			// Config by hand must pass Load-validated compat entries.
+			// This error cannot occur through config.Load, which validates every
+			// compat entry with the same ValidateName and ValidateBaseURL. The
+			// config package tests validate every built-in entry. A caller that
+			// makes a Config by hand must give Load-validated compat entries.
 			panic(err)
 		}
 		adapters = append(adapters, adapter)

--- a/proxy/internal/standalone/standalone_test.go
+++ b/proxy/internal/standalone/standalone_test.go
@@ -698,6 +698,49 @@ func TestBuildAdapters_RegistersNamedCompatBeforeLegacy(t *testing.T) {
 	}
 }
 
+func TestBuildAdapters_OpenCodeGoRouteUsesOpenCodeUpstream(t *testing.T) {
+	adapters := buildAdapters(config.Config{})
+	req := httptest.NewRequest(http.MethodPost, "/compat/opencode-go/v1/responses", nil)
+	for _, adapter := range adapters {
+		if adapter.Name() != "openai_compatible" || !adapter.MatchRoute(req.Method, req.URL.Path) {
+			continue
+		}
+		upstream, err := adapter.ResolveUpstreamURL(req.Context(), req, providers.RouteContext{})
+		if err != nil {
+			t.Fatalf("resolve OpenCode Go route: %v", err)
+		}
+		want := "https://opencode.ai/zen/go/v1/responses"
+		if got := upstream.String(); got != want {
+			t.Fatalf("OpenCode Go upstream = %q, want %q", got, want)
+		}
+		return
+	}
+	t.Fatal("built-in OpenCode Go adapter was not registered")
+}
+
+// TestCreds_OpenCodeGoBuiltinCompatCredential proves that the built-in OpenCode
+// Go mount has its own BYOK policy. The proxy adds this mount only if the user
+// config has no opencode-go entry. Thus a keyless request must not use the wrong
+// OPENAI_COMPAT_API_KEY secret. A user entry must still win.
+func TestCreds_OpenCodeGoBuiltinCompatCredential(t *testing.T) {
+	t.Setenv("OPENCODE_API_KEY", "sk-opencode")
+	t.Setenv("OPENAI_COMPAT_API_KEY", "sk-legacy")
+
+	builtin := Creds{cfg: config.Config{}}
+	req := httptest.NewRequest(http.MethodPost, "/compat/opencode-go/v1/responses", nil)
+	if got := builtin.Resolve("openai_compatible", req); got.Key != "sk-opencode" || got.AuthFallbackEnv != "OPENCODE_API_KEY" {
+		t.Errorf("built-in OpenCode Go credential = %+v, want OPENCODE_API_KEY key and fallback policy", got)
+	}
+
+	t.Setenv("OPENCODE_ZEN_API_KEY", "sk-user")
+	configured := Creds{cfg: config.Config{Compat: map[string]config.CompatConfig{
+		"opencode-go": {BaseURL: "https://opencode.example.test", APIKeyEnv: "OPENCODE_ZEN_API_KEY"},
+	}}}
+	if got := configured.Resolve("openai_compatible", req); got.Key != "sk-user" || got.AuthFallbackEnv != "OPENCODE_ZEN_API_KEY" {
+		t.Errorf("configured OpenCode Go credential = %+v, want the user api_key_env to win", got)
+	}
+}
+
 func TestBuildAdapters_DefaultCompatBareRoutePreservesConfiguredBase(t *testing.T) {
 	cfg := config.Config{Providers: map[string]config.ProviderConfig{
 		"openai_compatible": {BaseURL: "http://127.0.0.1:11434/v1?tenant=local"},


### PR DESCRIPTION
## Summary

- Route [OpenCode Go](https://opencode.ai/go) models to a named compat mount, not to api.openai.com (fixes #946)
- Route only known providers; unknown providers get pass-through with a warning, not a 401 error
- Register a built-in `opencode-go` compat mount in the standalone proxy, with the upstream `https://opencode.ai/zen/go`
- Resolve BYOK keys for the built-in mount from `OPENCODE_API_KEY`; a user `compat:` entry with the same name wins

## Proof

- `go test ./proxy/internal/standalone/`
- `npm test` in `packages/pi-extension` (25/25)
- `python3 tests/verify_repo.py`
- Manual: `caveman pi --provider opencode-go --model <model> -p 'Reply with OK'` returns OK through the proxy; `caveman-proxy stats` shows the request

## Known limits

- The route for opencode-go `anthropic-messages` models (`minimax-m3`, `qwen3.7-max`, `qwen3.7-plus`) goes to `https://opencode.ai/zen/go`. Pi sends the key as `x-api-key`. The compat adapter sends the key to the upstream as `Authorization: Bearer`. No test shows that the upstream accepts a Bearer header on `/v1/messages`. Before this PR, the route for these models went to `api.anthropic.com`. Thus this PR does not cause a regression for these models. On this path, compression does not apply. The proxy sends the request bytes unchanged.
- The extension still routes a provider with the name `openai`, `anthropic`, or `google` and a custom base URL (litellm, ollama, Azure) to the default upstream. This behavior existed before #946. This PR does not change it.

## Follow-ups, not in this PR

Separate PRs will cover these items:

- The extension will route by the original base URL of the provider, read from `ctx.modelRegistry`. A loopback or custom endpoint will then pass through with the warning.
- An integration test will cover the seam between the pi extension, the gateway prefix strip, and the `/compat/opencode-go` mount.
- A test against the upstream will show if the upstream accepts a Bearer header on `/v1/messages`. If it does not, the mount will forward `x-api-key` unchanged.
- A release note will name the built-in upstream URL and the `compat.opencode-go` override. A `buildAdapters` test will show that a user entry replaces the built-in mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

