### PR TITLE
fix(proxy): forward OpenCode session headers on the opencode-go mount

### DIFF
--- a/proxy/internal/standalone/standalone_test.go
+++ b/proxy/internal/standalone/standalone_test.go
@@ -1115,16 +1115,19 @@ func TestStandaloneOpenCodeGoAuthEndToEnd(t *testing.T) {
 	const anthropicResponse = `{"id":"msg","type":"message","role":"assistant","model":"minimax-m3","content":[{"type":"text","text":"OK"}],"usage":{"input_tokens":1,"output_tokens":1}}`
 	const openAIBody = `{"model":"glm-5.2","messages":[{"role":"user","content":"Reply with OK"}]}`
 	const openAIResponse = `{"id":"chat","model":"glm-5.2","choices":[{"message":{"role":"assistant","content":"OK"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`
+	const responsesBody = `{"model":"glm-5.2","input":"Reply with OK"}`
+	const responsesResponse = `{"id":"resp","model":"glm-5.2","output":[{"type":"message","content":[{"type":"output_text","text":"OK"}]}],"usage":{"input_tokens":1,"output_tokens":1}}`
 
 	cases := []struct {
-		name       string
-		path       string
-		body       string
-		response   string
-		inbound    map[string]string
-		wantURL    string
-		wantAPIKey string
-		wantAuth   string
+		name        string
+		path        string
+		body        string
+		response    string
+		inbound     map[string]string
+		wantURL     string
+		wantAPIKey  string
+		wantAuth    string
+		wantHeaders map[string]string
 	}{
 		{
 			name:       "messages with inbound x-api-key",
@@ -1161,6 +1164,57 @@ func TestStandaloneOpenCodeGoAuthEndToEnd(t *testing.T) {
 			wantURL:  "https://opencode.ai/zen/go/v1/chat/completions",
 			wantAuth: "Bearer sk-inbound",
 		},
+		{
+			name:     "messages forwards the OpenCode session headers",
+			path:     "/w/pi/compat/opencode-go/v1/messages",
+			body:     anthropicBody,
+			response: anthropicResponse,
+			inbound: map[string]string{
+				"x-api-key":          "sk-inbound",
+				"x-opencode-session": "ses_messages",
+				"x-opencode-client":  "pi",
+			},
+			wantURL:    "https://opencode.ai/zen/go/v1/messages",
+			wantAPIKey: "sk-inbound",
+			wantHeaders: map[string]string{
+				"x-opencode-session": "ses_messages",
+				"x-opencode-client":  "pi",
+			},
+		},
+		{
+			name:     "chat completions forwards the OpenCode session headers",
+			path:     "/w/pi/compat/opencode-go/v1/chat/completions",
+			body:     openAIBody,
+			response: openAIResponse,
+			inbound: map[string]string{
+				"authorization":      "Bearer sk-inbound",
+				"x-opencode-session": "ses_chat",
+				"x-opencode-client":  "pi",
+			},
+			wantURL:  "https://opencode.ai/zen/go/v1/chat/completions",
+			wantAuth: "Bearer sk-inbound",
+			wantHeaders: map[string]string{
+				"x-opencode-session": "ses_chat",
+				"x-opencode-client":  "pi",
+			},
+		},
+		{
+			name:     "responses forwards the OpenCode session headers",
+			path:     "/w/pi/compat/opencode-go/v1/responses",
+			body:     responsesBody,
+			response: responsesResponse,
+			inbound: map[string]string{
+				"authorization":      "Bearer sk-inbound",
+				"x-opencode-session": "ses_responses",
+				"x-opencode-client":  "pi",
+			},
+			wantURL:  "https://opencode.ai/zen/go/v1/responses",
+			wantAuth: "Bearer sk-inbound",
+			wantHeaders: map[string]string{
+				"x-opencode-session": "ses_responses",
+				"x-opencode-client":  "pi",
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1195,6 +1249,15 @@ func TestStandaloneOpenCodeGoAuthEndToEnd(t *testing.T) {
 			}
 			if strings.Contains(upstream.headers.Get("authorization")+upstream.headers.Get("x-api-key"), "sk-legacy") {
 				t.Fatal("OPENAI_COMPAT_API_KEY reached the opencode-go mount")
+			}
+			for name, want := range tc.wantHeaders {
+				if got := upstream.headers.Get(name); got != want {
+					t.Errorf("upstream %s = %q, want %q", name, got, want)
+				}
+			}
+			// A case that sends no OpenCode header must not gain one.
+			if tc.wantHeaders["x-opencode-session"] == "" && upstream.headers.Get("x-opencode-session") != "" {
+				t.Errorf("upstream x-opencode-session = %q, want no header", upstream.headers.Get("x-opencode-session"))
 			}
 			if !bytes.Equal(upstream.body, []byte(tc.body)) {
 				t.Fatalf("record mode changed the body:\n got %s\nwant %s", upstream.body, tc.body)

--- a/proxy/providers/openaicompat/openaicompat.go
+++ b/proxy/providers/openaicompat/openaicompat.go
@@ -180,13 +180,19 @@ func (a namedAdapter) InspectRequest(ctx context.Context, body providers.BodyRea
 // inbound Bearer token keeps its scheme on every path, as the repository
 // preserves the auth scheme of an inbound credential. The placeholder token is
 // not a real credential. The gateway replaces it from the environment after
-// this mapping, so it must land in the header of the wire protocol.
+// this mapping, so it must land in the header of the wire protocol. The method
+// also forwards the OpenCode session headers on every path of the opencode-go
+// mount. See openCodeSessionHeaders.
 func (a namedAdapter) SanitizeAndMapHeaders(ctx context.Context, req *http.Request, credential providers.Credential, upstream *url.URL) (http.Header, error) {
 	out, err := a.Base.SanitizeAndMapHeaders(ctx, req, credential, upstream)
 	if err != nil {
 		return nil, err
 	}
-	if req == nil || req.URL == nil || !a.anthropicMessagesPath(req.URL.Path) {
+	if req == nil || req.URL == nil {
+		return out, nil
+	}
+	a.forwardOpenCodeHeaders(out, req.Header)
+	if !a.anthropicMessagesPath(req.URL.Path) {
 		return out, nil
 	}
 	if credential.Key != "" && !realBearer(credential) {
@@ -197,6 +203,37 @@ func (a namedAdapter) SanitizeAndMapHeaders(ctx context.Context, req *http.Reque
 		out.Set("anthropic-version", "2023-06-01")
 	}
 	return out, nil
+}
+
+// openCodeGoPrefix is the mount of the built-in OpenCode Go upstream. The
+// session headers below are forwarded on this mount only.
+const openCodeGoPrefix = "/compat/opencode-go"
+
+// openCodeSessionHeaders are the headers that OpenCode reads for session
+// attribution. Pi sends x-opencode-session and x-opencode-client. The OpenCode
+// CLI sends all four. OpenCode announced that from 2026-09-06 a request without
+// x-opencode-session can get an error. The shared allowlist of the base adapter
+// drops every x-opencode-* header, thus this mount puts them back.
+var openCodeSessionHeaders = []string{
+	"x-opencode-session",
+	"x-opencode-client",
+	"x-opencode-project",
+	"x-opencode-request",
+}
+
+// forwardOpenCodeHeaders copies the OpenCode session headers from the inbound
+// request to the upstream headers. The copy is gated on the opencode-go mount.
+// Another named mount has no use for these headers. It must not learn the
+// session identity of the caller.
+func (a namedAdapter) forwardOpenCodeHeaders(out, inbound http.Header) {
+	if a.prefix != openCodeGoPrefix {
+		return
+	}
+	for _, name := range openCodeSessionHeaders {
+		for _, value := range inbound.Values(name) {
+			out.Add(name, value)
+		}
+	}
 }
 
 // realBearer reports whether the credential is a Bearer token from the inbound

--- a/proxy/providers/openaicompat/openaicompat_test.go
+++ b/proxy/providers/openaicompat/openaicompat_test.go
@@ -277,3 +277,88 @@ func TestNewNamed_AnthropicMessagesPathUsesAPIKeyHeader(t *testing.T) {
 		t.Fatalf("empty credential produced auth headers: %v", out)
 	}
 }
+
+// TestNewNamed_ForwardsOpenCodeSessionHeaders pins the session headers that
+// OpenCode reads for attribution. The shared allowlist of the base adapter
+// drops every x-opencode-* header, and OpenCode can reject a request without
+// x-opencode-session. The forward covers the three Pi paths and stops at the
+// opencode-go mount.
+func TestNewNamed_ForwardsOpenCodeSessionHeaders(t *testing.T) {
+	adapter := mustNamed(t, "opencode-go", "https://opencode.ai/zen/go")
+	credential := providers.Credential{Mode: "ephemeral_header", Key: "sk-test"}
+	inbound := map[string]string{
+		"x-opencode-session": "ses_123",
+		"x-opencode-client":  "pi",
+		"x-opencode-project": "prj_456",
+		"x-opencode-request": "req_789",
+	}
+	paths := []string{
+		"/compat/opencode-go/v1/messages",
+		"/compat/opencode-go/v1/chat/completions",
+		"/compat/opencode-go/v1/responses",
+	}
+	for _, path := range paths {
+		t.Run("forwards "+path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			for name, value := range inbound {
+				req.Header.Set(name, value)
+			}
+			out, err := adapter.SanitizeAndMapHeaders(context.Background(), req, credential, nil)
+			if err != nil {
+				t.Fatalf("SanitizeAndMapHeaders: %v", err)
+			}
+			for name, want := range inbound {
+				if got := out.Get(name); got != want {
+					t.Errorf("%s = %q, want %q", name, got, want)
+				}
+			}
+		})
+		t.Run("omits "+path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			out, err := adapter.SanitizeAndMapHeaders(context.Background(), req, credential, nil)
+			if err != nil {
+				t.Fatalf("SanitizeAndMapHeaders: %v", err)
+			}
+			for name := range inbound {
+				if got := out.Get(name); got != "" {
+					t.Errorf("%s = %q, want no header", name, got)
+				}
+			}
+		})
+	}
+
+	// The messages path keeps the credential mapping of the wire protocol.
+	req := httptest.NewRequest(http.MethodPost, "/compat/opencode-go/v1/messages", nil)
+	for name, value := range inbound {
+		req.Header.Set(name, value)
+	}
+	out, err := adapter.SanitizeAndMapHeaders(context.Background(), req, credential, nil)
+	if err != nil {
+		t.Fatalf("SanitizeAndMapHeaders: %v", err)
+	}
+	if got := out.Get("x-api-key"); got != "sk-test" {
+		t.Errorf("x-api-key = %q, want %q", got, "sk-test")
+	}
+	if got := out.Get("authorization"); got != "" {
+		t.Errorf("authorization = %q, want no header", got)
+	}
+	if got := out.Get("anthropic-version"); got != "2023-06-01" {
+		t.Errorf("anthropic-version = %q, want %q", got, "2023-06-01")
+	}
+
+	// Another named mount gets none of the headers.
+	other := mustNamed(t, "other", "https://api.example.test")
+	otherReq := httptest.NewRequest(http.MethodPost, "/compat/other/v1/chat/completions", nil)
+	for name, value := range inbound {
+		otherReq.Header.Set(name, value)
+	}
+	otherOut, err := other.SanitizeAndMapHeaders(context.Background(), otherReq, credential, nil)
+	if err != nil {
+		t.Fatalf("SanitizeAndMapHeaders on the other mount: %v", err)
+	}
+	for name := range inbound {
+		if got := otherOut.Get(name); got != "" {
+			t.Errorf("other mount %s = %q, want no header", name, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- The opencode-go compat mount now forwards `x-opencode-session`, `x-opencode-client`, `x-opencode-project`, and `x-opencode-request` to the upstream (fixes #1006). Pi 0.85.1 sends the first two on each request that has a session ID. OpenCode announced that from 2026-09-06 a request without `x-opencode-session` can get an error.
- `Base.SanitizeAndMapHeaders` builds a new header map from a fixed allowlist, thus the proxy dropped every `x-opencode-*` header. The named adapter in `proxy/providers/openaicompat/openaicompat.go` now copies the four names after the base call and before the early return for non-Messages paths. Thus the copy runs on `/v1/messages`, `/v1/chat/completions`, and `/v1/responses`.
- The copy is gated on the mount prefix `/compat/opencode-go`. The shared allowlist, the credential mapping, and the `x-api-key` remap on `/v1/messages` are unchanged. No `x-opencode-*` wildcard is added, so another named mount does not learn the session identity of the caller.
- The four header names live in one package-level slice with a comment that gives the reason.

## Proof

- New adapter test `TestNewNamed_ForwardsOpenCodeSessionHeaders` in `proxy/providers/openaicompat/openaicompat_test.go`. It covers the three paths with the headers present and absent. It asserts that the messages path still sets `x-api-key` and `anthropic-version`. It asserts that a second named mount at `/compat/other` forwards none of the four headers.
- `TestStandaloneOpenCodeGoAuthEndToEnd` in `proxy/internal/standalone/standalone_test.go` gets a `wantHeaders` field and three new cases, one per path. Each case sends `x-opencode-session` and `x-opencode-client` through `/w/pi/compat/opencode-go/...` and asserts the exact values at the fake upstream, next to the existing auth and body assertions. The four existing cases now assert that no `x-opencode-session` gets to the upstream.
- Regression proof: with the tests from this branch and `openaicompat.go` from `main`, both tests fail. The adapter test reports four empty headers on each of the three paths. The standalone test reports `upstream x-opencode-session = ""` on all three new cases.
- `go build ./...`, `gofmt -l`, and `go vet` on the changed packages are clean. `go test ./providers/... ./internal/standalone/... ./internal/gateway/...` passes.
- Local end-to-end run on 2026-09-06: a proxy built from this branch, a `compat: opencode-go` override to a loopback fake upstream, and `CAVE_SSRF_ALLOWLIST=127.0.0.1:9999`. The fake upstream received `x-opencode-session` and `x-opencode-client` on `/v1/chat/completions` and `/v1/responses`. The binary from bin-v1.1.6 sent none.
- Not run: `proxy/cmd/caveman-proxy`, `proxy/internal/nativeruntime`, and `proxy/internal/store` fail on this machine because the temp directory is group-writable. They fail the same way on a clean `main` and do not touch the changed code.

## Notes

- The fix lives in the Go proxy binary. Users need a new `bin-v*` release, not only a CLI bump.
- The OpenCode CLI with `caveman enable opencode` and an OpenCode Go model goes through the `/w/opencode` route. That route uses the same allowlist and is not changed here. The attribution of `x-opencode-project` and `x-opencode-request` to the OpenCode CLI comes from #1006 and is not checked against the OpenCode CLI source.
- No local record shows the headers that the installed Pi client sent to the proxy. The database and `CAVE_CAPTURE_DIR` store no headers. The claim about Pi rests on the quoted `getSessionHeaders` source in #1006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

