### PR TITLE
docs: add PR template with test-status checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- Title: Conventional Commit, terse, why over what — e.g. `fix(stats): pin number formatting to en-US (#954)` -->
+
+## Summary
+
+<!-- One or two sentences: what this PR does and why. Link the issue/PR that motivated it. -->
+
+## Verification
+
+<!-- Every PR that touches testable code lists the real commands run and their counts. -->
+
+- [ ] **Test status is filled with actual counts from a run on this branch** (`N passed, M failed, K skipped`). If this PR touches no testable code, say so explicitly instead.
+
+**Test status**: `N passed, M failed, K skipped` — `pytest tests/...` (or the `npm test` equivalent)
+
+## Notes
+
+<!-- Supersedes / follow-up to / references #NNN; anything else the reviewer should know. -->


### PR DESCRIPTION
Per the closure of #955: "If PR body accuracy becomes a recurring problem, a PR template checkbox is the cheaper fix."

This adds exactly that: a `.github/PULL_REQUEST_TEMPLATE.md` with a verification checkbox that requires **actual** counts from a real run (`N passed, M failed, K skipped`) or an explicit "no testable code changed" statement — so a PR without a Test status section does not pass silently, and the 181-vs-183 class of fiction (summarize counting 46+0+4 as 92) has a standing guard.

No CI changes, no behavior changes — template file only.

**Verification**
- `git diff origin/main...HEAD` — 1 file, 17 lines, markdown only
- The template renders as a checkbox list in the PR composer; this PR's own body follows it