### PR TITLE
fix(compress): compare code blocks by document position, not extraction type

### DIFF
--- a/skills/caveman-compress/scripts/validate.py
+++ b/skills/caveman-compress/scripts/validate.py
@@ -72,6 +72,13 @@ def extract_code_blocks(text):
     fence must use same char and be at least as long as opening). Supports
     nested fences (e.g. an outer 4-backtick block wrapping inner 3-backtick
     content).
+
+    Merges fenced and indented blocks by their DOCUMENT POSITION, not by
+    type. validate_code_blocks compares this list positionally (c1 != c2),
+    so a type-grouped return (all fenced, then all indented) makes two
+    blocks that swapped RELATIVE order in the document produce the same
+    list on both sides: the comparison passes while the invariant it
+    exists to check (block order preserved) has actually been violated.
     """
     blocks = []
     lines = text.split("\n")
@@ -82,6 +89,7 @@ def extract_code_blocks(text):
         if not m:
             i += 1
             continue
+        start = i
         fence_char = m.group(2)[0]
         fence_len = len(m.group(2))
         open_line = lines[i]
@@ -103,10 +111,11 @@ def extract_code_blocks(text):
             block_lines.append(lines[i])
             i += 1
         if closed:
-            blocks.append("\n".join(block_lines))
+            blocks.append((start, "\n".join(block_lines)))
         # Unclosed fences are silently skipped — they indicate malformed markdown
         # and including them would cause false-positive validation failures.
-    return blocks + extract_indented_code_blocks(text)
+    ordered = sorted(blocks + extract_indented_code_blocks(text), key=lambda pair: pair[0])
+    return [block_text for _, block_text in ordered]
 
 
 def extract_indented_code_blocks(text):
@@ -123,6 +132,10 @@ def extract_indented_code_blocks(text):
     prose the compressor SHOULD rewrite. A run is only treated as code when the
     document is not inside a list and the run is preceded by a blank line — so
     this adds detections, it never turns existing passes into false failures.
+
+    Returns (start_line, text) pairs rather than bare text: extract_code_blocks
+    needs each block's document position to merge it with fenced blocks in
+    order (see that function's docstring).
     """
     blocks = []
     lines = text.split("\n")
@@ -150,6 +163,7 @@ def extract_indented_code_blocks(text):
         elif indent == 0:
             in_list = False
         if not in_list and previous_blank and indent >= 4:
+            start = i
             run = []
             while i < n and i not in fenced:
                 current = lines[i]
@@ -170,7 +184,7 @@ def extract_indented_code_blocks(text):
                 run.append(current)
                 i += 1
             if run:
-                blocks.append("\n".join(run))
+                blocks.append((start, "\n".join(run)))
             previous_blank = False
             continue
         previous_blank = False

--- a/tests/test_validate_inline.py
+++ b/tests/test_validate_inline.py
@@ -53,9 +53,11 @@ class TestIndentedFenceDoesNotSwallow(unittest.TestCase):
         # it is now extracted as one (and must be preserved — it is literal
         # content the document is SHOWING). What must never happen is it opening
         # a fence that swallows the real block: `real = 1` stays its own entry.
+        # Order is document position (the indented marker appears before the
+        # real fenced block), not extraction type.
         self.assertEqual(
             extract_code_blocks(doc),
-            ["```js\nreal = 1\n```", "    ```"],
+            ["    ```", "```js\nreal = 1\n```"],
         )
         self.assertEqual(extract_inline_codes(doc), ["alpha"])
 
@@ -179,6 +181,46 @@ class TestIndentedCodeIsValidated(unittest.TestCase):
         Treating it as code would make ordinary nested prose uncompressible."""
         doc = "# Doc\n\n- a bullet\n    - nested prose that should stay compressible\n"
         self.assertEqual(extract_code_blocks(doc), [])
+
+
+class TestCrossTypeBlockOrderIsValidated(unittest.TestCase):
+    """extract_code_blocks used to return all fenced blocks (in doc order)
+    followed by all indented blocks (in doc order), so a fenced block and an
+    indented block swapping RELATIVE position produced the same concatenated
+    list on both sides of the diff. validate_code_blocks compares this list
+    positionally, so the swap passed silently even though the invariant it
+    checks (code block order preserved) was violated."""
+
+    ORIG = "Intro.\n\n```python\nprint('hi')\n```\n\nMiddle.\n\n    kubectl delete pod --all -n prod\n\nEnd.\n"
+    # Same two blocks, unchanged content, but the indented block now comes
+    # BEFORE the fenced block instead of after it.
+    SWAPPED = "Intro.\n\n    kubectl delete pod --all -n prod\n\nMiddle.\n\n```python\nprint('hi')\n```\n\nEnd.\n"
+
+    def test_extraction_reflects_document_order(self):
+        self.assertEqual(
+            extract_code_blocks(self.ORIG),
+            ["```python\nprint('hi')\n```", "    kubectl delete pod --all -n prod"],
+        )
+        self.assertEqual(
+            extract_code_blocks(self.SWAPPED),
+            ["    kubectl delete pod --all -n prod", "```python\nprint('hi')\n```"],
+        )
+
+    def test_swapped_block_order_fails_validation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            o, c = Path(tmp) / "o.md", Path(tmp) / "c.md"
+            o.write_text(self.ORIG, encoding="utf-8")
+            c.write_text(self.SWAPPED, encoding="utf-8")
+            result = validate(o, c)
+            self.assertFalse(result.is_valid, "a swapped block order must not pass")
+
+    def test_identical_document_still_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            o, c = Path(tmp) / "o.md", Path(tmp) / "c.md"
+            o.write_text(self.ORIG, encoding="utf-8")
+            c.write_text(self.ORIG, encoding="utf-8")
+            result = validate(o, c)
+            self.assertTrue(result.is_valid, result.errors)
 
 
 class TestPreservationPromisesAreErrors(unittest.TestCase):


### PR DESCRIPTION
`extract_code_blocks()` (`skills/caveman-compress/scripts/validate.py:109`) concatenated all fenced blocks in document order, then appended all indented blocks in document order: `blocks + extract_indented_code_blocks(text)`. That preserves within-type order but throws away cross-type order. `validate_code_blocks()` diffs this list with a plain `c1 != c2`, so a compression pass that swaps a fenced block and an indented block's relative position, content unchanged, produced identical lists on both sides and reported the file unchanged.

Fix: `extract_code_blocks()` and `extract_indented_code_blocks()` now track each block's starting line, and the final list is merged by that position instead of by extraction type. Both extractors still decide block boundaries exactly as before; only the merge order changed.

Fixes #997

**Verification**
- New regression test (`TestCrossTypeBlockOrderIsValidated`): fails on `main`, passes on this branch, run in a clean `python:3.11-slim` container.
- Full `tests/test_validate_inline.py` (23 tests) and `python -m unittest discover -s tests` (136 tests) both pass in `python:3.11-slim` / `node:20-slim`, matching the repo's `python` CI job.
- One existing test's expected block order (`test_lone_indented_marker_does_not_capture_the_real_block`) encoded the old type-grouped order; updated to the correct document-position order.
- Did not check the JS/Node compression paths in `src/` and `mcp-servers/`; this fix is scoped to the Python validator only.
