### PR TITLE
fix(pi): route only default provider endpoints

### DIFF
--- a/packages/pi-extension/README.md
+++ b/packages/pi-extension/README.md
@@ -6,7 +6,11 @@ One extension, four jobs:
 
 - **Proxy routing** — points the selected model's provider at your local Caveman
   proxy (`/w/pi/...`) with a baseUrl-only override. Pi keeps owning auth, model
-  names, pricing, and `models.json`; nothing is copied or rewritten.
+  names, pricing, and `models.json`; nothing is copied or rewritten. The
+  extension routes a provider only when its base URL points at the upstream
+  host of the proxy route (`api.anthropic.com`, `api.openai.com`,
+  `generativelanguage.googleapis.com`, or `opencode.ai`). A provider that points
+  at a local relay or at another endpoint stays direct, with one notice.
 - **Exact recovery** — registers a single model-visible tool, `caveman_retrieve`,
   backed by the local `caveman-mcp` binary and the shared CCR store. Compressed
   bytes are always recoverable, byte-exact.

--- a/packages/pi-extension/src/protocol.ts
+++ b/packages/pi-extension/src/protocol.ts
@@ -97,17 +97,47 @@ const ROUTES_BY_PROVIDER_API: Readonly<Record<string, Readonly<Record<string, st
   },
 };
 
-// If the caller gives a provider, this function routes only the providers that the
-// local proxy can resolve. If the caller gives no provider, the function keeps the
-// API-only behavior for existing callers.
-export function routeForApi(gateway: string, api: string | undefined, provider?: string): string | undefined {
-  const providerRoutes = provider ? ROUTES_BY_PROVIDER_API[provider] : undefined;
-  if (provider && providerRoutes) {
-    const path = api ? providerRoutes[api] : undefined;
-    return path ? joinUrl(gateway, path) : undefined;
+// The proxy sends each route to one fixed upstream host. The extension routes a
+// provider only when the original base URL of the provider points at that host.
+// A provider with the name "openai" can point at a local relay (litellm, ollama)
+// or at Azure. Such a provider must keep its endpoint. If the pi catalog moves
+// opencode-go to another host, the stale built-in mount in the proxy must not
+// get the request. A provider that is not in this table never routes.
+export const UPSTREAM_HOSTS_BY_PROVIDER: Readonly<Record<string, string>> = {
+  anthropic: "api.anthropic.com",
+  openai: "api.openai.com",
+  google: "generativelanguage.googleapis.com",
+  "opencode-go": "opencode.ai",
+};
+
+export function upstreamHostFor(provider: string | undefined): string | undefined {
+  return provider ? UPSTREAM_HOSTS_BY_PROVIDER[provider] : undefined;
+}
+
+// hostOf returns the lowercase host name of a URL, or undefined for a value
+// that is not a URL. A caller compares the result with the table above.
+export function hostOf(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return undefined;
   }
-  if (provider && provider !== "anthropic" && provider !== "openai" && provider !== "google") return undefined;
-  const path = api ? ROUTES_BY_API[api] : undefined;
+}
+
+// routeForApi gives the gateway route for one model, or undefined for a model
+// that must stay direct. With a provider, the provider must be in
+// UPSTREAM_HOSTS_BY_PROVIDER. With an original base URL, the host of that URL
+// must be the upstream host of the provider. Without a provider, the function
+// keeps the API-only behavior for existing callers.
+export function routeForApi(gateway: string, api: string | undefined, provider?: string, originalBaseUrl?: string): string | undefined {
+  if (provider) {
+    const expected = UPSTREAM_HOSTS_BY_PROVIDER[provider];
+    if (!expected) return undefined;
+    if (originalBaseUrl !== undefined && hostOf(originalBaseUrl) !== expected) return undefined;
+  }
+  const table = (provider ? ROUTES_BY_PROVIDER_API[provider] : undefined) ?? ROUTES_BY_API;
+  const path = api ? table[api] : undefined;
   return path ? joinUrl(gateway, path) : undefined;
 }
 

--- a/packages/pi-extension/src/provider.ts
+++ b/packages/pi-extension/src/provider.ts
@@ -16,7 +16,9 @@ export class ProviderRouter {
   private overridden = new Set<string>();
   // originals keeps the base URL of each overridden provider. After an override,
   // the registry reports the gateway route for that provider, so the original
-  // is not available from the registry.
+  // is not available from the registry. Pi keeps extension overrides in memory
+  // only, so a new pi process always starts from the original base URL and this
+  // map never sees a stale override from an earlier process.
   private originals = new Map<string, string>();
   private applying = false;
   private warnedModels = new Set<string>();

--- a/packages/pi-extension/src/provider.ts
+++ b/packages/pi-extension/src/provider.ts
@@ -4,7 +4,7 @@
 // flags, context sizes, and model names.
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { isLoopbackUrl, routeForApi } from "./protocol.ts";
+import { hostOf, isLoopbackUrl, routeForApi, upstreamHostFor } from "./protocol.ts";
 
 type Notify = (message: string, kind: "warning" | "info") => void;
 
@@ -14,6 +14,10 @@ export class ProviderRouter {
   private gateway: string | undefined;
   private gateOpen = false;
   private overridden = new Set<string>();
+  // originals keeps the base URL of each overridden provider. After an override,
+  // the registry reports the gateway route for that provider, so the original
+  // is not available from the registry.
+  private originals = new Map<string, string>();
   private applying = false;
   private warnedModels = new Set<string>();
 
@@ -49,7 +53,8 @@ export class ProviderRouter {
   async apply(model: ExtensionContext["model"], ctx: ExtensionContext): Promise<void> {
     if (!this.gateOpen || this.applying || !this.gateway) return;
     if (!model) return;
-    const route = routeForApi(this.gateway, model.api, model.provider);
+    const original = this.overridden.has(model.provider) ? this.originals.get(model.provider) ?? model.baseUrl : model.baseUrl;
+    const route = routeForApi(this.gateway, model.api, model.provider, original);
     let oauth = true;
     try {
       oauth = ctx.modelRegistry.isUsingOAuth(model);
@@ -61,9 +66,13 @@ export class ProviderRouter {
       const key = `${model.provider}/${model.id}`;
       if (!this.warnedModels.has(key)) {
         this.warnedModels.add(key);
+        const expected = upstreamHostFor(model.provider);
+        const endpointMismatch = expected !== undefined && hostOf(original) !== expected;
         const reason = oauth
           ? "OAuth/subscription credentials are not routed"
-          : `unsupported provider/API "${model.provider}/${model.api}"`;
+          : endpointMismatch
+            ? `provider endpoint ${hostOf(original) ?? original} is not ${expected}`
+            : `unsupported provider/API "${model.provider}/${model.api}"`;
         this.notify(`Caveman: pass-through for ${key} (${reason}); no compression`, "warning");
       }
       return;
@@ -76,6 +85,7 @@ export class ProviderRouter {
           this.overridden.delete(provider);
         }
       }
+      this.originals.set(model.provider, original);
       this.pi.registerProvider(model.provider, { baseUrl: route });
       this.overridden.add(model.provider);
       // Re-resolve so the FIRST request uses the refreshed model object. A
@@ -102,5 +112,6 @@ export class ProviderRouter {
       } catch { /* restoring direct is best-effort */ }
     }
     this.overridden.clear();
+    this.originals.clear();
   }
 }

--- a/packages/pi-extension/tests/fixtures/stub-provider-extension.mjs
+++ b/packages/pi-extension/tests/fixtures/stub-provider-extension.mjs
@@ -1,21 +1,44 @@
-// Registers a loopback test provider so integration runs never leave the
-// machine: direct (ungated) traffic fast-fails on a dead local port, and gated
-// traffic goes wherever the caveman extension routes it. The provider id is
-// "openai" because routeForApi routes only allowlisted provider names.
+// Registers three test providers.
+//
+// The gated arms ("openai" and "opencode-go") declare the real upstream hosts,
+// because the extension routes a provider only when its base URL points at the
+// host that the proxy sends to. With an open gate, the extension re-points them
+// at the stub gateway, so a passing run never leaves the machine. If routing
+// regresses, the dummy key reaches the real host and the request fails with a
+// 401 error or a DNS error.
+//
+// The loopback arm ("anthropic") points at a dead local port. The closed-gate
+// tests use it, so direct traffic fast-fails locally. The open-gate test for a
+// custom endpoint uses it too: the extension must keep it direct.
 export default function (pi) {
+  const model = (id, name) => ({
+    id,
+    name,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 32768,
+    maxTokens: 1024,
+  });
   pi.registerProvider("openai", {
-    name: "Stub Provider",
-    baseUrl: "http://127.0.0.1:1",
+    name: "Stub OpenAI",
+    baseUrl: "https://api.openai.com/v1",
     apiKey: "dummy-key-for-stub",
     api: "openai-completions",
-    models: [{
-      id: "stub-model",
-      name: "Stub Model",
-      reasoning: false,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 32768,
-      maxTokens: 1024,
-    }],
+    models: [model("stub-model", "Stub Model")],
+  });
+  pi.registerProvider("opencode-go", {
+    name: "Stub OpenCode Go",
+    baseUrl: "https://opencode.ai/zen/go/v1",
+    apiKey: "dummy-key-for-stub",
+    api: "openai-completions",
+    models: [model("stub-go-model", "Stub Go Model")],
+  });
+  pi.registerProvider("anthropic", {
+    name: "Stub Local Anthropic",
+    baseUrl: "http://127.0.0.1:1",
+    apiKey: "dummy-key-for-stub",
+    api: "anthropic-messages",
+    models: [model("stub-local", "Stub Local Model")],
   });
 }

--- a/packages/pi-extension/tests/integration.runtime.mjs
+++ b/packages/pi-extension/tests/integration.runtime.mjs
@@ -209,11 +209,12 @@ test("closed gate (no run-state): zero proxy requests and a visible direct-mode 
     const out = await runPi(fx.env, [
       "--extension", stubProviderExtension, "--extension", extension,
       "--no-session", "--no-skills", "--no-context-files", "--no-prompt-templates", "--no-themes", "--no-extensions",
-      "--provider", "openai", "--model", "stub-model",
+      "--provider", "anthropic", "--model", "stub-local",
       "-p", "say hi",
     ]);
-    // Direct mode points at the dead loopback port the stub provider declares —
-    // the call fast-fails locally; what matters is honesty and zero routed traffic.
+    // Direct mode points at the dead loopback port of the "anthropic" stub
+    // provider. The call fast-fails locally. What matters is honesty and zero
+    // routed traffic.
     const providerHits = requests.filter((r) => r.method === "POST");
     assert.equal(providerHits.length, 0, `gate closed but stub saw: ${JSON.stringify(providerHits)}`);
     assert.match(out.stderr + out.stdout, /direct mode, no compression/, `stderr: ${out.stderr}`);
@@ -230,7 +231,7 @@ test("published recovery=false: gate refuses even with a live proxy and working 
     const out = await runPi(fx.env, [
       "--extension", stubProviderExtension, "--extension", extension,
       "--no-session", "--no-skills", "--no-context-files", "--no-prompt-templates", "--no-themes", "--no-extensions",
-      "--provider", "openai", "--model", "stub-model",
+      "--provider", "anthropic", "--model", "stub-local",
       "-p", "say hi",
     ]);
     // Proxy is alive (health probe hits the stub) but published recovery is
@@ -238,6 +239,53 @@ test("published recovery=false: gate refuses even with a live proxy and working 
     const providerHits = requests.filter((r) => r.method === "POST");
     assert.equal(providerHits.length, 0, `gate must refuse (false, *): ${JSON.stringify(providerHits)}`);
     assert.match(out.stderr + out.stdout, /recovery not available/, `stderr: ${out.stderr}`);
+  } finally {
+    fx.cleanup();
+    server.close();
+  }
+});
+
+// The seam of #946: the extension route string, the /w/pi prefix strip in the
+// proxy, and the built-in compat mount name are three separate literals. This
+// test drives an opencode-go model through the stub gateway and asserts the
+// path that the proxy must accept.
+test("open gate: opencode-go routes through the compat mount", { skip: !havePi && "pi devDependency missing" }, async () => {
+  const { server, requests, port } = await startStub();
+  const fx = fixture(port);
+  try {
+    const out = await runPi(fx.env, [
+      "--extension", stubProviderExtension, "--extension", extension,
+      "--no-session", "--no-skills", "--no-context-files", "--no-prompt-templates", "--no-themes", "--no-extensions",
+      "--provider", "opencode-go", "--model", "stub-go-model",
+      "-p", "say hi",
+    ]);
+    assert.match(out.stdout, /CAVEMAN_STUB_OK/, `stdout: ${out.stdout}\nstderr: ${out.stderr}`);
+    const providerHits = requests.filter((r) => r.method === "POST");
+    assert.ok(providerHits.length >= 1, `no provider request reached the stub; all: ${JSON.stringify(requests)}`);
+    assert.equal(providerHits[0].path, "/w/pi/compat/opencode-go/v1/chat/completions");
+  } finally {
+    fx.cleanup();
+    server.close();
+  }
+});
+
+// A provider with an allowlisted name but a custom endpoint (a local relay, or
+// Azure under the name "openai") must stay direct. The stub "anthropic" provider
+// points at a dead loopback port, so the direct call fast-fails and nothing
+// leaves the machine.
+test("open gate: a provider with a custom endpoint stays direct with a notice", { skip: !havePi && "pi devDependency missing" }, async () => {
+  const { server, requests, port } = await startStub();
+  const fx = fixture(port);
+  try {
+    const out = await runPi(fx.env, [
+      "--extension", stubProviderExtension, "--extension", extension,
+      "--no-session", "--no-skills", "--no-context-files", "--no-prompt-templates", "--no-themes", "--no-extensions",
+      "--provider", "anthropic", "--model", "stub-local",
+      "-p", "say hi",
+    ]);
+    const providerHits = requests.filter((r) => r.method === "POST");
+    assert.equal(providerHits.length, 0, `custom endpoint was routed: ${JSON.stringify(providerHits)}`);
+    assert.match(out.stderr + out.stdout, /pass-through for anthropic\/stub-local \(provider endpoint 127\.0\.0\.1 is not api\.anthropic\.com\)/, `stderr: ${out.stderr}`);
   } finally {
     fx.cleanup();
     server.close();

--- a/packages/pi-extension/tests/protocol.runtime.mjs
+++ b/packages/pi-extension/tests/protocol.runtime.mjs
@@ -11,6 +11,7 @@ const {
   MAX_CONTEXT_BYTES,
   ROUTES_BY_API,
   additionalContextOf,
+  hostOf,
   isLoopbackUrl,
   outputReplacementOf,
   routeForApi,
@@ -18,6 +19,7 @@ const {
   taskContinuation,
   taskTerms,
   taskType,
+  upstreamHostFor,
   promptDigest,
   resolveHookInvocations,
 } = await import(dist);
@@ -41,6 +43,24 @@ test("route table maps supported APIs and refuses everything else", () => {
     assert.equal(routeForApi(gw, api), undefined, `api ${api} must not route`);
   }
   assert.equal(Object.keys(ROUTES_BY_API).length, 4);
+});
+
+test("route gate compares the original provider host with the proxy upstream host", () => {
+  const gw = "http://127.0.0.1:8787";
+  assert.equal(routeForApi(gw, "openai-completions", "openai", "https://api.openai.com/v1"), `${gw}/w/pi/openai/v1`);
+  assert.equal(routeForApi(gw, "openai-completions", "openai", "http://127.0.0.1:4000/v1"), undefined, "a local relay named openai must stay direct");
+  assert.equal(routeForApi(gw, "openai-completions", "openai", "https://my-resource.openai.azure.com/openai"), undefined, "Azure named openai must stay direct");
+  assert.equal(routeForApi(gw, "anthropic-messages", "anthropic", "https://api.anthropic.com"), `${gw}/w/pi`);
+  assert.equal(routeForApi(gw, "anthropic-messages", "anthropic", "http://127.0.0.1:1"), undefined);
+  assert.equal(routeForApi(gw, "google-generative-ai", "google", "https://generativelanguage.googleapis.com"), `${gw}/w/pi/v1beta`);
+  assert.equal(routeForApi(gw, "anthropic-messages", "opencode-go", "https://opencode.ai/zen/go"), `${gw}/w/pi/compat/opencode-go`);
+  assert.equal(routeForApi(gw, "openai-completions", "opencode-go", "https://opencode.ai/zen/go/v1"), `${gw}/w/pi/compat/opencode-go/v1`);
+  assert.equal(routeForApi(gw, "openai-completions", "opencode-go", "https://other.example/v1"), undefined, "a moved opencode-go endpoint must stay direct");
+  assert.equal(routeForApi(gw, "openai-completions", "openai", "not a url"), undefined, "an unreadable base URL must stay direct");
+  assert.equal(upstreamHostFor("openai"), "api.openai.com");
+  assert.equal(upstreamHostFor("openrouter"), undefined);
+  assert.equal(hostOf("https://API.OpenAI.com/v1"), "api.openai.com");
+  assert.equal(hostOf("not a url"), undefined);
 });
 
 test("loopback detection", () => {


### PR DESCRIPTION
## Summary

- The extension routes a provider only when the host of its original base URL is the upstream host of the proxy route (fixes #970). The hosts are `api.anthropic.com`, `api.openai.com`, `generativelanguage.googleapis.com`, and `opencode.ai`. A provider with the name `openai` that points at a local relay (litellm, ollama) or at Azure now stays direct, with one notice that names the endpoint.
- The router caches the original base URL before the first override. After an override, every `ctx.modelRegistry` surface reports the gateway route, so the registry cannot give the original.
- A new integration test drives an `opencode-go` model through the stub gateway and asserts the path `/w/pi/compat/opencode-go/v1/chat/completions` (fixes #971). This is the seam of #946.
- The stub provider fixture declares three providers: `openai` on the real host, `opencode-go` on the real host, and `anthropic` on a dead loopback port. The closed-gate tests use the loopback provider, so direct traffic still fast-fails on the machine.

## Proof

- `npm test` in `packages/pi-extension`: 28 tests pass, 0 skipped. The pinned pi 0.84.2 CLI drives the six integration cases.
- Regression proof: with the tests and the fixture from this branch and the source from `main`, exactly two tests fail: `route gate compares the original provider host with the proxy upstream host` and `open gate: a provider with a custom endpoint stays direct with a notice`.
- `node scripts/bundle-pi-extension.mjs` in `packages/cli` bundles the new source. `node --test tests/pi-wrap.runtime.mjs tests/pi-enable.runtime.mjs`: 6 tests pass.
- `python3 tests/verify_repo.py` passes.
- Not run: a live `caveman pi` session against a real proxy. The installed CLI 1.3.1 ships a proxy from before #948. The stub-gateway integration test and the Go end-to-end test in #969 cover the same seam.

## Known limits

- A user who points both the pi `openai` provider and the proxy `providers.openai.base_url` at the same custom relay gets pass-through with a notice instead of routed compression. Before this change, such a setup routed through the proxy.
- Pi supports a separate `baseUrl` for each model in one provider. The router still stores one original URL for each provider.
- After Caveman routes one default model, a same-provider switch can route a custom-endpoint model to the wrong service. This bug exists on `main`.
- PR #972 fixes the provider-level case only. Issue #973 tracks the model-level follow-up.
- The routed integration tests are not hermetic. If routing regresses, a dummy key reaches `api.openai.com` or `opencode.ai`.
- The provider returns a 401 error, or the request fails because DNS is unavailable. The fixture comment states this risk.
- The `anthropic-messages` arm of the seam is covered by the protocol unit test here and by the Go end-to-end test in #969. The stub gateway does not answer Anthropic SSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
