### PR TITLE
feat(mcp): add streamable-HTTP transport

### DIFF
--- a/mcp/cmd/caveman-mcp/main.go
+++ b/mcp/cmd/caveman-mcp/main.go
@@ -1,7 +1,10 @@
-// Command caveman-mcp is the Caveman MCP server over stdio. An MCP host (Claude
-// Code, Cursor, …) spawns it and speaks JSON-RPC on stdin/stdout; the three
-// caveman_* tools wrap the Caveman Engine. Logs go to stderr only — stdout
-// is the protocol channel.
+// Command caveman-mcp is the Caveman MCP server. The default transport is
+// stdio — an MCP host (Claude Code, Cursor, …) spawns it and speaks JSON-RPC on
+// stdin/stdout. With `-http <addr>` it serves the SAME server over the MCP
+// streamable-HTTP transport on the given address (e.g. `-http :8080`), so a
+// remote host can reach the caveman_* tools without a parallel Node server
+// (upstream review #934: the Go binary is the architectural owner of MCP). Logs
+// go to stderr only — stdout is the protocol channel on stdio.
 //
 // By default it opens the SHARED file recovery store (CAVEMAN_CCR_DB, else
 // ~/.caveman/ccr.db) — the same store the Caveman gateway writes — so a
@@ -25,7 +28,8 @@ import (
 var version = "dev"
 
 func main() {
-	if handled, code := handleArgs(os.Args[1:], os.Stdout, os.Stderr); handled {
+	rest, addr, wantHTTP := splitHTTPFlag(os.Args[1:])
+	if handled, code := handleArgs(rest, os.Stdout, os.Stderr); handled {
 		os.Exit(code)
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
@@ -39,10 +43,44 @@ func main() {
 
 	eng := engine.New(store, nil)
 	srv := mcp.NewServerVersion("caveman", version, mcp.EngineTools(eng, logger), logger)
+
+	if wantHTTP {
+		logger.Info("serving MCP over streamable HTTP", "addr", addr)
+		if err := srv.StartHTTP(addr); err != nil {
+			logger.Error("http serve", "err", err)
+			os.Exit(1)
+		}
+		return
+	}
 	if err := srv.Serve(os.Stdin, os.Stdout); err != nil {
 		logger.Error("serve", "err", err)
 		os.Exit(1)
 	}
+}
+
+// splitHTTPFlag scans args once for `-http [addr]`, returning the remaining
+// args (the flag and its address removed) and the address to serve. A bare
+// `-http` (no following arg) defaults to a loopback address; when the flag is
+// absent, args is returned unchanged. The first `-http` wins the address; every
+// `-http` pair is removed so handleArgs only ever sees what it understands.
+func splitHTTPFlag(args []string) (rest []string, addr string, wantHTTP bool) {
+	rest = make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-http" {
+			if !wantHTTP {
+				if i+1 < len(args) {
+					addr = args[i+1]
+				} else {
+					addr = "127.0.0.1:8931"
+				}
+				wantHTTP = true
+			}
+			i++ // skip the flag's address
+			continue
+		}
+		rest = append(rest, args[i])
+	}
+	return rest, addr, wantHTTP
 }
 
 func handleArgs(args []string, stdout, stderr io.Writer) (bool, int) {
@@ -53,14 +91,14 @@ func handleArgs(args []string, stdout, stderr io.Writer) (bool, int) {
 		err := json.NewEncoder(stdout).Encode(map[string]any{
 			"version":      version,
 			"schema":       "caveman.mcp.version.v1",
-			"capabilities": []string{"mcp_recovery", "build_stamped_version"},
+			"capabilities": []string{"mcp_recovery", "build_stamped_version", "http_transport"},
 		})
 		if err != nil {
 			return true, 1
 		}
 		return true, 0
 	}
-	_, _ = io.WriteString(stderr, "usage: caveman-mcp [version --json]\n")
+	_, _ = io.WriteString(stderr, "usage: caveman-mcp [version --json | -http <addr>]\n")
 	return true, 2
 }
 

--- a/mcp/cmd/caveman-mcp/main_test.go
+++ b/mcp/cmd/caveman-mcp/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -27,8 +28,11 @@ func TestVersionJSON(t *testing.T) {
 	if got.Schema != "caveman.mcp.version.v1" {
 		t.Fatalf("schema=%q", got.Schema)
 	}
-	if len(got.Capabilities) != 2 || got.Capabilities[0] != "mcp_recovery" {
+	if len(got.Capabilities) != 3 || got.Capabilities[0] != "mcp_recovery" {
 		t.Fatalf("capabilities=%v", got.Capabilities)
+	}
+	if got.Capabilities[2] != "http_transport" {
+		t.Fatalf("capabilities=%v want http_transport last", got.Capabilities)
 	}
 }
 
@@ -42,7 +46,7 @@ func TestUnknownArgumentExitsTwo(t *testing.T) {
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout=%q", stdout.String())
 	}
-	if stderr.String() != "usage: caveman-mcp [version --json]\n" {
+	if stderr.String() != "usage: caveman-mcp [version --json | -http <addr>]\n" {
 		t.Fatalf("stderr=%q", stderr.String())
 	}
 }
@@ -51,5 +55,38 @@ func TestNoArgumentsStartsServer(t *testing.T) {
 	handled, code := handleArgs(nil, &bytes.Buffer{}, &bytes.Buffer{})
 	if handled || code != 0 {
 		t.Fatalf("handled=%v code=%d", handled, code)
+	}
+}
+
+func TestSplitHTTPFlag(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantRest []string
+		wantAddr string
+		wantHTTP bool
+	}{
+		{"normal -http <addr>", []string{"-http", "127.0.0.1:9000"}, []string{}, "127.0.0.1:9000", true},
+		{"flag stripped, trailing args kept", []string{"-http", ":8080", "version", "--json"}, []string{"version", "--json"}, ":8080", true},
+		{"bare -http defaults to loopback", []string{"-http"}, []string{}, "127.0.0.1:8931", true},
+		{"absent flag leaves args unchanged", []string{"version", "--json"}, []string{"version", "--json"}, "", false},
+		{"no args", nil, []string{}, "", false},
+		{"repeated -http: first wins, all pairs removed", []string{"-http", "a", "-http", "b"}, []string{}, "a", true},
+		{"-http -http consumes second as address", []string{"-http", "-http"}, []string{}, "-http", true},
+		{"flag mid-args keeps siblings", []string{"foo", "-http", ":9000", "bar"}, []string{"foo", "bar"}, ":9000", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rest, addr, wantHTTP := splitHTTPFlag(tc.args)
+			if !reflect.DeepEqual(rest, tc.wantRest) {
+				t.Fatalf("rest=%v want %v", rest, tc.wantRest)
+			}
+			if addr != tc.wantAddr {
+				t.Fatalf("addr=%q want %q", addr, tc.wantAddr)
+			}
+			if wantHTTP != tc.wantHTTP {
+				t.Fatalf("wantHTTP=%v want %v", wantHTTP, tc.wantHTTP)
+			}
+		})
 	}
 }

--- a/mcp/http_transport.go
+++ b/mcp/http_transport.go
@@ -1,0 +1,197 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// MCP streamable-HTTP transport (2025-06-18 spec) for the same Server the stdio
+// adapter serves. One HTTP endpoint; JSON-RPC messages arrive via POST, and
+// server→client messages — none exist for this tool set, since every tool is
+// request/response — would flow over an SSE stream opened by GET.
+//
+// This exists so the architectural owner (the Go caveman-mcp) can serve remote
+// hosts instead of a parallel Node server (upstream review #934): the transport
+// reuses the exact same Server, dispatch, tool set, size caps, and fail-closed
+// semantics as stdio. No sessions are managed (the server is stateless and never
+// sends unsolicited messages), so no Mcp-Session-Id header is emitted — clients
+// that require sessions will see a normal JSON-RPC initialize reply and can
+// decide; the transport never claims semantics it does not provide.
+//
+// CORS is permissive on purpose: MCP clients (Claude Desktop, remote hosts)
+// connect from arbitrary origins and there is no cookie/credential state to
+// protect — the endpoint is authenticated by deployment (bind address / proxy),
+// not by the browser.
+
+// ServeHTTP implements http.Handler. Methods:
+//
+//	POST /  — one JSON-RPC message (single or batch); replied with application/json
+//	GET  /  — SSE stream (heartbeats only; kept open until the client disconnects)
+//	OPTIONS — CORS preflight
+//
+// Anything else is 405 Method Not Allowed.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	setCORS(w)
+	switch r.Method {
+	case http.MethodOptions:
+		w.WriteHeader(http.StatusNoContent)
+	case http.MethodPost:
+		s.serveHTTPPost(w, r)
+	case http.MethodGet:
+		s.serveHTTPGet(w, r)
+	default:
+		w.Header().Set("Allow", "GET, POST, OPTIONS")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func setCORS(w http.ResponseWriter) {
+	h := w.Header()
+	h.Set("Access-Control-Allow-Origin", "*")
+	h.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	h.Set("Access-Control-Allow-Headers", "content-type, accept, mcp-session-id, mcp-protocol-version")
+	h.Set("Access-Control-Expose-Headers", "mcp-session-id")
+}
+
+func (s *Server) serveHTTPPost(w http.ResponseWriter, r *http.Request) {
+	ct := r.Header.Get("Content-Type")
+	if ct != "" && !strings.HasPrefix(strings.ToLower(ct), "application/json") {
+		http.Error(w, "content-type must be application/json", http.StatusUnsupportedMediaType)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, int64(s.maxInboundBytes)+1))
+	if err != nil {
+		http.Error(w, "could not read request body", http.StatusBadRequest)
+		return
+	}
+	if len(body) > s.maxInboundBytes {
+		s.writeHTTPJSON(w, http.StatusBadRequest,
+			errorResponse(nil, codeInvalidRequest, "cave_payload_too_large: message exceeds cap"))
+		return
+	}
+	raw := bytes.TrimSpace(body)
+	if len(raw) == 0 {
+		s.writeHTTPJSON(w, http.StatusBadRequest,
+			errorResponse(nil, codeInvalidRequest, "empty request body"))
+		return
+	}
+
+	if raw[0] == '[' {
+		s.serveHTTPBatch(w, raw)
+		return
+	}
+	var req rpcRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		s.log.Warn("http decode request", "err", err)
+		s.writeHTTPJSON(w, http.StatusBadRequest, errorResponse(nil, codeParseError, "parse error"))
+		return
+	}
+	resp, isNotif := s.serveOne(req)
+	if isNotif {
+		// A notification gets no reply; the request is done.
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	s.writeHTTPJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) serveHTTPBatch(w http.ResponseWriter, raw []byte) {
+	var raws []json.RawMessage
+	if err := json.Unmarshal(raw, &raws); err != nil {
+		s.log.Warn("http decode batch", "err", err)
+		s.writeHTTPJSON(w, http.StatusBadRequest, errorResponse(nil, codeParseError, "parse error"))
+		return
+	}
+	if len(raws) == 0 {
+		s.writeHTTPJSON(w, http.StatusBadRequest, errorResponse(nil, codeInvalidRequest, "empty batch"))
+		return
+	}
+	responses := make([]rpcResponse, 0, len(raws))
+	for _, rawMsg := range raws {
+		var req rpcRequest
+		if err := json.Unmarshal(rawMsg, &req); err != nil {
+			responses = append(responses, errorResponse(nil, codeInvalidRequest, "invalid request in batch"))
+			continue
+		}
+		resp, isNotif := s.serveOne(req)
+		if isNotif {
+			continue
+		}
+		responses = append(responses, resp)
+	}
+	if len(responses) == 0 {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	b, err := json.Marshal(responses)
+	if err != nil {
+		s.writeHTTPJSON(w, http.StatusInternalServerError,
+			errorResponse(nil, codeInternalError, "cave_internal_error"))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(b)
+}
+
+// serveHTTPGet opens the SSE side of the transport. This tool set emits no
+// server-initiated messages, so the stream carries only spec heartbeats and
+// stays open until the client disconnects (request context done) — which is
+// what a compliant MCP client expects after opening the GET connection.
+func (s *Server) serveHTTPGet(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	ticker := time.NewTicker(s.heartbeat)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			// SSE comment heartbeat keeps intermediaries and clients from
+			// treating the idle stream as dead.
+			_, _ = io.WriteString(w, ": ping\n\n")
+			flusher.Flush()
+		}
+	}
+}
+
+func (s *Server) writeHTTPJSON(w http.ResponseWriter, status int, resp rpcResponse) {
+	b, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, "cave_internal_error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(b)
+}
+
+// StartHTTP runs the server over streamable HTTP on addr (e.g. ":8080") until
+// the listener is closed. It exists so the CLI can offer -http with the same
+// server instance the stdio path uses.
+func (s *Server) StartHTTP(addr string) error {
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           s,
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("http serve: %w", err)
+	}
+	return nil
+}

--- a/mcp/http_transport_test.go
+++ b/mcp/http_transport_test.go
@@ -1,0 +1,248 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// httpPost sends one JSON-RPC message over the streamable-HTTP transport and
+// returns the decoded HTTP response.
+func httpPost(t *testing.T, srv *httptest.Server, body string) (*http.Response, []byte) {
+	t.Helper()
+	resp, err := http.Post(srv.URL, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp, b
+}
+
+func httpDecode(t *testing.T, b []byte) respOut {
+	t.Helper()
+	var r respOut
+	if err := json.Unmarshal(b, &r); err != nil {
+		t.Fatalf("decode response (%v): %q", err, b)
+	}
+	if r.JSONRPC != "2.0" {
+		t.Fatalf("missing jsonrpc 2.0: %q", b)
+	}
+	return r
+}
+
+func newHTTPServer(t *testing.T, eng Engine) *httptest.Server {
+	t.Helper()
+	srv := NewServer("caveman", EngineTools(eng, nil), nil)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestHTTPInitialize(t *testing.T) {
+	ts := newHTTPServer(t, mockEngine{})
+	resp, b := httpPost(t, ts, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%q", resp.StatusCode, b)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type=%q want application/json", ct)
+	}
+	r := httpDecode(t, b)
+	if r.Error != nil {
+		t.Fatalf("initialize errored: %+v", r.Error)
+	}
+	var res struct {
+		ProtocolVersion string `json:"protocolVersion"`
+		ServerInfo      struct {
+			Name string `json:"name"`
+		} `json:"serverInfo"`
+	}
+	if err := json.Unmarshal(r.Result, &res); err != nil {
+		t.Fatalf("decode initialize result: %v", err)
+	}
+	if res.ProtocolVersion != "2024-11-05" {
+		t.Fatalf("protocolVersion=%q", res.ProtocolVersion)
+	}
+	if res.ServerInfo.Name != "caveman" {
+		t.Fatalf("serverInfo.name=%q", res.ServerInfo.Name)
+	}
+}
+
+func TestHTTPToolsList(t *testing.T) {
+	ts := newHTTPServer(t, mockEngine{})
+	_, b := httpPost(t, ts, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	r := httpDecode(t, b)
+	var res struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(r.Result, &res); err != nil {
+		t.Fatalf("decode tools/list: %v", err)
+	}
+	if len(res.Tools) != 5 {
+		t.Fatalf("want 5 tools, got %d", len(res.Tools))
+	}
+}
+
+// TestHTTPToolCallRoundTrip drives a real compress through the transport: the
+// same dispatch, engine, and result cap the stdio server uses. The repetitive
+// JSON input is the proven compressible shape from the stdio full-cycle test.
+func TestHTTPToolCallRoundTrip(t *testing.T) {
+	ts := newHTTPServer(t, realEngine(t))
+	input := `{"items":[` + strings.Repeat(`{"k":"v","n":1},`, 50) + `{"k":"v","n":1}]}`
+	body, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+		"params": map[string]any{"name": "caveman_compress", "arguments": map[string]any{"input": input}},
+	})
+	_, b := httpPost(t, ts, string(body))
+	r := httpDecode(t, b)
+	if r.Error != nil {
+		t.Fatalf("tools/call errored: %+v", r.Error)
+	}
+	tr := decodeTool(t, r.Result)
+	if tr.IsError {
+		t.Fatalf("compress returned isError: %s", tr.Content[0].Text)
+	}
+	var payload struct {
+		RecoveryHandle *string `json:"recovery_handle"`
+		Ratio          float64 `json:"ratio"`
+	}
+	if err := json.Unmarshal([]byte(tr.Content[0].Text), &payload); err != nil {
+		t.Fatalf("decode compress payload: %v", err)
+	}
+	if payload.RecoveryHandle == nil || payload.Ratio <= 0 {
+		t.Fatalf("expected a real compression with recovery handle, ratio=%v handle=%v", payload.Ratio, payload.RecoveryHandle)
+	}
+}
+
+func TestHTTPBatch(t *testing.T) {
+	ts := newHTTPServer(t, mockEngine{})
+	resp, b := httpPost(t, ts, `[{"jsonrpc":"2.0","id":1,"method":"ping"},{"jsonrpc":"2.0","id":2,"method":"tools/list"}]`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%q", resp.StatusCode, b)
+	}
+	var arr []respOut
+	if err := json.Unmarshal(b, &arr); err != nil {
+		t.Fatalf("batch response not an array (%v): %q", err, b)
+	}
+	if len(arr) != 2 {
+		t.Fatalf("want 2 responses, got %d", len(arr))
+	}
+}
+
+func TestHTTPNotificationGetsNoReply(t *testing.T) {
+	ts := newHTTPServer(t, mockEngine{})
+	resp, b := httpPost(t, ts, `{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status=%d want 202", resp.StatusCode)
+	}
+	if len(bytes.TrimSpace(b)) != 0 {
+		t.Fatalf("notification reply should be empty, got %q", b)
+	}
+}
+
+func TestHTTPParseError(t *testing.T) {
+	ts := newHTTPServer(t, mockEngine{})
+	resp, b := httpPost(t, ts, `{"jsonrpc":"2.0","id":1,"method":`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d want 400", resp.StatusCode)
+	}
+	r := httpDecode(t, b)
+	if r.Error == nil || r.Error.Code != codeParseError {
+		t.Fatalf("want parse error, got %+v", r.Error)
+	}
+}
+
+func TestHTTPWrongContentType(t *testing.T) {
+	ts := newHTTPServer(t, mockEngine{})
+	resp, err := http.Post(ts.URL, "text/plain", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnsupportedMediaType {
+		t.Fatalf("status=%d want 415", resp.StatusCode)
+	}
+}
+
+func TestHTTPMethodNotAllowed(t *testing.T) {
+	ts := newHTTPServer(t, mockEngine{})
+	req, err := http.NewRequest(http.MethodPut, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status=%d want 405", resp.StatusCode)
+	}
+}
+
+func TestHTTPPayloadTooLarge(t *testing.T) {
+	srv := NewServer("caveman", EngineTools(mockEngine{}, nil), nil)
+	srv.maxInboundBytes = 1024 // shrink the cap so the test stays fast
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	big := `{"jsonrpc":"2.0","id":1,"method":"ping","params":{"pad":"` + strings.Repeat("x", 4096) + `"}}`
+	resp, b := httpPost(t, ts, big)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d want 400", resp.StatusCode)
+	}
+	r := httpDecode(t, b)
+	if r.Error == nil || r.Error.Message != "cave_payload_too_large: message exceeds cap" {
+		t.Fatalf("want payload-too-large error, got %+v", r.Error)
+	}
+}
+
+// TestHTTPSSEGet opens the GET side of the transport and expects a live
+// text/event-stream that delivers heartbeats. The stream never closes by
+// design (it ends on client disconnect), so reads are bounded line reads, not
+// ReadAll.
+func TestHTTPSSEGet(t *testing.T) {
+	srv := NewServer("caveman", EngineTools(mockEngine{}, nil), nil)
+	srv.heartbeat = 50 * time.Millisecond // short interval so the test is fast
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("content-type=%q want text/event-stream", ct)
+	}
+	br := bufio.NewReader(resp.Body)
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("SSE stream never delivered a heartbeat")
+		default:
+		}
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read: %v (got %q)", err, line)
+		}
+		if strings.Contains(line, ": ping") {
+			return // first heartbeat proves the stream is live
+		}
+	}
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"time"
 )
 
 // Handler runs one tool call. It receives the raw JSON `arguments` and returns a
@@ -66,6 +67,10 @@ type Server struct {
 	version         string
 	maxInboundBytes int
 	maxResultBytes  int
+	// heartbeat is the SSE keep-alive interval for the HTTP transport. The
+	// 2025-06-18 spec allows heartbeats at any cadence; 15s keeps proxies and
+	// clients from treating an idle stream as dead. Tests shorten it.
+	heartbeat time.Duration
 }
 
 // NewServer builds a server over the given ordered tool set. log must write to
@@ -93,7 +98,7 @@ func NewServerVersion(name, version string, tools []Tool, log *slog.Logger) *Ser
 			exempt[t.Name] = true
 		}
 	}
-	return &Server{
+	s := &Server{
 		tools:           tools,
 		index:           idx,
 		capExempt:       exempt,
@@ -102,7 +107,9 @@ func NewServerVersion(name, version string, tools []Tool, log *slog.Logger) *Ser
 		version:         version,
 		maxInboundBytes: defaultMaxInboundBytes,
 		maxResultBytes:  defaultMaxResultBytes,
+		heartbeat:       15 * time.Second,
 	}
+	return s
 }
 
 // Serve runs the JSON-RPC loop until in reaches EOF. Framing is line-delimited

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -545,6 +545,13 @@ func TestZeroEgressNoNetworkImports(t *testing.T) {
 			if !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
 				continue
 			}
+			// http_transport.go is the explicit, opt-in HTTP surface behind the
+			// `-http` flag; it is the ONE file allowed to import net/http. The
+			// stdio path (Serve) never touches it, so the egress guarantee for
+			// the default adapter is unchanged.
+			if e.Name() == "http_transport.go" {
+				continue
+			}
 			f, err := parser.ParseFile(fset, filepath.Join(dir, e.Name()), nil, parser.ImportsOnly)
 			if err != nil {
 				t.Fatalf("parse %s: %v", e.Name(), err)


### PR DESCRIPTION
Adds the missing second transport to the Go caveman-mcp binary: the MCP streamable-HTTP transport (spec 2025-06-18) — POST JSON-RPC (single + batch), GET SSE with heartbeats, CORS, 405/415/400 error mapping, payload cap.

Reuses the same serveOne/dispatch/EngineTools/size-cap machinery as stdio — zero tool reimplementation. New CLI flag `-http <addr>`; `version --json` now reports the `http_transport` capability. The stdio path opens nothing; the zero-egress invariant keeps its teeth via a documented carve-out for this one opt-in file.

**Verification**
- `go vet ./...` clean
- `go test ./mcp/... ./mcp/cmd/...` green (10 new transport tests)
- End-to-end binary smoke over real HTTP: initialize 200, tools/call compress dispatch, SSE GET text/event-stream
- Full `go test ./...` green except pre-existing shrink failures that reproduce identically on clean main (sandbox denies TEMP writes — environmental)