### PR TITLE
fix(shrink): escalate to SIGKILL on a stuck upstream

### DIFF
--- a/src/mcp-servers/caveman-shrink/index.js
+++ b/src/mcp-servers/caveman-shrink/index.js
@@ -27,9 +27,9 @@
 //   CAVEMAN_SHRINK_DEBUG=1  log compression deltas to stderr
 
 const { spawn } = require('child_process');
-const { constants: osConstants } = require('os');
 const { StringDecoder } = require('string_decoder');
 const { compressDescriptionsInPlace, compress } = require('./compress');
+const { createShutdown } = require('./shutdown');
 
 const args = process.argv.slice(2);
 if (args.length === 0) {
@@ -59,20 +59,21 @@ upstream.on('error', err => {
   process.stderr.write(`caveman-shrink: failed to spawn upstream: ${err.message}\n`);
 });
 
+const shutdown = createShutdown({
+  child: upstream,
+  spawnFailed: () => spawnFailed,
+  detachInput: () => {
+    process.stdin.pause();
+    process.stdin.removeListener('data', forwardInput);
+    process.stdin.removeListener('end', endInput);
+  },
+});
+
 // `exit` can fire while stdout still has unread data and while our own stdout
 // is backpressured. Wait for child `close`, stop accepting client input, then
 // let Node exit naturally so every transformed byte drains.
 upstream.on('close', (code, signal) => {
-  process.stdin.pause();
-  process.stdin.removeListener('data', forwardInput);
-  process.stdin.removeListener('end', endInput);
-  if (spawnFailed) {
-    process.exitCode = 1;
-  } else if (signal) {
-    process.exitCode = 128 + (osConstants.signals[signal] || 1);
-  } else {
-    process.exitCode = code || 0;
-  }
+  process.exitCode = shutdown.onClose(code, signal);
 });
 
 // Registering a handler here suppresses Node's default terminate-on-signal
@@ -88,16 +89,18 @@ upstream.on('close', (code, signal) => {
 // the upstream on exactly the teardown a user is most likely to trigger by
 // hand. Registering it here keeps that on the one code path the other two use.
 //
-// SIGKILL is deliberately absent: it cannot be trapped, and on that path the
-// upstream is orphaned by the OS with nothing this process can do about it.
-// Windows has no real signals — process.kill() there terminates the target
-// without running handlers — so teardown on that platform goes through the
-// stdin EOF the `close` handler above already forwards.
-function forwardSignalToUpstream(signal) {
-  if (!upstream.killed) upstream.kill(signal);
-}
+// Forwarding alone is not enough for a server that traps the signal and
+// declines to exit: nothing would ever fire `close`, and the wrapper would sit
+// there as long as the upstream did. `shutdown.forward` escalates to SIGKILL
+// after a grace period so teardown terminates either way.
+//
+// SIGKILL is deliberately absent from the list below: it cannot be trapped, and
+// on that path the upstream is orphaned by the OS with nothing this process can
+// do about it. Windows has no real signals — process.kill() there terminates
+// the target without running handlers — so teardown on that platform goes
+// through the stdin EOF the `close` handler above already forwards.
 for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
-  process.on(signal, () => forwardSignalToUpstream(signal));
+  process.on(signal, () => shutdown.forward(signal));
 }
 
 // JSON-RPC framing over stdio: messages are separated by newlines (the

--- a/src/mcp-servers/caveman-shrink/package.json
+++ b/src/mcp-servers/caveman-shrink/package.json
@@ -26,6 +26,7 @@
     "index.js",
     "compress.js",
     "spawn-options.js",
+    "shutdown.js",
     "README.md"
   ]
 }

--- a/src/mcp-servers/caveman-shrink/shutdown.js
+++ b/src/mcp-servers/caveman-shrink/shutdown.js
@@ -1,0 +1,67 @@
+// Teardown for the caveman-shrink proxy, kept out of index.js so it can be
+// driven by tests without spawning a real upstream process.
+//
+// Two jobs:
+//   1. Forward a termination signal to the upstream and, if the upstream
+//      ignores it, escalate to SIGKILL after a grace period. Without the
+//      escalation a server that traps SIGTERM and declines to exit keeps both
+//      itself and this wrapper alive after the host has asked them to stop.
+//   2. Translate the upstream's `close` into our own exit code, and detach the
+//      client-side stdin listeners so the event loop can drain.
+
+const { constants: osConstants } = require('os');
+
+// Long enough for a server to flush and close its own resources, short enough
+// that a host tearing down a session does not visibly hang on us.
+const DEFAULT_GRACE_MS = 2000;
+
+function createShutdown({
+  child,
+  detachInput = () => {},
+  spawnFailed = () => false,
+  graceMs = DEFAULT_GRACE_MS,
+  // Injectable so the escalation can be tested without waiting on a real clock.
+  timers = { setTimeout, clearTimeout },
+} = {}) {
+  let graceTimer = null;
+
+  function clearGrace() {
+    if (graceTimer === null) return;
+    timers.clearTimeout(graceTimer);
+    graceTimer = null;
+  }
+
+  return {
+    // Send `signal` to the upstream and arm the escalation. Safe to call more
+    // than once: `kill` marks the child, so an impatient second Ctrl-C is a
+    // no-op rather than a duplicate signal and a second timer. A child that has
+    // already exited on its own is left alone.
+    forward(signal) {
+      if (child.killed || child.exitCode !== null || child.signalCode !== null) return;
+      child.kill(signal);
+      graceTimer = timers.setTimeout(() => {
+        graceTimer = null;
+        // Still here after the grace period: the upstream is ignoring the
+        // signal, so take the one it cannot trap.
+        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      }, graceMs);
+    },
+
+    // Returns the exit code this process should adopt. A child that died from
+    // a signal has no exit code of its own, so report it the way a shell does.
+    onClose(code, signal) {
+      clearGrace();
+      detachInput();
+      if (spawnFailed()) return 1;
+      if (signal) return 128 + (osConstants.signals[signal] || 1);
+      return code || 0;
+    },
+
+    // Exposed for tests; nothing in index.js needs to ask.
+    get pendingEscalation() {
+      return graceTimer !== null;
+    },
+  };
+}
+
+module.exports = { createShutdown, DEFAULT_GRACE_MS };

--- a/tests/test_mcp_shrink.js
+++ b/tests/test_mcp_shrink.js
@@ -13,6 +13,9 @@ const { compress, compressDescriptionsInPlace } = require(
 const { getSpawnOptions } = require(
   path.join(ROOT, 'src', 'mcp-servers', 'caveman-shrink', 'spawn-options.js')
 );
+const { createShutdown, DEFAULT_GRACE_MS } = require(
+  path.join(ROOT, 'src', 'mcp-servers', 'caveman-shrink', 'shutdown.js')
+);
 
 let passed = 0;
 let failed = 0;
@@ -215,6 +218,120 @@ test('package.json "files" ships every module the entry points require (#597)', 
       queue.push(dep);
     }
   }
+});
+
+
+// ── Teardown (shutdown.js) ──────────────────────────────────────────────────
+// A stand-in for the spawned upstream. Node sets exitCode/signalCode on a
+// ChildProcess once it has gone; before that both are null, which is what
+// createShutdown reads to decide whether anything is still worth killing.
+function fakeChild({ exitCode = null, signalCode = null, killed = false } = {}) {
+  return {
+    exitCode,
+    signalCode,
+    killed,
+    signals: [],
+    kill(sig) {
+      this.signals.push(sig);
+      this.killed = true;
+      return true;
+    },
+  };
+}
+
+// Hand-driven clock: nothing here waits on a real timer, so the escalation
+// tests stay synchronous and cannot flake under a loaded CI box.
+function fakeTimers() {
+  const pending = new Map();
+  let next = 1;
+  return {
+    setTimeout(fn) { pending.set(next, fn); return next++; },
+    clearTimeout(id) { pending.delete(id); },
+    get armed() { return pending.size; },
+    fire() {
+      const fns = [...pending.values()];
+      pending.clear();
+      for (const fn of fns) fn();
+    },
+  };
+}
+
+test('forwards a termination signal to a live upstream', () => {
+  const child = fakeChild();
+  const shutdown = createShutdown({ child, timers: fakeTimers() });
+  shutdown.forward('SIGTERM');
+  assert.deepEqual(child.signals, ['SIGTERM']);
+});
+
+test('escalates to SIGKILL when the upstream ignores the signal', () => {
+  // The whole point of the grace period: a server that traps SIGTERM and
+  // declines to exit would otherwise keep the wrapper alive alongside it.
+  const child = fakeChild();
+  const timers = fakeTimers();
+  const shutdown = createShutdown({ child, timers });
+  shutdown.forward('SIGTERM');
+  assert.equal(shutdown.pendingEscalation, true);
+  timers.fire();
+  assert.deepEqual(child.signals, ['SIGTERM', 'SIGKILL']);
+});
+
+test('does not escalate when the upstream exits inside the grace period', () => {
+  const child = fakeChild();
+  const timers = fakeTimers();
+  const shutdown = createShutdown({ child, timers });
+  shutdown.forward('SIGTERM');
+  child.exitCode = 0;            // upstream honoured the signal
+  timers.fire();
+  assert.deepEqual(child.signals, ['SIGTERM'], 'SIGKILL sent to an already-exited child');
+});
+
+test('a second signal is a no-op, not a duplicate kill and a second timer', () => {
+  // An impatient double Ctrl-C must not re-signal a child that is already
+  // being torn down, nor leave a second escalation timer behind it.
+  const child = fakeChild();
+  const timers = fakeTimers();
+  const shutdown = createShutdown({ child, timers });
+  shutdown.forward('SIGINT');
+  shutdown.forward('SIGINT');
+  assert.deepEqual(child.signals, ['SIGINT'], 'second Ctrl-C re-signalled the child');
+  assert.equal(timers.armed, 1, 'second Ctrl-C armed another timer');
+});
+
+test('leaves an already-exited upstream alone', () => {
+  const child = fakeChild({ exitCode: 0 });
+  const timers = fakeTimers();
+  const shutdown = createShutdown({ child, timers });
+  shutdown.forward('SIGTERM');
+  assert.deepEqual(child.signals, []);
+  assert.equal(timers.armed, 0);
+});
+
+test('close clears a pending escalation and detaches client input', () => {
+  const child = fakeChild();
+  const timers = fakeTimers();
+  let detached = 0;
+  const shutdown = createShutdown({ child, timers, detachInput: () => { detached++; } });
+  shutdown.forward('SIGTERM');
+  shutdown.onClose(0, null);
+  assert.equal(shutdown.pendingEscalation, false);
+  assert.equal(detached, 1);
+  timers.fire();
+  assert.deepEqual(child.signals, ['SIGTERM'], 'stale timer fired after close');
+});
+
+test('close reports the upstream exit code, or 128+signal when it was killed', () => {
+  const mk = extra => createShutdown({ child: fakeChild(), timers: fakeTimers(), ...extra });
+  assert.equal(mk().onClose(0, null), 0);
+  assert.equal(mk().onClose(3, null), 3);
+  assert.equal(mk().onClose(null, 'SIGTERM'), 143);
+  assert.equal(mk().onClose(null, 'SIGINT'), 130);
+  assert.equal(mk({ spawnFailed: () => true }).onClose(0, null), 1, 'spawn failure must not report success');
+});
+
+test('the default grace period is a real duration', () => {
+  // Guards against a refactor that drops the default to 0 and turns every
+  // teardown into an immediate SIGKILL.
+  assert.ok(DEFAULT_GRACE_MS >= 1000, `grace period too short: ${DEFAULT_GRACE_MS}ms`);
 });
 
 console.log(`\n${passed} passed, ${failed} failed`);


### PR DESCRIPTION
Follow-up to #775, which you reviewed on #993. You kept the SIGHUP gap it found and asked for the two pieces that did not come across: the grace period for a child that ignores the signal, and moving teardown into a testable `shutdown.js`. Both are here, rebuilt on current `main` rather than rebased, so there is no months-old base and no merge commit this time.

## Problem

`forwardSignalToUpstream` on `main` sends the signal and stops there:

```js
function forwardSignalToUpstream(signal) {
  if (!upstream.killed) upstream.kill(signal);
}
```

An upstream that honours SIGTERM exits, and `close` fires. One that traps it and declines to exit keeps running, and since nothing else terminates the wrapper, both processes survive the teardown the host just asked for. That is the same orphan the forwarding was added to prevent, on the subset of servers that install their own handler.

## Fix

`shutdown.forward(signal)` arms a 2s timer when it sends the signal and sends SIGKILL if the child is still alive when it expires. The timer is cleared on `close`, so a server that exits promptly is not delayed by it.

Teardown moves into `src/mcp-servers/caveman-shrink/shutdown.js`: signal forwarding, the escalation, exit-code translation, and the stdin detach. `index.js` keeps the wiring. Timers are injected, so the escalation tests run synchronously and cannot flake on a loaded runner.

`shutdown.js` is added to `package.json` "files". The packaging test from #597 fails without it, which turned out to be a useful guard.

## Evidence

`node tests/test_mcp_shrink.js` gives 26 passed / 0 failed, up from 18 on main.

Each of the eight new tests was run against a variant with the behaviour deliberately removed, so none of them is decorative:

| Variant | Test that catches it |
|---|---|
| escalation removed | escalates to SIGKILL when the upstream ignores the signal |
| SIGKILL sent unconditionally | does not escalate when the upstream exits inside the grace period |
| liveness guard removed | a second signal is a no-op, not a duplicate kill |
| `close` leaves the timer armed | close clears a pending escalation |
| grace period set to 0 | the default grace period is a real duration |
| signal exit code returns 1 | close reports 128+signal |

End to end, wrapping a server that follows stdin EOF, before and after the change:

```
main  : exited code=0 in 27ms | description -> "This is tool that reads file"
branch: exited code=0 in 36ms | description -> "This is tool that reads file"
```

Same output, same exit code, and the grace timer stays out of the normal path.

`python tests/verify_repo.py` passes. `npm test` passes.

## One thing I left out

While building the end-to-end check I hit a separate case that is still open on `main`. It is not what you asked for, so it is not in this PR. An upstream that ignores **stdin EOF** is orphaned, because `endInput()` only ends the child's stdin and nothing follows up:

```
main  : HUNG - wrapper still alive 6s after stdin EOF (upstream orphaned)
branch: HUNG - wrapper still alive 6s after stdin EOF (upstream orphaned)
```

That matters most on Windows, where there are no real signals and the comment in `index.js` points teardown at this exact path. #775 carried a backstop for it inside `endInput()`. Happy to send it as its own PR if you want it.

## Notes

- MIT directory, so inbound = outbound.
- Signed off (DCO).
- The SIGKILL escalation cannot be exercised natively on Windows, where `kill()` terminates the target without running handlers. The logic is covered by the unit tests above; I do not have a Linux node install on this machine to demonstrate it in a real process.
