### PR TITLE
test(hooks): add reproduction corpus and table test for mode activation (#187)

### DIFF
--- a/tests/fixtures/mode-activation/cases.json
+++ b/tests/fixtures/mode-activation/cases.json
@@ -1,0 +1,220 @@
+[
+  {
+    "id": 1,
+    "prompt": "activate caveman",
+    "expected": {
+      "action": "set",
+      "mode": "full"
+    },
+    "issue": null,
+    "reason": "Direct natural-language activation command",
+    "category": "intended_activation",
+    "known_failing": false
+  },
+  {
+    "id": 2,
+    "prompt": "turn on caveman mode",
+    "expected": {
+      "action": "set",
+      "mode": "full"
+    },
+    "issue": null,
+    "reason": "Natural-language turn-on phrase",
+    "category": "intended_activation",
+    "known_failing": false
+  },
+  {
+    "id": 3,
+    "prompt": "talk like caveman",
+    "expected": {
+      "action": "set",
+      "mode": "full"
+    },
+    "issue": null,
+    "reason": "Persona activation phrase",
+    "category": "intended_activation",
+    "known_failing": false
+  },
+  {
+    "id": 4,
+    "prompt": "stop caveman",
+    "expected": {
+      "action": "clear"
+    },
+    "issue": null,
+    "reason": "Direct natural-language deactivation command",
+    "category": "intended_deactivation",
+    "known_failing": false
+  },
+  {
+    "id": 5,
+    "prompt": "back to normal mode",
+    "expected": {
+      "action": "clear"
+    },
+    "issue": null,
+    "reason": "Natural-language return to normal mode",
+    "category": "intended_deactivation",
+    "known_failing": false
+  },
+  {
+    "id": 6,
+    "prompt": "be brief",
+    "expected": {
+      "action": "set",
+      "mode": "full"
+    },
+    "issue": null,
+    "reason": "Brevity shortcut trigger",
+    "category": "intended_activation",
+    "known_failing": false
+  },
+  {
+    "id": 7,
+    "prompt": "/caveman ultra",
+    "expected": {
+      "action": "set",
+      "mode": "ultra"
+    },
+    "issue": 975,
+    "reason": "Slash command setting specific intensity level",
+    "category": "slash_command",
+    "known_failing": false
+  },
+  {
+    "id": 8,
+    "prompt": "/caveman off",
+    "expected": {
+      "action": "clear"
+    },
+    "issue": null,
+    "reason": "Slash command clearing active mode",
+    "category": "slash_command",
+    "known_failing": false
+  },
+  {
+    "id": 9,
+    "prompt": "what is caveman mode?",
+    "expected": null,
+    "issue": 598,
+    "reason": "Question about caveman must not activate mode",
+    "category": "question_guard",
+    "known_failing": false
+  },
+  {
+    "id": 10,
+    "prompt": "how does caveman work?",
+    "expected": null,
+    "issue": 598,
+    "reason": "Informational question about caveman behavior",
+    "category": "question_guard",
+    "known_failing": false
+  },
+  {
+    "id": 11,
+    "prompt": "I was reading about caveman art and stone tools",
+    "expected": null,
+    "issue": null,
+    "reason": "Historical prose mentioning caveman without command intent",
+    "category": "negative_prose",
+    "known_failing": false
+  },
+  {
+    "id": 12,
+    "prompt": "the ultra-wide monitor setup is great for development",
+    "expected": null,
+    "issue": null,
+    "reason": "Hardware discussion mentioning ultra without slash command",
+    "category": "negative_prose",
+    "known_failing": false
+  },
+  {
+    "id": 13,
+    "prompt": "switch to a different branch in git",
+    "expected": null,
+    "issue": null,
+    "reason": "Git branch command containing switch to",
+    "category": "negative_prose",
+    "known_failing": false
+  },
+  {
+    "id": 14,
+    "prompt": "switch from normal mode to debug mode",
+    "expected": null,
+    "issue": 187,
+    "reason": "Editor mode discussion without caveman context",
+    "category": "negative_prose",
+    "known_failing": false
+  },
+  {
+    "id": 15,
+    "prompt": "use normal mode for this task",
+    "expected": null,
+    "issue": 187,
+    "reason": "Normal mode mention without caveman context",
+    "category": "negative_prose",
+    "known_failing": false
+  },
+  {
+    "id": 16,
+    "prompt": "I want to start building a caveman-themed game",
+    "expected": null,
+    "current": {
+      "action": "set",
+      "mode": "full"
+    },
+    "issue": 187,
+    "reason": "Natural prose matches broad want.*caveman regex",
+    "category": "false_activation",
+    "known_failing": true
+  },
+  {
+    "id": 17,
+    "prompt": "don't activate caveman",
+    "expected": null,
+    "current": {
+      "action": "set",
+      "mode": "full"
+    },
+    "issue": 187,
+    "reason": "Negated command matches activate.*caveman without negative prefix guard",
+    "category": "false_activation",
+    "known_failing": true
+  },
+  {
+    "id": 18,
+    "prompt": "fix(caveman): stop caveman being disabled by ordinary prose",
+    "expected": null,
+    "current": {
+      "action": "clear"
+    },
+    "issue": 187,
+    "reason": "Commit message discussing stop caveman regex falsely clears active mode",
+    "category": "false_deactivation",
+    "known_failing": true
+  },
+  {
+    "id": 19,
+    "prompt": "The plugin unlinks the host-global flag whenever a prompt matches the regex that is supposed to detect a request to disable caveman. Fix that.",
+    "expected": null,
+    "current": {
+      "action": "clear"
+    },
+    "issue": 187,
+    "reason": "Technical issue report discussing disable caveman triggers deactivation",
+    "category": "false_deactivation",
+    "known_failing": true
+  },
+  {
+    "id": 20,
+    "prompt": "Should we turn off caveman for subagents? I am not asking you to do it, just asking.",
+    "expected": null,
+    "current": {
+      "action": "clear"
+    },
+    "issue": 187,
+    "reason": "Question about deactivation clears mode because isQuestion only guards activation",
+    "category": "false_deactivation",
+    "known_failing": true
+  }
+]

--- a/tests/test_mode_activation_corpus.js
+++ b/tests/test_mode_activation_corpus.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Table-driven regression corpus for mode-tracker natural-language activation (#187, #672, #975).
+//
+// Reads test cases from tests/fixtures/mode-activation/cases.json and asserts
+// parseModeChange behavior. Known-failing cases from open issues are explicitly
+// marked so the corpus lands cleanly without breaking CI while preserving an
+// honest record of current behavior for future regex refinements.
+//
+// Run: node tests/test_mode_activation_corpus.js
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const { parseModeChange } = require('../src/hooks/caveman-parse');
+
+const HOOK_PATH = path.resolve(__dirname, '..', 'src', 'hooks', 'caveman-mode-tracker.js');
+const FIXTURES_PATH = path.resolve(__dirname, 'fixtures', 'mode-activation', 'cases.json');
+
+const defaultFull = { getDefaultMode: () => 'full' };
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${e.message}`);
+  }
+}
+
+function runTracker(prompt, presetFlag) {
+  const cfg = fs.mkdtempSync(path.join(os.tmpdir(), 'caveman-corpus-parity-'));
+  try {
+    if (presetFlag) fs.writeFileSync(path.join(cfg, '.caveman-active'), presetFlag);
+    spawnSync(process.execPath, [HOOK_PATH], {
+      input: JSON.stringify({ prompt }),
+      env: { ...process.env, CLAUDE_CONFIG_DIR: cfg },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf8',
+    });
+    const flagPath = path.join(cfg, '.caveman-active');
+    return fs.existsSync(flagPath) ? fs.readFileSync(flagPath, 'utf8') : null;
+  } finally {
+    fs.rmSync(cfg, { recursive: true, force: true });
+  }
+}
+
+console.log('caveman mode-activation reproduction corpus tests\n');
+
+assert.ok(fs.existsSync(FIXTURES_PATH), 'fixtures file must exist at ' + FIXTURES_PATH);
+const cases = JSON.parse(fs.readFileSync(FIXTURES_PATH, 'utf8'));
+assert.ok(Array.isArray(cases) && cases.length > 0, 'fixtures must contain array of cases');
+
+for (const tc of cases) {
+  const label = `case #${tc.id} [${tc.category}]: "${tc.prompt}"`;
+  test(label, () => {
+    const verdict = parseModeChange(tc.prompt, defaultFull);
+    if (tc.known_failing) {
+      assert.deepStrictEqual(
+        verdict,
+        tc.current,
+        `${tc.reason} (documented known failure for issue #${tc.issue})`
+      );
+    } else {
+      assert.deepStrictEqual(
+        verdict,
+        tc.expected,
+        `${tc.reason}`
+      );
+    }
+  });
+}
+
+// Parity verification on representative corpus cases against real hook
+const parityIds = [1, 4, 7, 8, 9, 11, 16, 18];
+for (const id of parityIds) {
+  const tc = cases.find((c) => c.id === id);
+  if (!tc) continue;
+  test(`parity hook execution: case #${tc.id} "${tc.prompt}"`, () => {
+    const verdict = parseModeChange(tc.prompt, defaultFull);
+    const expectedFlag =
+      verdict === null ? null :
+      verdict.action === 'clear' ? null :
+      verdict.mode;
+    const actualFlag = runTracker(tc.prompt, null);
+    assert.strictEqual(actualFlag, expectedFlag);
+  });
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
### Summary

Adds a table-driven test corpus in `tests/fixtures/mode-activation/cases.json` and a runner in `tests/test_mode_activation_corpus.js` covering natural-language activation and deactivation behavior (#187, #672, #975).

### Why

Activation and deactivation bug reports often arrive as narrative anecdotes, making regressions hard to track without an explicit reproduction table.

This PR introduces a pure-data fixture set without modifying any existing production code or regexes:
1. **Intended triggers**: Explicit commands (`/caveman ultra`, `/caveman off`, `activate caveman`, `be brief`, `back to normal mode`).
2. **Negative prose controls**: General text that shouldn't trigger state changes (`"I was reading about caveman art"`, `"switch to a different branch in git"`, `"the ultra-wide monitor setup"`, `"switch from normal mode to debug mode"`).
3. **Documented known failures**: Exact edge cases reported in #187 (e.g. `"I want to start building a caveman game"`, `"don't activate caveman"`, `"fix(caveman): stop caveman being disabled by ordinary prose"`).

### Mechanics

- `tests/fixtures/mode-activation/cases.json` stores prompts, expected outcomes, categories, and references to open issues.
- `tests/test_mode_activation_corpus.js` exercises `parseModeChange` across all cases and validates parity against the hook (`caveman-mode-tracker.js`).
- Known-failing cases are explicitly flagged (`known_failing: true`) and assert current behavior so CI passes while maintaining an honest baseline for future regex improvements.
- Uses standard library only (`fs`, `path`, `assert`, `child_process`). Runs 28 assertions in ~3s.

### Verification

- `node tests/test_mode_activation_corpus.js` (28 passed, 0 failed)
- `node tests/test_caveman_parse.js` (49 passed, 0 failed)
- `node tests/test_mode_tracker_stdin.js` (18 passed, 0 failed)
- `python -m unittest tests/test_mode_tracker.py` (34 passed, 0 failed)
