### PR TITLE
fix(redact): recognize ghs_ GitHub App installation tokens

### DIFF
--- a/packages/subagent-tax/lib/sink.mjs
+++ b/packages/subagent-tax/lib/sink.mjs
@@ -93,7 +93,7 @@ export function redactHeaders(headers) {
 // shift by a few chars; body_bytes always records the raw pre-redaction length.
 const BODY_PATTERNS = [
   { re: /[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+/g, tag: "email" },
-  { re: /\b(?:sk-[A-Za-z0-9_-]{10,}|ghp_[A-Za-z0-9]{20,}|gho_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{20,})\b/g, tag: "key" },
+  { re: /\b(?:sk-[A-Za-z0-9_-]{10,}|ghp_[A-Za-z0-9]{20,}|gho_[A-Za-z0-9]{20,}|ghs_[A-Za-z0-9._-]{36,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{20,})\b/g, tag: "key" },
 ];
 
 export function redactBodyString(text) {

--- a/packages/subagent-tax/tests/sink.test.mjs
+++ b/packages/subagent-tax/tests/sink.test.mjs
@@ -21,6 +21,15 @@ test("redactBody scrubs emails and credential-shaped strings, keeps JSON valid",
   assert.ok(out.system.includes("/Users/x stays"), "non-secret content untouched");
 });
 
+test("redactBody scrubs a GitHub App installation token (stateless JWT format)", () => {
+  const token = "ghs_" + "1eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJnaXRodWIifQ.c2lnbmF0dXJlLXBhcnQ";
+  const body = { model: "m", system: `installation token: ${token} in transcript`, messages: [] };
+  const out = redactBody(body);
+  assert.ok(!JSON.stringify(out).includes(token));
+  assert.match(out.system, /redacted:key:[0-9a-f]{8}/);
+  assert.ok(out.system.includes("installation token:") && out.system.includes("in transcript"));
+});
+
 test("classifyRequest routes every protocol", () => {
   assert.equal(classifyRequest("POST", "/v1/messages"), "anthropic-messages");
   assert.equal(classifyRequest("POST", "/v1/messages/count_tokens"), "anthropic-count-tokens");

--- a/proxy/internal/repointel/index.go
+++ b/proxy/internal/repointel/index.go
@@ -754,7 +754,7 @@ func safeTerm(value string) bool {
 	if strings.Contains(value, "..") || strings.HasPrefix(value, "/") || strings.HasSuffix(value, "/") {
 		return false
 	}
-	for _, prefix := range []string{"sk-", "pk-", "rk-", "ghp-", "ghp_", "github_pat-", "github_pat_", "xoxb-", "xoxa-", "xoxp-", "xoxr-", "xoxs-", "akia-", "akia_"} {
+	for _, prefix := range []string{"sk-", "pk-", "rk-", "ghp-", "ghp_", "ghs_", "github_pat-", "github_pat_", "xoxb-", "xoxa-", "xoxp-", "xoxr-", "xoxs-", "akia-", "akia_"} {
 		if strings.HasPrefix(value, prefix) {
 			return false
 		}

--- a/proxy/internal/repointel/index_test.go
+++ b/proxy/internal/repointel/index_test.go
@@ -426,6 +426,18 @@ func TestNormalizeTermsIsBoundedAndFailClosed(t *testing.T) {
 	}
 }
 
+func TestSafeTermRejectsGitHubAppInstallationToken(t *testing.T) {
+	// Fixture split mid-token so GitHub push protection never sees a
+	// contiguous secret-shaped literal.
+	token := "ghs_" + "1eyj0expiredtestfixturenotarealtoken"
+	if safeTerm(token) {
+		t.Fatalf("safeTerm(%q) = true, want false (ghs_ is a GitHub App installation token prefix)", token)
+	}
+	if !safeTerm("auth") {
+		t.Fatalf("safeTerm(\"auth\") = false, want true for an ordinary term")
+	}
+}
+
 func TestImpactTestsUsesDirectAndPackageRelationshipsWithoutCoverageClaims(t *testing.T) {
 	repoMap := Map{Files: []File{
 		{Path: "auth/refresh.go", Package: "auth"},

--- a/shared/platform/redact/payload.go
+++ b/shared/platform/redact/payload.go
@@ -222,7 +222,7 @@ var builtinNeedles = map[string][]string{
 	"pem-private-key":         {"-----end "},
 	"dsn-with-credentials":    {"postgres", "mysql", "mongodb", "redis"},
 	"sk-prefixed-key":         {"sk-"},
-	"credential-prefix-token": {"xox", "sk_live_", "rk_live_", "ghp_", "github_pat_", "aiza", "sk-proj-"},
+	"credential-prefix-token": {"xox", "sk_live_", "rk_live_", "ghp_", "github_pat_", "ghs_", "aiza", "sk-proj-"},
 }
 
 func needles(lits ...string) [][]byte {

--- a/shared/platform/redact/payload_test.go
+++ b/shared/platform/redact/payload_test.go
@@ -663,6 +663,7 @@ func TestPayloadRedactsVendorPrefixedTokens(t *testing.T) {
 		"github pat":        "ghp_16C7e42F292c6912E7710c838347Ae178B4a",
 		"github fine grain": "github_pat_11ABCDEFG0abcdefghijkl_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
 		"google api key":    "AIzaSyD-1234567890abcdefghijklmnopqrstuv",
+		"github app installation token (stateless JWT)": "ghs_" + "1eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJnaXRodWIifQ.c2lnbmF0dXJlLXBhcnQ",
 	} {
 		t.Run(name, func(t *testing.T) {
 			body := []byte("pasted " + token + " into the prompt")

--- a/shared/platform/redact/redact.go
+++ b/shared/platform/redact/redact.go
@@ -127,6 +127,7 @@ var (
 		`|rk_live_[A-Za-z0-9]{16,}` +
 		`|ghp_[A-Za-z0-9]{20,}` +
 		`|github_pat_[A-Za-z0-9_]{20,}` +
+		`|ghs_[A-Za-z0-9._-]{36,}` +
 		`|AIza[A-Za-z0-9_\-]{30,}` +
 		`|sk-proj-[A-Za-z0-9_\-]{20,})`)
 )

--- a/shared/platform/redact/redact_test.go
+++ b/shared/platform/redact/redact_test.go
@@ -76,6 +76,14 @@ var stringCases = []stringCase{
 		wantClean: true,
 		ruleHit:   "sk-prefixed-key",
 	},
+	// GitHub App installation token, stateless JWT format (dotted segments).
+	// Split mid-token so push protection never sees a contiguous secret.
+	{
+		name:      "GitHub App installation token (stateless JWT)",
+		input:     "seen in CI transcript: " + "ghs_" + "1eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJnaXRodWIifQ.c2lnbmF0dXJlLXBhcnQ",
+		wantClean: true,
+		ruleHit:   "credential-prefix-token",
+	},
 	// PEM private key
 	{
 		name: "PEM RSA private key block",


### PR DESCRIPTION
Added the `ghs_` branch at all four sites, with the character class you specified (letters, digits, dots, hyphens, underscores, dash last in the class) so it matches the stateless JWT shape and not just the old opaque token.

`payload.go`'s needle list needed the same addition since it gates whether the regex pass even runs; without it the regex change alone would never fire.

Tests: a synthetic `ghs_`-prefixed JWT-shaped fixture at each of the four call sites, split mid-token in source so push protection doesn't flag the fixtures themselves. All four show the same failure on main and pass on this branch. Full `go test ./shared/... ./proxy/...` and the `subagent-tax` node suite still pass (50/50).

Left `ghp_`, `gho_` and `github_pat_` untouched per your note, they're a different token family.
Fixes #1002