### PR TITLE
fix(mcp-servers): forward SIGTERM/SIGINT from caveman-shrink to its upstream child

### DIFF
--- a/src/mcp-servers/caveman-shrink/index.js
+++ b/src/mcp-servers/caveman-shrink/index.js
@@ -75,6 +75,19 @@ upstream.on('close', (code, signal) => {
   }
 });
 
+// Registering a handler here suppresses Node's default terminate-on-signal
+// behavior, so we must forward the signal to the child ourselves — otherwise
+// the wrapper would catch SIGTERM/SIGINT and never pass it on, leaving the
+// upstream process running, reparented to PID 1. Node keeps the process
+// alive only as long as something needs it to, so once `close` fires above
+// and removes the stdin listeners, the event loop drains and we exit with
+// the code/signal set there.
+function forwardSignalToUpstream(signal) {
+  if (!upstream.killed) upstream.kill(signal);
+}
+process.on('SIGTERM', () => forwardSignalToUpstream('SIGTERM'));
+process.on('SIGINT', () => forwardSignalToUpstream('SIGINT'));
+
 // JSON-RPC framing over stdio: messages are separated by newlines (the
 // MCP stdio transport uses LSP-like content but most servers emit one JSON
 // object per line). We line-buffer in both directions and parse opportunistically.

--- a/tests/installer/mcp-shrink.runtime.test.mjs
+++ b/tests/installer/mcp-shrink.runtime.test.mjs
@@ -1,11 +1,32 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const proxy = path.join(root, 'src', 'mcp-servers', 'caveman-shrink', 'index.js');
+
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(predicate, { timeoutMs = 5000, intervalMs = 20 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await sleep(intervalMs);
+  }
+  throw new Error('waitUntil: condition never became true');
+}
 
 test('caveman-shrink drains a large final response without requiring a trailing newline', () => {
   const size = 1_500_000;
@@ -33,3 +54,29 @@ test('caveman-shrink preserves UTF-8 code points split across upstream chunks', 
   assert.equal(result.status, 0, result.stderr);
   assert.equal(JSON.parse(result.stdout).result.payload, '🙂');
 });
+
+for (const signal of ['SIGTERM', 'SIGINT']) {
+  test(`caveman-shrink forwards ${signal} to its spawned upstream process`, async () => {
+    const pidFile = path.join(os.tmpdir(), `caveman-shrink-${signal}-${process.pid}-${Date.now()}.pid`);
+    const upstream = [
+      `require('fs').writeFileSync(${JSON.stringify(pidFile)}, String(process.pid))`,
+      'process.stdin.resume()',
+      'setInterval(() => {}, 1000000)',
+    ].join(';');
+
+    const wrapper = spawn(process.execPath, [proxy, process.execPath, '-e', upstream], { stdio: 'ignore' });
+
+    try {
+      await waitUntil(() => fs.existsSync(pidFile));
+      const upstreamPid = Number(fs.readFileSync(pidFile, 'utf8'));
+      assert.ok(isAlive(upstreamPid), 'upstream process should be running before the signal');
+
+      wrapper.kill(signal);
+      await waitUntil(() => wrapper.exitCode !== null || wrapper.signalCode !== null);
+      await waitUntil(() => !isAlive(upstreamPid));
+    } finally {
+      fs.rmSync(pidFile, { force: true });
+      if (isAlive(wrapper.pid)) wrapper.kill('SIGKILL');
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #742. `caveman-shrink` (the MCP proxy that wraps an upstream MCP server) only reacted to the spawned child's own `error`/`close` events — it never listened for signals sent to the wrapper itself. If something tears the wrapper down directly with SIGTERM/SIGINT (an MCP host ending a session, disabling a tool, reloading config) instead of killing a whole process group, the upstream child was left running, reparented to PID 1.

- Add `process.on('SIGTERM', ...)` / `process.on('SIGINT', ...)` handlers that forward the received signal to `upstream` via `upstream.kill(signal)`.
- The existing `upstream.on('close', ...)` handler already sets the correct exit code (`128 + signal number`) once the child actually stops, so no change needed there — the parent's event loop drains naturally after `close` removes the stdin listeners.

## Test plan

- [x] Reproduced the issue's own repro against unpatched `main`: after `kill -TERM` on the wrapper, the fake upstream process survived with `PPID 1`.
- [x] Added two regression tests to `tests/installer/mcp-shrink.runtime.test.mjs` (SIGTERM and SIGINT) that spawn the wrapper around a long-running child, record the child's real PID, signal the wrapper, and assert the child process no longer exists. Confirmed both fail against unpatched `index.js` and pass with the fix.
- [x] Full suite: `npm test` — 247/247 passing (245 pre-existing + 2 new).