### PR TITLE
fix(caveman-compress): reject a compressed body that is not smaller than the input

### DIFF
--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -649,6 +649,22 @@ def _compress_file_locked(filepath: Path) -> bool:
         print("   already in caveman form. Original file is untouched (no backup created).")
         return False
 
+    # A rewrite that is structurally faithful but LONGER than the input passes
+    # every check below (validate() only checks structural invariants, not
+    # length) and would otherwise be written over the original and reported
+    # as a successful compression — the opposite of what this tool exists to
+    # do (issue #776). Same length is also a reject: a compression that saved
+    # nothing isn't a compression.
+    compressed_len = len(compressed_body.strip())
+    body_len = len(body.strip())
+    if compressed_len >= body_len:
+        print(
+            "❌ Compression aborted: output is not smaller than input "
+            f"({compressed_len} >= {body_len} chars)."
+        )
+        print("   Original file is untouched (no backup created).")
+        return False
+
     # Reassemble: frontmatter (verbatim) + compressed body
     compressed = frontmatter + compressed_body
 

--- a/tests/test_compress_safety.py
+++ b/tests/test_compress_safety.py
@@ -73,6 +73,29 @@ class CompressSafetyTests(unittest.TestCase):
             self.assertEqual(path.read_text(encoding="utf-8"), original)
             self.assertFalse((Path(tmp) / "task.original.md").exists())
 
+    def test_expanded_compressed_output_does_not_touch_disk(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            original = "# Heading\n\nFox jump dog.\n"
+            expanded = "# Heading\n\nThe quick brown fox jumps over the lazy dog, repeatedly.\n"
+            path = self._file_with(Path(tmp), original)
+            with mock.patch.object(compress_mod, "call_claude", return_value=expanded):
+                ok = compress_mod.compress_file(path)
+            self.assertFalse(ok)
+            self.assertEqual(path.read_text(encoding="utf-8"), original)
+            self.assertFalse((Path(tmp) / "task.original.md").exists())
+
+    def test_same_length_compressed_output_does_not_touch_disk(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            original = "# Heading\n\nFox jump dog now.\n"
+            same_length = "# Heading\n\nDog jump fox now.\n"
+            self.assertEqual(len(original.strip()), len(same_length.strip()))
+            path = self._file_with(Path(tmp), original)
+            with mock.patch.object(compress_mod, "call_claude", return_value=same_length):
+                ok = compress_mod.compress_file(path)
+            self.assertFalse(ok)
+            self.assertEqual(path.read_text(encoding="utf-8"), original)
+            self.assertFalse((Path(tmp) / "task.original.md").exists())
+
     def test_real_compression_writes_backup_and_target(self):
         # Isolate the backup data dir to a temp location so the out-of-tree
         # backup (issue #420) never lands in the developer's real home dir.


### PR DESCRIPTION
## Summary

Fixes #776. `compress_file()` only rejected a compressed body when it was *exactly identical* to the input, and `validate()` checks structural invariants only (headings, code blocks, URLs, paths, bullets, inline code) — nothing compares length. A rewrite that is structurally faithful but **longer** than the input (or the same length with different content) passed every check, got written over the original, and was reported as a successful compression, defeating the tool's entire purpose.

- Added a length gate right after the existing identical-output guard in `compress_file()`: aborts before any backup or write when `len(compressed_body.strip()) >= len(body.strip())`.
- Message matches the issue's expected format: `❌ Compression aborted: output is not smaller than input (69 >= 26 chars).`

## Test plan

- [x] Reproduced the issue's exact repro against unpatched `main`: a 26-char body regressed to 69 chars, `compress_file()` returned `True`, and the larger file was written with a backup created.
- [x] Added two regression tests to `tests/test_compress_safety.py`, mirroring `test_identical_compressed_output_does_not_touch_disk`'s style:
  - `test_expanded_compressed_output_does_not_touch_disk` — output longer than input
  - `test_same_length_compressed_output_does_not_touch_disk` — output same length, different content
  Confirmed both fail against unpatched `compress.py` and pass with the fix.
- [x] Full suite: `python -m unittest discover -s tests -v` — 132/132 passing. `npm test` (Node suite) — 245/245 passing, unaffected by this change.