### PR TITLE
fix(hooks): convert MSYS-style CLAUDE_PLUGIN_ROOT to a Windows drive path

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-activate.js\"",
+            "command": "HOOK_ROOT=$(sed 's|^/\\([a-zA-Z]\\)/|\\1:/|' <<< \"${CLAUDE_PLUGIN_ROOT}\"); node \"$HOOK_ROOT/src/hooks/caveman-activate.js\"",
             "timeout": 30,
             "statusMessage": "Loading caveman mode..."
           }
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/src/hooks/caveman-mode-tracker.js\"",
+            "command": "HOOK_ROOT=$(sed 's|^/\\([a-zA-Z]\\)/|\\1:/|' <<< \"${CLAUDE_PLUGIN_ROOT}\"); node \"$HOOK_ROOT/src/hooks/caveman-mode-tracker.js\"",
             "timeout": 30,
             "statusMessage": "Tracking caveman mode..."
           }

--- a/tests/hooks/plugin-json-windows-hook-path.test.mjs
+++ b/tests/hooks/plugin-json-windows-hook-path.test.mjs
@@ -1,0 +1,58 @@
+// Regression test for issue #199: on Windows with Git Bash as the shell,
+// CLAUDE_PLUGIN_ROOT is set to an MSYS-style path (e.g. /c/Users/...), but
+// the hook commands in .claude-plugin/plugin.json pass it straight to
+// node.exe, which cannot resolve that format and throws MODULE_NOT_FOUND.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const PLUGIN_JSON = path.join(REPO_ROOT, '.claude-plugin', 'plugin.json');
+
+function hookCommand(hookName) {
+  const plugin = JSON.parse(fs.readFileSync(PLUGIN_JSON, 'utf8'));
+  return plugin.hooks[hookName][0].hooks[0].command;
+}
+
+// Runs a hook's shell command with a fake `node` on PATH that just echoes
+// the path argument it was given, so we can see exactly what path the real
+// node.exe would receive without needing a Windows host to run this on.
+function resolvedNodeArg(command, claudePluginRoot) {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-fakebin-'));
+  const fakeNode = path.join(binDir, 'node');
+  fs.writeFileSync(fakeNode, '#!/usr/bin/env bash\nprintf %s "$1"\n', { mode: 0o755 });
+  try {
+    const result = spawnSync('bash', ['-c', command], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH}`, CLAUDE_PLUGIN_ROOT: claudePluginRoot },
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return result.stdout;
+  } finally {
+    fs.rmSync(binDir, { recursive: true, force: true });
+  }
+}
+
+for (const hookName of ['SessionStart', 'UserPromptSubmit']) {
+  test(`${hookName} hook converts an MSYS-style CLAUDE_PLUGIN_ROOT to a Windows drive path`, () => {
+    const command = hookCommand(hookName);
+    const arg = resolvedNodeArg(command, '/c/Users/testuser/.claude/plugins/marketplaces/caveman');
+    assert.ok(
+      arg.startsWith('c:/Users/testuser/'),
+      `expected node's path argument to start with a Windows drive path, got: ${arg}`,
+    );
+    assert.ok(!arg.startsWith('/c/'), `node argument still looks like an MSYS path: ${arg}`);
+  });
+
+  test(`${hookName} hook leaves an ordinary POSIX CLAUDE_PLUGIN_ROOT unchanged`, () => {
+    const command = hookCommand(hookName);
+    const posixRoot = '/home/testuser/.claude/plugins/marketplaces/caveman';
+    const arg = resolvedNodeArg(command, posixRoot);
+    assert.ok(arg.startsWith(posixRoot), `expected the POSIX root to pass through untouched, got: ${arg}`);
+  });
+}


### PR DESCRIPTION
On Windows with Git Bash as the shell, Claude Code sets `CLAUDE_PLUGIN_ROOT`
as an MSYS-style path (`/c/Users/...`). Both hook commands in
`.claude-plugin/plugin.json` pass that string straight to `node.exe`, which
treats a leading `/c/` as a relative path on the current drive rather than a
drive root, so module resolution fails with `MODULE_NOT_FOUND` and
`SessionStart`/`UserPromptSubmit` silently no-op with no user-visible error.

The fix converts the path to a Windows drive form (`c:/Users/...`) before
invoking `node`, using the same sed transform from the issue's own
suggested workaround. It only matches a single-letter drive segment
(`^/[a-zA-Z]/`), so a POSIX-style root on macOS, Linux, or native Windows
shells passes through unchanged.

This is the same transform as the MSYS/Git Bash portion of #583, isolated
into a small, focused change now that #583 no longer applies cleanly.

Verified:
- New regression test (`tests/hooks/plugin-json-windows-hook-path.test.mjs`)
  reads the actual command strings from `plugin.json` and runs them under
  `bash -c` with a stub `node` on PATH, asserting the MSYS root gets
  converted and an ordinary POSIX root passes through untouched. Fails on
  main (2/4), passes on this branch (4/4).
- `npm test`, the standalone `tests/test_*.js` suite, `python -m unittest
  discover -s tests`, and `python tests/verify_repo.py` all pass in a clean
  Docker container against this branch.
- I have not run this on an actual Windows host with Git Bash and node.exe.
  I did replicate the CI `windows-powershell` job's own bash-parse check
  (`bash -n -c $h.command`) locally, and it passes.
