### PR TITLE
fix(install): gemini extension install must not wait for input (#400)

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -588,38 +588,62 @@ function installGemini(ctx) {
   //   --consent answers the extension-install warning. Do not pass it without
   //     the variable. Alone, it also answers the trust prompt with yes, and
   //     that writes cwd into trustedFolders.json permanently.
-  // A trusted cwd lets Gemini CLI load .gemini/ config and .env files. Gemini
-  // CLI also searches every parent directory up to the root for those files.
-  // So run the install from a new empty scratch directory below the user's
-  // own ~/.caveman/tmp. Every parent then belongs to the user or to root, and
-  // trust covers nothing. A directory below /tmp is not safe, because another
-  // local user can plant /tmp/.env. A directory below ~/.gemini/tmp is not
-  // safe, because Gemini CLI keeps per-project state there under the cwd
-  // name. The scratch directory comes from mkdtemp, so this run owns it and
-  // removes only it. Never remove a fixed path, because it can hold data from
-  // an earlier process. If the directory cannot be made, report a failure and
-  // do not start Gemini CLI. A GitHub source does not use cwd.
-  // A Gemini CLI before v0.7.0 rejects `--consent` with exit 1. The installer
-  // then reports a failure and does not wait.
-  const env = Object.assign({}, process.env, { GEMINI_CLI_TRUST_WORKSPACE: 'true' });
-  const scratchParent = path.join(os.homedir(), '.caveman', 'tmp');
-  note(`  env: GEMINI_CLI_TRUST_WORKSPACE=true. Trust applies to this process only, in a new empty scratch directory below ${scratchParent}. trustedFolders.json stays unchanged.`);
-  let cwd;
-  if (!opts.dryRun) {
-    try {
-      fs.mkdirSync(scratchParent, { recursive: true });
-      cwd = fs.mkdtempSync(path.join(scratchParent, 'gemini-install-'));
-    } catch (e) {
-      results.failed.push(['gemini', `could not create scratch directory below ${scratchParent}: ${e.message}`]);
-      process.stdout.write('\n');
-      return;
-    }
-  }
+  // Gemini CLI v0.41.0 adds `--skip-trust` and GEMINI_CLI_TRUST_WORKSPACE in
+  // one commit, upstream PR #25814. An older CLI ignores the variable. So the
+  // installer probes the root help one time. `--skip-trust` in the text shows
+  // that this CLI reads the variable. Without the flag, the installer runs the
+  // same command as before this change: the caller directory, no variable, and
+  // no `--consent`. On an older CLI, `--consent` answers the trust prompt with
+  // yes, and that trusts the caller directory permanently.
+  // Gemini CLI v0.11.0 adds `--consent`, which is older than `--skip-trust`.
+  // So a CLI with `--skip-trust` also has `--consent`. This is an assumption
+  // about the upstream release order.
+  const help = captureSpawn('gemini', ['--help']);
+  const sessionTrust = help.status === 0
+    && /--skip-trust\b/.test(`${help.stdout || ''}${help.stderr || ''}`);
+  const url = `https://github.com/${REPO}`;
   let r;
-  try {
-    r = runSpawn('gemini', ['extensions', 'install', `https://github.com/${REPO}`, '--consent'], { env, cwd }, opts.dryRun);
-  } finally {
-    if (cwd) { try { fs.rmSync(cwd, { recursive: true, force: true }); } catch (_) {} }
+  if (!sessionTrust) {
+    const tail = "Installing from the current directory with the CLI's own trust and consent prompts.";
+    if (help.status === 0) {
+      note(`  this Gemini CLI has no --skip-trust (added in v0.41.0). ${tail}`);
+    } else {
+      const code = help.error ? (help.error.code || 'spawn error')
+        : (help.status === null ? 'spawn error' : help.status);
+      note(`  could not read \`gemini --help\` (exit ${code}). ${tail}`);
+    }
+    r = runSpawn('gemini', ['extensions', 'install', url], null, opts.dryRun);
+  } else {
+    // A trusted cwd lets Gemini CLI load .gemini/ config and .env files. Gemini
+    // CLI also searches every parent directory up to the root for those files.
+    // So run the install from a new empty scratch directory below the user's
+    // own ~/.caveman/tmp. Every parent then belongs to the user or to root, and
+    // trust covers nothing. A directory below /tmp is not safe, because another
+    // local user can plant /tmp/.env. A directory below ~/.gemini/tmp is not
+    // safe, because Gemini CLI keeps per-project state there under the cwd
+    // name. The scratch directory comes from mkdtemp, so this run owns it and
+    // removes only it. Never remove a fixed path, because it can hold data from
+    // an earlier process. If the directory cannot be made, report a failure and
+    // do not start Gemini CLI. A GitHub source does not use cwd.
+    const env = Object.assign({}, process.env, { GEMINI_CLI_TRUST_WORKSPACE: 'true' });
+    const scratchParent = path.join(os.homedir(), '.caveman', 'tmp');
+    note(`  env: GEMINI_CLI_TRUST_WORKSPACE=true. Trust applies to this process only, in a new empty scratch directory below ${scratchParent}. trustedFolders.json stays unchanged.`);
+    let cwd;
+    if (!opts.dryRun) {
+      try {
+        fs.mkdirSync(scratchParent, { recursive: true });
+        cwd = fs.mkdtempSync(path.join(scratchParent, 'gemini-install-'));
+      } catch (e) {
+        results.failed.push(['gemini', `could not create scratch directory below ${scratchParent}: ${e.message}`]);
+        process.stdout.write('\n');
+        return;
+      }
+    }
+    try {
+      r = runSpawn('gemini', ['extensions', 'install', url, '--consent'], { env, cwd }, opts.dryRun);
+    } finally {
+      if (cwd) { try { fs.rmSync(cwd, { recursive: true, force: true }); } catch (_) {} }
+    }
   }
   if (spawnOk(r)) results.installed.push('gemini');
   else results.failed.push(['gemini', 'gemini extensions install failed']);

--- a/bin/install.js
+++ b/bin/install.js
@@ -578,7 +578,49 @@ function installGemini(ctx) {
       return;
     }
   }
-  const r = runSpawn('gemini', ['extensions', 'install', `https://github.com/${REPO}`], null, opts.dryRun);
+  // Under `curl | bash`, stdin is the script, not a terminal. Gemini CLI reads
+  // its workspace-trust and extension-consent answers from stdin, so the
+  // install never ends. See issues #400 and #676. Two parts remove the two
+  // prompts.
+  //   GEMINI_CLI_TRUST_WORKSPACE=true trusts cwd for this process only. It is
+  //     what `--skip-trust` sets. That flag belongs to the root chat command
+  //     and never reaches the `extensions` subcommand.
+  //   --consent answers the extension-install warning. Do not pass it without
+  //     the variable. Alone, it also answers the trust prompt with yes, and
+  //     that writes cwd into trustedFolders.json permanently.
+  // A trusted cwd lets Gemini CLI load .gemini/ config and .env files. Gemini
+  // CLI also searches every parent directory up to the root for those files.
+  // So run the install from a new empty scratch directory below the user's
+  // own ~/.caveman/tmp. Every parent then belongs to the user or to root, and
+  // trust covers nothing. A directory below /tmp is not safe, because another
+  // local user can plant /tmp/.env. A directory below ~/.gemini/tmp is not
+  // safe, because Gemini CLI keeps per-project state there under the cwd
+  // name. The scratch directory comes from mkdtemp, so this run owns it and
+  // removes only it. Never remove a fixed path, because it can hold data from
+  // an earlier process. If the directory cannot be made, report a failure and
+  // do not start Gemini CLI. A GitHub source does not use cwd.
+  // A Gemini CLI before v0.7.0 rejects `--consent` with exit 1. The installer
+  // then reports a failure and does not wait.
+  const env = Object.assign({}, process.env, { GEMINI_CLI_TRUST_WORKSPACE: 'true' });
+  const scratchParent = path.join(os.homedir(), '.caveman', 'tmp');
+  note(`  env: GEMINI_CLI_TRUST_WORKSPACE=true. Trust applies to this process only, in a new empty scratch directory below ${scratchParent}. trustedFolders.json stays unchanged.`);
+  let cwd;
+  if (!opts.dryRun) {
+    try {
+      fs.mkdirSync(scratchParent, { recursive: true });
+      cwd = fs.mkdtempSync(path.join(scratchParent, 'gemini-install-'));
+    } catch (e) {
+      results.failed.push(['gemini', `could not create scratch directory below ${scratchParent}: ${e.message}`]);
+      process.stdout.write('\n');
+      return;
+    }
+  }
+  let r;
+  try {
+    r = runSpawn('gemini', ['extensions', 'install', `https://github.com/${REPO}`, '--consent'], { env, cwd }, opts.dryRun);
+  } finally {
+    if (cwd) { try { fs.rmSync(cwd, { recursive: true, force: true }); } catch (_) {} }
+  }
   if (spawnOk(r)) results.installed.push('gemini');
   else results.failed.push(['gemini', 'gemini extensions install failed']);
   process.stdout.write('\n');

--- a/tests/installer/gemini-install.test.mjs
+++ b/tests/installer/gemini-install.test.mjs
@@ -6,18 +6,26 @@
 // Gemini CLI also asks an extension-consent question on that stdin.
 // The install then waits without an end.
 //
-// The correction has two parts. Keep the two parts together.
+// Gemini CLI v0.41.0 and later remove both prompts when the installer sends two parts together.
 // The `--consent` flag answers the extension-install warning.
 // The GEMINI_CLI_TRUST_WORKSPACE variable trusts the directory for this process.
 // The trust prompt then does not run, and trustedFolders.json stays unchanged.
 //
-// The `--consent` flag alone also removes the trust prompt.
+// The `--consent` flag alone also removes the trust prompt on some versions.
 // But its yes-branch writes the current directory into trustedFolders.json.
 // These tests hold the variable and the flag together.
 //
+// A Gemini CLI before v0.41.0 ignores the variable. The pair is not safe there.
+// The installer therefore probes `gemini --help` one time.
+// The text `--skip-trust` shows that this CLI reads the variable.
+// The guarantee of no prompt holds only for that result.
+// Without the flag, and after a failed probe, the installer runs the old command.
+// The old command uses the caller directory, no variable, and no `--consent`.
+// The CLI can then ask its own questions, as before this change.
+//
 // A trusted directory lets Gemini CLI load .gemini/ config and .env files.
 // Gemini CLI also searches every parent directory for those files.
-// The installer runs the command in a new empty scratch directory below ~/.caveman/tmp.
+// The installer runs the modern command in a new empty scratch directory below ~/.caveman/tmp.
 // Every parent then belongs to the user or to root, and the trust covers nothing.
 // Gemini CLI keeps per-project state in ~/.gemini/tmp, so the scratch directory is not there.
 // The directory comes from mkdtemp. The installer removes only that directory.
@@ -46,12 +54,32 @@ function freshTmpDir() {
 // The directory goes first in PATH, and the first match wins.
 // Thus a real `gemini` on the machine needs no removal.
 // The fake answers `extensions list` with no extensions and records nothing for it.
+// The fake answers a bare `--help` with a short root help text and records nothing for it.
+// The help text holds the `--skip-trust` line only when the option skipTrust is true.
+// The options helpExit and helpStream give the exit status and the output stream of that answer.
 // For other calls it records the trust variable, its cwd, and each argument in CAVEMAN_TEST_RECORD.
 //
 // On Windows the installer starts a `.cmd` file only when it is a Node shim.
 // `portableInvocation` reads the shim, finds the script, and starts it with `process.execPath`.
 // So the Windows fake is `gemini.js` plus a shim in the shape that `parseWindowsNodeShim` accepts.
-function fakeGeminiDir(root, exitCode = 0) {
+const HELP_HEAD = [
+  'gemini [options]',
+  '',
+  'Options:',
+  '  -m, --model                 Model                          [string]',
+];
+const HELP_SKIP_TRUST = '  --skip-trust                Trust the current workspace for this session.  [boolean] [default: false]';
+const HELP_TAIL = [
+  '  -h, --help                  Show help                     [boolean]',
+];
+
+function helpLines(skipTrust) {
+  return skipTrust ? [...HELP_HEAD, HELP_SKIP_TRUST, ...HELP_TAIL] : [...HELP_HEAD, ...HELP_TAIL];
+}
+
+function fakeGeminiDir(root, options = {}) {
+  const { exitCode = 0, skipTrust = true, helpExit = 0, helpStream = 'stdout' } = options;
+  const help = helpLines(skipTrust);
   const dir = path.join(root, 'fake-bin');
   fs.mkdirSync(dir, { recursive: true });
   if (IS_WIN) {
@@ -59,6 +87,10 @@ function fakeGeminiDir(root, exitCode = 0) {
       "const fs = require('node:fs');\n"
       + 'const args = process.argv.slice(2);\n'
       + "if (args[0] === 'extensions' && args[1] === 'list') { console.log('No extensions installed.'); process.exit(0); }\n"
+      + `if (args.length === 1 && args[0] === '--help') {\n`
+      + `  process.${helpStream}.write(${JSON.stringify(help.join('\n') + '\n')});\n`
+      + `  process.exit(${helpExit});\n`
+      + '}\n'
       + 'const lines = [\n'
       + "  'GEMINI_CLI_TRUST_WORKSPACE=' + (process.env.GEMINI_CLI_TRUST_WORKSPACE || ''),\n"
       + "  'CWD=' + fs.realpathSync.native(process.cwd()),\n"
@@ -71,9 +103,16 @@ function fakeGeminiDir(root, exitCode = 0) {
       + '"%~dp0\\node.exe" "%~dp0\\gemini.js" %*\r\n');
   } else {
     const file = path.join(dir, 'gemini');
+    const redirect = helpStream === 'stderr' ? ' 1>&2' : '';
     fs.writeFileSync(file,
       '#!/bin/sh\n'
       + 'if [ "$1" = extensions ] && [ "$2" = list ]; then echo "No extensions installed."; exit 0; fi\n'
+      + 'if [ $# -eq 1 ] && [ "$1" = --help ]; then\n'
+      + `  cat <<'EOF_HELP'${redirect}\n`
+      + `${help.join('\n')}\n`
+      + 'EOF_HELP\n'
+      + `  exit ${helpExit}\n`
+      + 'fi\n'
       + '{\n'
       + '  echo "GEMINI_CLI_TRUST_WORKSPACE=${GEMINI_CLI_TRUST_WORKSPACE-}"\n'
       + '  echo "CWD=$(pwd -P)"\n'
@@ -85,24 +124,31 @@ function fakeGeminiDir(root, exitCode = 0) {
   return dir;
 }
 
-function runInstaller(root, args, fakeBin) {
+// The child environment starts from a copy of the test environment without GEMINI_CLI_TRUST_WORKSPACE.
+// The legacy path keeps an inherited variable.
+// Without that removal, the test cannot tell an inherited value from an installer-added value.
+// The option extraEnv adds variables to the child environment after that removal.
+function runInstaller(root, args, fakeBin, extraEnv = {}) {
   const home = path.join(root, 'home');
   fs.mkdirSync(home, { recursive: true });
   const record = path.join(root, 'record.txt');
   const sep = IS_WIN ? ';' : ':';
+  const baseEnv = { ...process.env };
+  delete baseEnv.GEMINI_CLI_TRUST_WORKSPACE;
   const r = spawnSync(process.execPath, [
     INSTALLER, ...args,
     '--config-dir', path.join(root, 'claude'),
     '--no-mcp-shrink',
   ], {
     env: {
-      ...process.env,
+      ...baseEnv,
       HOME: home,
       USERPROFILE: home,
       XDG_CONFIG_HOME: path.join(home, '.config'),
       NO_COLOR: '1',
       CAVEMAN_TEST_RECORD: record,
       PATH: `${fakeBin}${sep}${process.env.PATH || ''}`,
+      ...extraEnv,
     },
     input: '',
     encoding: 'utf8',
@@ -144,18 +190,44 @@ function assertScratchCwd(record, home) {
   assert.equal(fs.existsSync(cwd), false, `scratch dir not removed: ${cwd}`);
 }
 
-function assertConsentCall(record, home) {
+// Check the recorded command.
+// The option expectConsent selects the modern parts: the variable and `--consent`.
+// The option expectScratch selects the scratch-directory check.
+// The legacy path has no modern part, so both options are false there.
+function assertInstallCall(record, home, options = {}) {
+  const { expectConsent = true, expectScratch = expectConsent } = options;
   const t = tokens(record);
-  assert.ok(t.includes('GEMINI_CLI_TRUST_WORKSPACE=true'),
-    `session-only trust variable not passed to gemini: ${t.join(' ')}`);
   const iExtensions = t.indexOf('extensions');
   const iInstall = t.indexOf('install');
   const iUrl = t.indexOf(URL);
-  const iConsent = t.indexOf('--consent');
   assert.ok(iExtensions >= 0 && iInstall > iExtensions, `bad subcommand: ${t.join(' ')}`);
   assert.ok(iUrl > iInstall, `repository URL missing or misplaced: ${t.join(' ')}`);
-  assert.ok(iConsent > iUrl, `--consent missing or before the URL: ${t.join(' ')}`);
-  assertScratchCwd(record, home);
+  if (expectConsent) {
+    assert.ok(t.includes('GEMINI_CLI_TRUST_WORKSPACE=true'),
+      `session-only trust variable not passed to gemini: ${t.join(' ')}`);
+    assert.ok(t.indexOf('--consent') > iUrl, `--consent missing or before the URL: ${t.join(' ')}`);
+  } else {
+    assert.equal(t.includes('GEMINI_CLI_TRUST_WORKSPACE=true'), false,
+      `legacy path passed the trust variable: ${t.join(' ')}`);
+    assert.equal(t.includes('--consent'), false, `legacy path passed --consent: ${t.join(' ')}`);
+  }
+  if (expectScratch) assertScratchCwd(record, home);
+}
+
+function assertConsentCall(record, home) {
+  assertInstallCall(record, home);
+}
+
+// The legacy path must run in the installer's own directory.
+// It must also leave no scratch directory below <home>/.caveman/tmp.
+function assertCallerCwd(record, home) {
+  assert.equal(recordedCwd(record), fs.realpathSync.native(process.cwd()),
+    'legacy path did not run in the caller cwd');
+  const scratchParent = path.join(home, '.caveman', 'tmp');
+  const left = fs.existsSync(scratchParent)
+    ? fs.readdirSync(scratchParent).filter((name) => name.startsWith('gemini-install-'))
+    : [];
+  assert.deepEqual(left, [], `legacy path made a scratch dir: ${left.join(', ')}`);
 }
 
 // ── 1. Piped stdin with --non-interactive. The installer passes the two parts. ──
@@ -205,14 +277,14 @@ test('gemini dry run prints the --consent command and the trust variable', () =>
   }
 });
 
-// ── 4. An old CLI rejects --consent with exit code 1.
+// ── 4. A CLI that supports session trust but fails. It rejects the command with exit code 1.
 //      The installer must report a failure. It must not wait.
 //      The record must show that the fake started with the full command.
 //      Without that check, a launcher error gives the same message and the test passes falsely. ──
 test('gemini install reports a failure when the CLI rejects the command', () => {
   const root = freshTmpDir();
   try {
-    const fakeBin = fakeGeminiDir(root, 1);
+    const fakeBin = fakeGeminiDir(root, { exitCode: 1 });
     const { result, record, home } = runInstaller(root, ['--only', 'gemini', '--force', '--non-interactive'], fakeBin);
     assert.equal(result.status, 1, `installer must exit 1 when its only agent fails: ${result.stdout}${result.stderr}`);
     const out = `${result.stdout}${result.stderr}`;
@@ -282,6 +354,97 @@ test('gemini install preserves existing files below ~/.caveman/tmp', () => {
     }
     const left = fs.readdirSync(scratchParent).filter((name) => name.startsWith('gemini-install-'));
     assert.deepEqual(left, [], `scratch dirs left behind: ${left.join(', ')}`);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── 8. An older Gemini CLI with no `--skip-trust` in its help.
+//      The installer must run the command from before this change.
+//      That command uses the caller directory, no trust variable, and no `--consent`.
+//      A `--consent` on such a CLI trusts the caller directory permanently. ──
+test('gemini install falls back to the plain command on a CLI without --skip-trust', () => {
+  const root = freshTmpDir();
+  try {
+    const fakeBin = fakeGeminiDir(root, { skipTrust: false });
+    const { result, record, home } = runInstaller(root, ['--only', 'gemini', '--force', '--non-interactive'], fakeBin);
+    assert.notEqual(result.status, 1, `installer must not fail: ${result.stdout}${result.stderr}`);
+    assert.match(result.stdout, /gemini/);
+    assert.match(result.stdout, /installed/i);
+    assertInstallCall(record, home, { expectConsent: false });
+    assertCallerCwd(record, home);
+    assert.match(result.stdout, /no --skip-trust/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── 9. The dry run on an older CLI shows the plain command.
+//      It shows no `--consent` and no trust variable. It starts nothing. ──
+test('gemini dry run prints the plain command on a CLI without --skip-trust', () => {
+  const root = freshTmpDir();
+  try {
+    const fakeBin = fakeGeminiDir(root, { skipTrust: false });
+    const { result, record } = runInstaller(root, ['--only', 'gemini', '--force', '--dry-run'], fakeBin);
+    assert.notEqual(result.status, 2, `argv error: ${result.stderr}`);
+    const line = result.stdout.split(/\r?\n/).find((l) => l.includes('would run: gemini extensions install'));
+    assert.ok(line, `dry-run line missing: ${result.stdout}`);
+    assert.equal(line.trim(), `would run: gemini extensions install ${URL}`);
+    assert.doesNotMatch(result.stdout, /GEMINI_CLI_TRUST_WORKSPACE=true/);
+    assert.equal(fs.existsSync(record), false, 'dry run started gemini');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── 10. The probe fails with exit code 1, but its text holds `--skip-trust`.
+//       A failed probe does not prove support, so the installer must use the plain command.
+//       This checks the exit-status condition of the probe. ──
+test('gemini install falls back to the plain command when the help probe fails', () => {
+  const root = freshTmpDir();
+  try {
+    const fakeBin = fakeGeminiDir(root, { helpExit: 1 });
+    const { result, record, home } = runInstaller(root, ['--only', 'gemini', '--force', '--non-interactive'], fakeBin);
+    assert.notEqual(result.status, 1, `installer must not fail: ${result.stdout}${result.stderr}`);
+    assertInstallCall(record, home, { expectConsent: false });
+    assertCallerCwd(record, home);
+    assert.match(result.stdout, /could not read/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── 11. The help text comes on standard error. The exit status is 0.
+//       The probe must read both streams, so the modern command must run. ──
+test('gemini install reads the help probe from stderr too', () => {
+  const root = freshTmpDir();
+  try {
+    const fakeBin = fakeGeminiDir(root, { helpStream: 'stderr' });
+    const { result, record, home } = runInstaller(root, ['--only', 'gemini', '--force', '--non-interactive'], fakeBin);
+    assert.notEqual(result.status, 2, `argv error: ${result.stderr}`);
+    assertConsentCall(record, home);
+    assert.match(result.stdout, /installed/i);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── 12. The user sets GEMINI_CLI_TRUST_WORKSPACE before the install, on a CLI without `--skip-trust`.
+//       The legacy path keeps the inherited environment. It does not add and does not remove the variable.
+//       The command still has no `--consent`, and it still runs in the caller directory. ──
+test('gemini legacy path keeps an inherited GEMINI_CLI_TRUST_WORKSPACE', () => {
+  const root = freshTmpDir();
+  try {
+    const fakeBin = fakeGeminiDir(root, { skipTrust: false });
+    const { result, record, home } = runInstaller(root, ['--only', 'gemini', '--force', '--non-interactive'], fakeBin,
+      { GEMINI_CLI_TRUST_WORKSPACE: 'true' });
+    assert.notEqual(result.status, 1, `installer must not fail: ${result.stdout}${result.stderr}`);
+    const t = tokens(record);
+    assert.ok(t.includes('GEMINI_CLI_TRUST_WORKSPACE=true'), `inherited variable was removed: ${t.join(' ')}`);
+    assert.equal(t.includes('--consent'), false, `legacy path passed --consent: ${t.join(' ')}`);
+    assert.ok(t.indexOf(URL) > t.indexOf('install'), `repository URL missing or misplaced: ${t.join(' ')}`);
+    assertCallerCwd(record, home);
+    assert.match(result.stdout, /no --skip-trust/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/installer/gemini-install.test.mjs
+++ b/tests/installer/gemini-install.test.mjs
@@ -1,0 +1,288 @@
+// The Gemini extension install must not wait for input.
+// See issue #400.
+//
+// A `curl | bash` install gives the child process a non-TTY stdin.
+// Gemini CLI asks a workspace-trust question on that stdin.
+// Gemini CLI also asks an extension-consent question on that stdin.
+// The install then waits without an end.
+//
+// The correction has two parts. Keep the two parts together.
+// The `--consent` flag answers the extension-install warning.
+// The GEMINI_CLI_TRUST_WORKSPACE variable trusts the directory for this process.
+// The trust prompt then does not run, and trustedFolders.json stays unchanged.
+//
+// The `--consent` flag alone also removes the trust prompt.
+// But its yes-branch writes the current directory into trustedFolders.json.
+// These tests hold the variable and the flag together.
+//
+// A trusted directory lets Gemini CLI load .gemini/ config and .env files.
+// Gemini CLI also searches every parent directory for those files.
+// The installer runs the command in a new empty scratch directory below ~/.caveman/tmp.
+// Every parent then belongs to the user or to root, and the trust covers nothing.
+// Gemini CLI keeps per-project state in ~/.gemini/tmp, so the scratch directory is not there.
+// The directory comes from mkdtemp. The installer removes only that directory.
+// If the installer cannot create that directory, it must not start Gemini CLI.
+// These tests check the directory, the failure path, and existing user data too.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const INSTALLER = path.join(REPO_ROOT, 'bin', 'install.js');
+const URL = 'https://github.com/JuliusBrussee/caveman';
+const IS_WIN = process.platform === 'win32';
+
+function freshTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-gemini-'));
+}
+
+// Write a fake `gemini` into its own directory.
+// The directory goes first in PATH, and the first match wins.
+// Thus a real `gemini` on the machine needs no removal.
+// The fake answers `extensions list` with no extensions and records nothing for it.
+// For other calls it records the trust variable, its cwd, and each argument in CAVEMAN_TEST_RECORD.
+//
+// On Windows the installer starts a `.cmd` file only when it is a Node shim.
+// `portableInvocation` reads the shim, finds the script, and starts it with `process.execPath`.
+// So the Windows fake is `gemini.js` plus a shim in the shape that `parseWindowsNodeShim` accepts.
+function fakeGeminiDir(root, exitCode = 0) {
+  const dir = path.join(root, 'fake-bin');
+  fs.mkdirSync(dir, { recursive: true });
+  if (IS_WIN) {
+    fs.writeFileSync(path.join(dir, 'gemini.js'),
+      "const fs = require('node:fs');\n"
+      + 'const args = process.argv.slice(2);\n'
+      + "if (args[0] === 'extensions' && args[1] === 'list') { console.log('No extensions installed.'); process.exit(0); }\n"
+      + 'const lines = [\n'
+      + "  'GEMINI_CLI_TRUST_WORKSPACE=' + (process.env.GEMINI_CLI_TRUST_WORKSPACE || ''),\n"
+      + "  'CWD=' + fs.realpathSync.native(process.cwd()),\n"
+      + '  ...args,\n'
+      + '];\n'
+      + "fs.appendFileSync(process.env.CAVEMAN_TEST_RECORD, lines.join('\\n') + '\\n');\n"
+      + `process.exit(${exitCode});\n`);
+    fs.writeFileSync(path.join(dir, 'gemini.cmd'),
+      '@echo off\r\n'
+      + '"%~dp0\\node.exe" "%~dp0\\gemini.js" %*\r\n');
+  } else {
+    const file = path.join(dir, 'gemini');
+    fs.writeFileSync(file,
+      '#!/bin/sh\n'
+      + 'if [ "$1" = extensions ] && [ "$2" = list ]; then echo "No extensions installed."; exit 0; fi\n'
+      + '{\n'
+      + '  echo "GEMINI_CLI_TRUST_WORKSPACE=${GEMINI_CLI_TRUST_WORKSPACE-}"\n'
+      + '  echo "CWD=$(pwd -P)"\n'
+      + '  for a in "$@"; do echo "$a"; done\n'
+      + '} >> "$CAVEMAN_TEST_RECORD"\n'
+      + `exit ${exitCode}\n`);
+    fs.chmodSync(file, 0o755);
+  }
+  return dir;
+}
+
+function runInstaller(root, args, fakeBin) {
+  const home = path.join(root, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  const record = path.join(root, 'record.txt');
+  const sep = IS_WIN ? ';' : ':';
+  const r = spawnSync(process.execPath, [
+    INSTALLER, ...args,
+    '--config-dir', path.join(root, 'claude'),
+    '--no-mcp-shrink',
+  ], {
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      XDG_CONFIG_HOME: path.join(home, '.config'),
+      NO_COLOR: '1',
+      CAVEMAN_TEST_RECORD: record,
+      PATH: `${fakeBin}${sep}${process.env.PATH || ''}`,
+    },
+    input: '',
+    encoding: 'utf8',
+  });
+  return { result: r, record, home };
+}
+
+// Split the record into tokens.
+// The POSIX fake writes one token on each line.
+// The Windows fake writes all arguments on one line.
+// Therefore split on each space and on each line end.
+function tokens(record) {
+  return fs.readFileSync(record, 'utf8')
+    .split(/\r?\n/)
+    .filter((line) => !line.startsWith('CWD='))
+    .join(' ')
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+// The path can contain spaces, so read the CWD line whole.
+function recordedCwd(record) {
+  const line = fs.readFileSync(record, 'utf8').split(/\r?\n/).find((l) => l.startsWith('CWD='));
+  assert.ok(line, 'fake gemini did not record its cwd');
+  return line.slice('CWD='.length).trim();
+}
+
+// The install must run in a new directory below <home>/.caveman/tmp.
+// It must not run in the caller's directory or below the shared OS temp root.
+// The installer must remove the directory after the run.
+// Windows can give the temp root a short 8.3 name, so resolve both parents with the native realpath.
+function assertScratchCwd(record, home) {
+  const cwd = recordedCwd(record);
+  const scratchParent = fs.realpathSync.native(path.join(home, '.caveman', 'tmp'));
+  const parent = fs.realpathSync.native(path.dirname(cwd));
+  assert.notEqual(path.resolve(cwd), path.resolve(process.cwd()), 'gemini ran in the caller cwd');
+  assert.equal(parent, scratchParent, `gemini cwd is not below ~/.caveman/tmp: ${cwd}`);
+  assert.ok(path.basename(cwd).startsWith('gemini-install-'), `unexpected scratch dir name: ${cwd}`);
+  assert.equal(fs.existsSync(cwd), false, `scratch dir not removed: ${cwd}`);
+}
+
+function assertConsentCall(record, home) {
+  const t = tokens(record);
+  assert.ok(t.includes('GEMINI_CLI_TRUST_WORKSPACE=true'),
+    `session-only trust variable not passed to gemini: ${t.join(' ')}`);
+  const iExtensions = t.indexOf('extensions');
+  const iInstall = t.indexOf('install');
+  const iUrl = t.indexOf(URL);
+  const iConsent = t.indexOf('--consent');
+  assert.ok(iExtensions >= 0 && iInstall > iExtensions, `bad subcommand: ${t.join(' ')}`);
+  assert.ok(iUrl > iInstall, `repository URL missing or misplaced: ${t.join(' ')}`);
+  assert.ok(iConsent > iUrl, `--consent missing or before the URL: ${t.join(' ')}`);
+  assertScratchCwd(record, home);
+}
+
+// ── 1. Piped stdin with --non-interactive. The installer passes the two parts. ──
+test('gemini install passes --consent and session-only trust (non-interactive)', () => {
+  const root = freshTmpDir();
+  try {
+    const fakeBin = fakeGeminiDir(root);
+    const { result, record, home } = runInstaller(root, ['--only', 'gemini', '--force', '--non-interactive'], fakeBin);
+    assert.notEqual(result.status, 2, `argv error: ${result.stderr}`);
+    assertConsentCall(record, home);
+    assert.match(result.stdout, /gemini/);
+    assert.match(result.stdout, /installed/i);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── 2. The same call without --non-interactive. Stdin stays a pipe.
+//      Thus the installer must not use a TTY branch. ──
+test('gemini install needs no TTY branch: same command without --non-interactive', () => {
+  const root = freshTmpDir();
+  try {
+    const fakeBin = fakeGeminiDir(root);
+    const { result, record, home } = runInstaller(root, ['--only', 'gemini', '--force'], fakeBin);
+    assert.notEqual(result.status, 2, `argv error: ${result.stderr}`);
+    assertConsentCall(record, home);
+    assert.match(result.stdout, /gemini/);
+    assert.match(result.stdout, /installed/i);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── 3. The dry run shows the command and the variable. It starts nothing. ──
+test('gemini dry run prints the --consent command and the trust variable', () => {
+  const root = freshTmpDir();
+  try {
+    const fakeBin = fakeGeminiDir(root);
+    const { result, record } = runInstaller(root, ['--only', 'gemini', '--force', '--dry-run'], fakeBin);
+    assert.notEqual(result.status, 2, `argv error: ${result.stderr}`);
+    assert.ok(result.stdout.includes(`would run: gemini extensions install ${URL} --consent`),
+      `dry-run line missing: ${result.stdout}`);
+    assert.match(result.stdout, /GEMINI_CLI_TRUST_WORKSPACE=true/);
+    assert.equal(fs.existsSync(record), false, 'dry run started gemini');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── 4. An old CLI rejects --consent with exit code 1.
+//      The installer must report a failure. It must not wait.
+//      The record must show that the fake started with the full command.
+//      Without that check, a launcher error gives the same message and the test passes falsely. ──
+test('gemini install reports a failure when the CLI rejects the command', () => {
+  const root = freshTmpDir();
+  try {
+    const fakeBin = fakeGeminiDir(root, 1);
+    const { result, record, home } = runInstaller(root, ['--only', 'gemini', '--force', '--non-interactive'], fakeBin);
+    assert.equal(result.status, 1, `installer must exit 1 when its only agent fails: ${result.stdout}${result.stderr}`);
+    const out = `${result.stdout}${result.stderr}`;
+    assert.match(out, /gemini extensions install failed/);
+    assert.ok(fs.existsSync(record), 'fake gemini did not start');
+    assertConsentCall(record, home);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── 5. The default path without --force. The installer first runs
+//      `gemini extensions list`, then the install. This is the issue #400 path. ──
+test('gemini install without --force runs the list preflight and then the same command', () => {
+  const root = freshTmpDir();
+  try {
+    const fakeBin = fakeGeminiDir(root);
+    const { result, record, home } = runInstaller(root, ['--only', 'gemini', '--non-interactive'], fakeBin);
+    assert.notEqual(result.status, 2, `argv error: ${result.stderr}`);
+    assertConsentCall(record, home);
+    assert.match(result.stdout, /installed/i);
+    assert.doesNotMatch(result.stdout, /already installed/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── 6. The scratch directory cannot be made. A file blocks the parent path.
+//      The installer must report a failure and must not start Gemini CLI. ──
+test('gemini install fails closed when the scratch directory cannot be created', () => {
+  const root = freshTmpDir();
+  try {
+    const fakeBin = fakeGeminiDir(root);
+    const home = path.join(root, 'home');
+    fs.mkdirSync(path.join(home, '.caveman'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.caveman', 'tmp'), 'not a directory\n');
+    const { result, record } = runInstaller(root, ['--only', 'gemini', '--force', '--non-interactive'], fakeBin);
+    assert.equal(result.status, 1, `installer must exit 1 when its only agent fails: ${result.stdout}${result.stderr}`);
+    const out = `${result.stdout}${result.stderr}`;
+    assert.match(out, /could not create scratch directory/);
+    assert.doesNotMatch(out, /\$ gemini extensions install/);
+    assert.equal(fs.existsSync(record), false, 'gemini ran without a scratch directory');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── 7. User data below ~/.caveman/tmp must survive.
+//      The installer removes only the directory that it created. ──
+test('gemini install preserves existing files below ~/.caveman/tmp', () => {
+  const root = freshTmpDir();
+  try {
+    const fakeBin = fakeGeminiDir(root);
+    const home = path.join(root, 'home');
+    const scratchParent = path.join(home, '.caveman', 'tmp');
+    fs.mkdirSync(path.join(scratchParent, 'gemini-install'), { recursive: true });
+    const sentinels = [
+      path.join(scratchParent, 'user-data'),
+      path.join(scratchParent, 'gemini-install', 'user-data'),
+    ];
+    for (const file of sentinels) fs.writeFileSync(file, 'keep me\n');
+    const { result, record } = runInstaller(root, ['--only', 'gemini', '--force', '--non-interactive'], fakeBin);
+    assert.notEqual(result.status, 2, `argv error: ${result.stderr}`);
+    assertConsentCall(record, home);
+    for (const file of sentinels) {
+      assert.equal(fs.readFileSync(file, 'utf8'), 'keep me\n', `installer erased ${file}`);
+    }
+    const left = fs.readdirSync(scratchParent).filter((name) => name.startsWith('gemini-install-'));
+    assert.deepEqual(left, [], `scratch dirs left behind: ${left.join(', ')}`);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

A `curl | bash` install hangs at the Gemini CLI step. This change makes `gemini extensions install` finish without input on Gemini CLI v0.41.0 and later. It does not add any directory to the permanent trust file. On an older Gemini CLI it runs the same command as `main`.

Fixes #400
Fixes #676
Refs #460
Refs #993

## Problem

The shell pipe uses stdin for the installer script. The Gemini CLI child process inherits that stdin. Gemini CLI asks a workspace-trust question and an extension-consent question on stdin. It reads no answer, and the install waits without an end. The user sees the prompts but cannot answer them.

## Root cause

Gemini CLI reads both answers with `readline` on stdin. Commit ed1fbb7 added `--consent` for #676 on 2026-07-21. Commit 82864c8 moved the installer back to `bin/` on 2026-08-11 and dropped the flag. The current `main` passes no flag.

## Change

Two commits.

### Commit 1: session-only trust, consent flag, scratch directory

`installGemini` in `bin/install.js` runs:

```text
GEMINI_CLI_TRUST_WORKSPACE=true gemini extensions install https://github.com/JuliusBrussee/caveman --consent
```

The two parts have separate purposes:

- `GEMINI_CLI_TRUST_WORKSPACE=true` trusts the current directory for this process only. It is the variable that `--skip-trust` sets. Gemini CLI documents it for headless use. The trust prompt then does not run, and `trustedFolders.json` stays unchanged.
- `--consent` answers the extension-install warning.

The installer does not use `--skip-trust`. The root chat command owns that flag. After the subcommand, Gemini CLI rejects it as an unknown argument. Before the subcommand, Gemini CLI reads the other words as a chat prompt.

The installer does not use `--consent` alone. The trust prompt uses the same consent callback. Its yes-branch writes the current directory into `trustedFolders.json` permanently.

The installer runs the command in a new empty directory below `~/.caveman/tmp`. A trusted directory lets Gemini CLI load `.gemini/` config and `.env` files from the directory and from every parent. Below the user home, every parent belongs to the user or to root, so the trust covers nothing. A directory below `/tmp` is not safe, because any local user can plant `/tmp/.env`. A directory below `~/.gemini/tmp` is not safe, because Gemini CLI keeps project state there. The directory comes from `mkdtemp`, and the installer removes only that directory. If the installer cannot create it, it reports a failure and does not start Gemini CLI.

### Commit 2: capability probe for older CLIs

The review found that commit 1 passed both parts always. That fails or grants trust on an older Gemini CLI. Upstream source shows this:

| Tags | Untrusted directory on `extensions install` | `--consent` | `GEMINI_CLI_TRUST_WORKSPACE` |
|---|---|---|---|
| v0.10.0 to v0.12.0 | Hard reject | From v0.11.0 | Ignored |
| v0.13.0 to v0.28.0 | Trust prompt. `--consent` answers yes and writes the directory to `trustedFolders.json`. | Yes | Ignored |
| v0.29.0 to v0.40.0 | Same prompt on a TTY. Headless mode auto-trusts, upstream PR #18407. | Yes | Ignored |
| v0.41.0 and later | Prompt on a TTY. Headless mode needs `--skip-trust` or the variable, upstream PR #25814. | Yes | Honored |

`--skip-trust` and the variable come from the same upstream commit, dba9b9a0ff. So the installer now runs `gemini --help` one time and looks for `--skip-trust`:

- Flag present: the installer keeps the variable, the scratch directory, and `--consent`. No prompt, no wait, no write to `trustedFolders.json`.
- Flag absent, or probe failed: the installer runs the same command as `main`, from the caller directory, with no variable and no `--consent`. It prints one note line that names the case. Existing trust stays in effect. The installer grants no new trust. The CLI can prompt or wait, as on `main`.

`--consent` (v0.11.0) is older than `--skip-trust` (v0.41.0). So a CLI with `--skip-trust` also has `--consent`. The code comment states this assumption about the upstream release order.

The dry run prints the command for the installed CLI, and on the modern path the variable.

## Compatibility

The no-prompt guarantee holds only when the probe succeeds and finds `--skip-trust`. On every other version the installer sends the `main` command and leaves the CLI's own prompts in place. On no version does the installer make a directory trusted.

## Tests

`tests/installer/gemini-install.test.mjs`. A fake `gemini` on `PATH` answers `extensions list` and a bare `--help`, and records the trust variable, its cwd, and each argument for the install call. Twelve cases:

1. Piped stdin with `--non-interactive`: the variable is `true`, and `--consent` follows the URL.
2. Piped stdin without `--non-interactive`: the same result, so no TTY branch is necessary.
3. Dry run: the output shows the variable and the command, and Gemini CLI does not start.
4. A CLI with `--skip-trust` exits 1: the installer reports `gemini extensions install failed`.
5. Default path without `--force`: the `extensions list` preflight runs, then the same command.
6. The scratch directory cannot be made: the installer reports a failure, does not start Gemini CLI, and exits 1.
7. Existing files below `~/.caveman/tmp` keep their content, and no scratch directory remains.
8. A CLI without `--skip-trust`: the plain command runs in the caller directory, with no variable, no `--consent`, and no scratch directory.
9. Dry run on that CLI: the output shows the plain command and no variable.
10. The help probe exits 1 with `--skip-trust` in its text: the plain command runs, and the note says `could not read`.
11. The help text comes on stderr with exit 0: the modern command runs.
12. The user sets `GEMINI_CLI_TRUST_WORKSPACE=true` before the install, on a CLI without `--skip-trust`: the legacy path keeps the inherited variable and still passes no `--consent`.

The test helper removes `GEMINI_CLI_TRUST_WORKSPACE` from the child environment before it starts the installer. Without that removal, an inherited value looks like an installer-added value.

Results:

```text
node --test --test-force-exit tests/installer/gemini-install.test.mjs   12 pass, 0 fail
npm test                                                                 257 pass, 0 fail
python3 tests/verify_repo.py                                             all checks pass
```

## Manual test

Environment: Gemini CLI 0.58.0, Linux, a throwaway `HOME`, stdin from `/dev/null`.

| Case | Result | `trustedFolders.json` |
|---|---|---|
| Current command, no flags | Prompt shown, hung until a 60 s timeout | Not written |
| Installer with the probe (commit 2) | `--consent` command shown, exit 0, no prompt, extension listed, no scratch directory left | Not written |
| Bare `--consent`, no variable | Exit 0, no prompt, extension listed | Current directory written as `TRUST_FOLDER` |

The third row is why the modern path does not use `--consent` alone, and why the legacy path does not use `--consent` at all.

No Gemini CLI before v0.41.0 was available. The legacy path is proven by the fake only.

To repeat the second row:

```sh
TEST_HOME="$(mktemp -d)/home"; mkdir -p "$TEST_HOME"; cd "$TEST_HOME"
HOME="$TEST_HOME" USERPROFILE="$TEST_HOME" \
  bash /path/to/caveman/install.sh --only gemini --minimal --non-interactive --no-mcp-shrink \
  --config-dir "$TEST_HOME/.claude" </dev/null
HOME="$TEST_HOME" gemini extensions list          # expect: caveman
cat "$TEST_HOME/.gemini/trustedFolders.json"      # expect: no such file
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
