### PR TITLE
Fix Gemini agent tool frontmatter

### DIFF
--- a/agents/cavecrew-builder.md
+++ b/agents/cavecrew-builder.md
@@ -6,7 +6,6 @@ description: >
   scope. Returns caveman diff receipt. Use when scope is bounded and
   obvious; do NOT use for new features, new files (unless asked), or
   cross-file refactors.
-tools: [Read, Edit, Write, Grep, Glob]
 ---
 
 Caveman-ultra. Drop articles/filler. Code/paths exact, backticked. No narration.

--- a/agents/cavecrew-investigator.md
+++ b/agents/cavecrew-investigator.md
@@ -5,7 +5,6 @@ description: >
   "what calls Y", "list all uses of Z", "map this directory". Output is
   caveman-compressed so the main thread eats ~60% fewer tokens than
   vanilla Explore. Refuses to suggest fixes.
-tools: [Read, Grep, Glob, Bash]
 model: haiku
 ---
 

--- a/agents/cavecrew-reviewer.md
+++ b/agents/cavecrew-reviewer.md
@@ -5,7 +5,6 @@ description: >
   no scope creep. Output format `path:line: <emoji> <severity>: <problem>. <fix>.`
   Use for "review this PR", "review my diff", "audit this file". Skips
   formatting nits unless they change meaning.
-tools: [Read, Grep, Bash]
 model: haiku
 ---
 

--- a/plugins/caveman/agents/cavecrew-builder.md
+++ b/plugins/caveman/agents/cavecrew-builder.md
@@ -6,7 +6,6 @@ description: >
   scope. Returns caveman diff receipt. Use when scope is bounded and
   obvious; do NOT use for new features, new files (unless asked), or
   cross-file refactors.
-tools: [Read, Edit, Write, Grep, Glob]
 ---
 
 Caveman-ultra. Drop articles/filler. Code/paths exact, backticked. No narration.

--- a/plugins/caveman/agents/cavecrew-investigator.md
+++ b/plugins/caveman/agents/cavecrew-investigator.md
@@ -5,7 +5,6 @@ description: >
   "what calls Y", "list all uses of Z", "map this directory". Output is
   caveman-compressed so the main thread eats ~60% fewer tokens than
   vanilla Explore. Refuses to suggest fixes.
-tools: [Read, Grep, Glob, Bash]
 model: haiku
 ---
 

--- a/plugins/caveman/agents/cavecrew-reviewer.md
+++ b/plugins/caveman/agents/cavecrew-reviewer.md
@@ -5,7 +5,6 @@ description: >
   no scope creep. Output format `path:line: <emoji> <severity>: <problem>. <fix>.`
   Use for "review this PR", "review my diff", "audit this file". Skips
   formatting nits unless they change meaning.
-tools: [Read, Grep, Bash]
 model: haiku
 ---
 

--- a/tests/installer/gemini-agents.test.mjs
+++ b/tests/installer/gemini-agents.test.mjs
@@ -1,0 +1,80 @@
+// Regression for #373: Gemini CLI validates agent frontmatter tool names.
+//
+// The extension loader reads repo-root agents/cavecrew-*.md directly, so
+// Claude Code tool ids like Read/Edit/Bash make Gemini reject the whole agent.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const AGENTS_DIR = path.join(REPO_ROOT, 'agents');
+const GEMINI_BUILTIN_TOOLS = new Set([
+  'read_file',
+  'replace',
+  'write_file',
+  'grep_search',
+  'glob',
+  'run_shell_command',
+]);
+
+function cavecrewAgentFiles() {
+  return fs.readdirSync(AGENTS_DIR)
+    .filter((name) => /^cavecrew-.*\.md$/.test(name))
+    .map((name) => path.join(AGENTS_DIR, name))
+    .sort();
+}
+
+function frontmatter(file) {
+  const body = fs.readFileSync(file, 'utf8');
+  const match = body.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  assert.ok(match, `${path.relative(REPO_ROOT, file)} must start with closed YAML frontmatter`);
+  return match[1];
+}
+
+function unquote(value) {
+  return value.trim().replace(/^['"]|['"]$/g, '');
+}
+
+function parseTools(fm) {
+  const lines = fm.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    if (!line.startsWith('tools:')) continue;
+
+    const value = line.split(':', 2)[1].trim();
+    if (value.startsWith('[') && value.endsWith(']')) {
+      const inner = value.slice(1, -1).trim();
+      return inner ? inner.split(',').map(unquote) : [];
+    }
+    if (value) return [unquote(value)];
+
+    const tools = [];
+    for (const item of lines.slice(index + 1)) {
+      if (!/^\s/.test(item)) break;
+      const stripped = item.trim();
+      if (stripped.startsWith('- ')) tools.push(unquote(stripped.slice(2)));
+    }
+    return tools;
+  }
+  return null;
+}
+
+test('#373 root cavecrew agents omit tools or use Gemini CLI tool ids', () => {
+  const files = cavecrewAgentFiles();
+  assert.equal(files.length, 3, 'expected exactly the three cavecrew root agents');
+
+  for (const file of files) {
+    const tools = parseTools(frontmatter(file));
+    if (tools === null) continue;
+    const invalid = tools.filter((tool) => tool !== '*' && !GEMINI_BUILTIN_TOOLS.has(tool));
+    assert.deepEqual(
+      invalid,
+      [],
+      `${path.relative(REPO_ROOT, file)} declares Gemini-invalid tools: ${invalid.join(', ')}`,
+    );
+  }
+});

--- a/tests/installer/opencode-agent.test.mjs
+++ b/tests/installer/opencode-agent.test.mjs
@@ -6,9 +6,9 @@
 //   Configuration is invalid at .../cavecrew-reviewer.md
 //   ↳ Expected object | undefined, got ["Read","Grep","Bash"] tools
 //
-// Fix: strip the `tools:` field on copy. These tests prove the helper
-// strips the field, preserves every other frontmatter key and the body,
-// and handles both the inline array form and the multi-line YAML list form.
+// Fix: strip the `tools:` field on copy. Source cavecrew agents now omit it too
+// for Gemini compatibility (#373), while the helper still handles older copied
+// forms, preserving every other frontmatter key and the body.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -116,15 +116,12 @@ test('non-string input returns unchanged', () => {
   assert.deepEqual(transformOpencodeAgentFrontmatter({ x: 1 }), { x: 1 });
 });
 
-// ── Real shipped agent files: every one must transform to opencode-safe ──
-// This is the RED-state proof: each `agents/cavecrew-*.md` in the repo today
-// contains the offending `tools: [...]` form, which is what broke opencode
-// startup in the reported bug. After transform, the field is gone.
-test('all shipped cavecrew agent files contain offending tools array (RED proof)', () => {
+// ── Real shipped agent files: every one must already be tool-list safe ──
+test('all shipped cavecrew agent files omit tool lists at source', () => {
   for (const f of SHIPPED_AGENT_FILES) {
     const src = fs.readFileSync(path.join(REPO_ROOT, 'agents', f), 'utf8');
     const fm = frontmatter(src);
-    assert.match(fm, /^tools:\s*\[/m, `source ${f} should contain inline array form (this is the bug)`);
+    assert.doesNotMatch(fm, /^tools:/m, `source ${f} must not declare runtime-specific tools`);
   }
 });
 


### PR DESCRIPTION
Fixes #373. Summary: remove Claude-specific tools frontmatter from cavecrew agents and synced plugin mirrors, add Gemini CLI regression coverage, and update the opencode source baseline. Tests: node --test tests\installer\gemini-agents.test.mjs tests\installer\opencode-agent.test.mjs. Also ran node --test tests\installer\gemini-agents.test.mjs tests\installer\slash-commands.test.mjs tests\installer\package-bin.test.mjs. Full npm.cmd test was run locally too and still fails on two Windows environment checks unrelated to this change: symlink EPERM and bash hook command parsing.