### PR TITLE
fix(proxy): stop native hook bridge waiting for EOF

### DIFF
--- a/proxy/cmd/caveman-proxy/main.go
+++ b/proxy/cmd/caveman-proxy/main.go
@@ -81,6 +81,8 @@ func main() {
 	}
 }
 
+const nativeHookMaxPayloadBytes = 2 * 1024 * 1024
+
 func runNativeHookBridge(args []string) {
 	if len(args) == 0 {
 		return
@@ -95,11 +97,34 @@ func runNativeHookBridge(args []string) {
 		}
 		home = filepath.Join(userHome, ".caveman")
 	}
-	raw, err := io.ReadAll(io.LimitReader(os.Stdin, 2*1024*1024+1))
-	if err != nil || len(raw) > 2*1024*1024 {
+	raw, err := readNativeHookPayload(os.Stdin)
+	if err != nil || len(raw) > nativeHookMaxPayloadBytes {
 		return
 	}
 	_ = nativehook.Run(context.Background(), home, agent, adapter, raw, os.Stdout, os.Stderr)
+}
+
+func readNativeHookPayload(r io.Reader) ([]byte, error) {
+	raw := make([]byte, 0, 4096)
+	buf := make([]byte, 16*1024)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			if len(raw)+n > nativeHookMaxPayloadBytes {
+				return nil, fmt.Errorf("native hook payload too large")
+			}
+			raw = append(raw, buf[:n]...)
+			if json.Valid(raw) {
+				return raw, nil
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				return raw, nil
+			}
+			return nil, err
+		}
+	}
 }
 
 func runNativeWhy(logger *slog.Logger, args []string) {

--- a/proxy/cmd/caveman-proxy/main_test.go
+++ b/proxy/cmd/caveman-proxy/main_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/JuliusBrussee/caveman/proxy/internal/config"
 )
@@ -36,6 +37,39 @@ func TestInitializeNativePersistenceHealthyCCRRetainsRequestedMode(t *testing.T)
 	defer recovery.Close()
 	if len(key) != 32 || cfg.Mode != "compress" {
 		t.Fatalf("healthy persistence key=%d mode=%q", len(key), cfg.Mode)
+	}
+}
+
+func TestReadNativeHookPayloadReturnsBeforeEOF(t *testing.T) {
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	defer writer.Close()
+
+	got := make(chan []byte, 1)
+	errs := make(chan error, 1)
+	go func() {
+		raw, err := readNativeHookPayload(reader)
+		if err != nil {
+			errs <- err
+			return
+		}
+		got <- raw
+	}()
+
+	payload := []byte(`{"hook_event_name":"SessionStart","session_id":"codex-1"}`)
+	if _, err := writer.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-errs:
+		t.Fatal(err)
+	case raw := <-got:
+		if string(raw) != string(payload) {
+			t.Fatalf("payload = %q, want %q", raw, payload)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("native hook payload read waited for EOF after a complete JSON object")
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop the Go native-hook bridge from waiting for stdin EOF once it has a complete JSON hook payload
- preserve the existing 2 MiB payload cap and fail-open behavior
- add a regression test that keeps the pipe writer open after a Codex SessionStart payload

Fixes #949

## Testing
- `git diff --check`
- Not run: `gofmt` / `go test ./proxy/cmd/caveman-proxy` because the Go toolchain is not installed on this Windows PATH or WSL environment.