### PR TITLE
fix(opencode): inject the active level's filtered SKILL.md rules, not just the banner

### DIFF
--- a/src/plugins/opencode/plugin.js
+++ b/src/plugins/opencode/plugin.js
@@ -115,8 +115,75 @@ function removeFlag() {
   }
 }
 
-function reinforcementLine(mode) {
+function reinforcementBanner(mode) {
   return 'CAVEMAN MODE ACTIVE (' + mode + ') — session ruleset applies.';
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Derived from reinforcementBanner() itself (split on a sentinel) rather than
+// re-spelling the banner text as a second regex literal: one source of truth,
+// and it stays in sync if the wording above ever changes.
+const [bannerPrefix, bannerSuffix] = reinforcementBanner('\0').split('\0');
+const staleBlock = new RegExp(
+  escapeRegExp(bannerPrefix) + '[a-z-]+' + escapeRegExp(bannerSuffix) + '[\\s\\S]*$'
+);
+
+// SKILL.md is the single source of truth for caveman behavior, filtered to
+// the active level the same way caveman-activate.js does (#792 priority-2;
+// #909 already shipped priority-1). Kept local, not bridged via loadConfig().
+function canonicalModeLabel(mode) {
+  return mode === 'wenyan' ? 'wenyan-full' : mode;
+}
+
+function loadFilteredRuleset(mode) {
+  const modeLabel = canonicalModeLabel(mode);
+  // Two layouts, no CLAUDE_PLUGIN_ROOT-style env var for opencode: installed
+  // (plugins/caveman/plugin.js, skills at ../../skills/caveman/) and dev tree
+  // (src/plugins/opencode/plugin.js, skills three levels up at repo root).
+  const candidates = [
+    join(here, '..', '..', 'skills', 'caveman', 'SKILL.md'),
+    join(here, '..', '..', '..', 'skills', 'caveman', 'SKILL.md'),
+  ];
+  let skillContent = '';
+  for (const candidate of candidates) {
+    try {
+      skillContent = readFileSync(candidate, 'utf8');
+      break;
+    } catch (e) { /* try next candidate */ }
+  }
+  if (!skillContent) return null;
+
+  const body = skillContent.replace(/^---[\s\S]*?---\s*/, '');
+  const filtered = body.split('\n').reduce((acc, line) => {
+    // Intensity table rows start with | **level** |: keep only the active
+    // level's row (plus header/separator, which do not match this pattern).
+    const tableRowMatch = line.match(/^\|\s*\*\*(\S+?)\*\*\s*\|/);
+    if (tableRowMatch) {
+      if (tableRowMatch[1] === modeLabel) acc.push(line);
+      return acc;
+    }
+    // Example lines start with "- level:", keep only the active level's.
+    const exampleMatch = line.match(/^- (\S+?):\s/);
+    if (exampleMatch) {
+      if (exampleMatch[1] === modeLabel) acc.push(line);
+      return acc;
+    }
+    acc.push(line);
+    return acc;
+  }, []);
+  return filtered.join('\n');
+}
+
+function reinforcementLine(mode) {
+  const banner = reinforcementBanner(mode);
+  const ruleset = loadFilteredRuleset(mode);
+  // No SKILL.md reachable (a standalone hook install without the skills
+  // dir): fall back to the banner alone, the same degrade caveman-activate.js
+  // uses for the same case.
+  return ruleset ? banner + '\n\n' + ruleset : banner;
 }
 
 function applyModeChange(change) {
@@ -190,15 +257,15 @@ export const CavemanPlugin = async (_ctx) => {
       // append grows the system prompt without bound — silently eating the
       // context window. Rewrite any line we already left instead of stacking
       // another, so a mode switch updates in place rather than accumulating.
-      const stale = /CAVEMAN MODE ACTIVE \([a-z-]+\) — session ruleset applies\./g;
+      // staleBlock matches to end of string: `line` now carries the ruleset
+      // appended after the banner, and that content is always the last thing
+      // this hook writes into an entry, so replacing from the banner on is safe.
       let found = false;
       for (let i = 0; i < output.system.length; i++) {
-        if (typeof output.system[i] === 'string' && stale.test(output.system[i])) {
-          stale.lastIndex = 0;
-          output.system[i] = output.system[i].replace(stale, line);
+        if (typeof output.system[i] === 'string' && staleBlock.test(output.system[i])) {
+          output.system[i] = output.system[i].replace(staleBlock, line);
           found = true;
         }
-        stale.lastIndex = 0;
       }
       if (found) return;
       if (output.system.length > 0) {

--- a/tests/installer/opencode.test.mjs
+++ b/tests/installer/opencode.test.mjs
@@ -450,6 +450,66 @@ test('opencode plugin handles /caveman ultra, stop caveman, and session init via
   }
 });
 
+// ── system.transform must inject the ACTIVE LEVEL's filtered ruleset ─────
+// Checks injected content differs per level and a mid-session switch
+// replaces the whole block rather than stacking behind the prior one (#792).
+test('opencode system.transform injects the active level\'s filtered SKILL.md rules, not just the banner', async () => {
+  const xdg = freshTmpDir();
+  const shimDir = shimOpencode();
+  const origDefault = process.env.CAVEMAN_DEFAULT_MODE;
+  try {
+    const env = { ...process.env, XDG_CONFIG_HOME: xdg, PATH: pathWith(shimDir), NO_COLOR: '1' };
+    const r = runInstaller(['--only', 'opencode'], env);
+    assert.notEqual(r.status, 2);
+
+    const pluginPath = path.join(xdg, 'opencode', 'plugins', 'caveman', 'plugin.js');
+    process.env.XDG_CONFIG_HOME = xdg;
+    process.env.CAVEMAN_DEFAULT_MODE = 'full';
+
+    const mod = await import(pathToFileURL(pluginPath).href);
+    const factory = mod.default || mod.CavemanPlugin;
+    const handlers = await factory({});
+
+    await handlers['chat.message']({}, { parts: [{ type: 'text', text: '/caveman ultra' }] });
+    const sysUltra = { system: [] };
+    await handlers['experimental.chat.system.transform']({}, sysUltra);
+    assert.match(sysUltra.system[0], /CAVEMAN MODE ACTIVE \(ultra\)/);
+    // The ultra row's own text, present ONLY on the ultra intensity-table row.
+    assert.match(sysUltra.system[0], /NO prose abbreviations/,
+      'ultra should carry its own SKILL.md row, not just the banner');
+    assert.doesNotMatch(sysUltra.system[0], /No filler\/hedging\. Keep articles/,
+      'ultra must not carry the lite row');
+
+    // Switching level mid-session must swap in the NEW level's rules, not
+    // leave ultra's stacked behind lite's (the idempotent-rewrite path).
+    await handlers['chat.message']({}, { parts: [{ type: 'text', text: '/caveman lite' }] });
+    const sysLite = { system: [] };
+    await handlers['experimental.chat.system.transform']({}, sysLite);
+    await handlers['experimental.chat.system.transform']({}, sysLite); // reuse same array, as opencode may
+    assert.match(sysLite.system[0], /CAVEMAN MODE ACTIVE \(lite\)/);
+    assert.match(sysLite.system[0], /No filler\/hedging\. Keep articles/,
+      'lite should carry its own SKILL.md row');
+    assert.doesNotMatch(sysLite.system[0], /NO prose abbreviations/,
+      'switching to lite must drop ultra\'s row, not accumulate it');
+    assert.equal((sysLite.system[0].match(/CAVEMAN MODE ACTIVE/g) || []).length, 1,
+      'banner must not duplicate across repeated transforms');
+
+    // wenyan (bare, the stored flag value) must resolve to the wenyan-full
+    // SKILL.md row via the same alias caveman-activate.js uses, not emit an
+    // empty intensity section.
+    await handlers['chat.message']({}, { parts: [{ type: 'text', text: '/caveman wenyan' }] });
+    const sysWenyan = { system: [] };
+    await handlers['experimental.chat.system.transform']({}, sysWenyan);
+    assert.match(sysWenyan.system[0], /Maximum classical terseness/,
+      'bare wenyan flag should resolve to the wenyan-full row');
+  } finally {
+    if (origDefault === undefined) delete process.env.CAVEMAN_DEFAULT_MODE;
+    else process.env.CAVEMAN_DEFAULT_MODE = origDefault;
+    fs.rmSync(xdg, { recursive: true, force: true });
+    fs.rmSync(shimDir, { recursive: true, force: true });
+  }
+});
+
 // ── AGENTS.md marker damage must not splice the file ─────────────────────
 // Both markers present is not enough: they must be one matched pair, in order.
 // An END above a BEGIN made `existing.indexOf(END, begin)` return -1, and the


### PR DESCRIPTION
Fixes #983.

`experimental.chat.system.transform` in the opencode plugin only ever pushed the generic label `CAVEMAN MODE ACTIVE (<mode>)`. It never read `skills/caveman/SKILL.md`, so every intensity level ran on identical, empty instructions. The SessionStart hook already does the real work for another integration (`src/hooks/caveman-activate.js:325-404`): read SKILL.md, strip frontmatter, keep only the active level's intensity-table row and examples.

This mirrors that filter locally in `plugin.js` (not bridged through `caveman-config.js`, since `loadConfig()`/`loadParse()` above already exist purely because the compiled Bun runtime can't `require()`/`import()` a CJS sibling, and a third bridge isn't worth it for a ~15-line filter) and appends the result after the banner. The stale-block replace in `experimental.chat.system.transform` now matches to end of string instead of just the banner line, so a mid-session level switch swaps in the new level's rules rather than stacking behind the old ones.

Also derived the stale-block regex from `reinforcementBanner()` itself (splitting on a sentinel and escaping) rather than duplicating the banner text as a second literal, so the two can't drift.

**Verification**
- New regression test (`tests/installer/opencode.test.mjs`) confirmed failing against unpatched `main` (ultra's row absent, only the generic banner present) and passing on this branch, run in Docker on Node 18/20/22 (the CI matrix).
- Full `npm test` + `node --test tests/*.js` + `python -m unittest discover -s tests`, in Docker: same 16 pre-existing failures on `main` and on this branch (unrelated `profile scope` tests), no new failures.
- `competing-prs.sh` re-run at submission against `src/plugins/opencode/plugin.js`: one candidate, #740 (adds `recordModeChange` calls to `applyModeChange`/`handleSessionCreated`), confirmed by patch to not touch `reinforcementBanner`, `loadFilteredRuleset`, or the `system.transform` handler.
- I have not run this against opencode's own runtime, only against the plugin's exported hooks driven directly, the same way the existing test in this file already does.
