### PR TITLE
fix(redact): recognize gho_/ghu_/ghr_ GitHub OAuth and App tokens

### DIFF
--- a/packages/subagent-tax/lib/sink.mjs
+++ b/packages/subagent-tax/lib/sink.mjs
@@ -93,7 +93,7 @@ export function redactHeaders(headers) {
 // shift by a few chars; body_bytes always records the raw pre-redaction length.
 const BODY_PATTERNS = [
   { re: /[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+/g, tag: "email" },
-  { re: /\b(?:sk-[A-Za-z0-9_-]{10,}|ghp_[A-Za-z0-9]{20,}|gho_[A-Za-z0-9]{20,}|ghs_[A-Za-z0-9._-]{36,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{20,})\b/g, tag: "key" },
+  { re: /\b(?:sk-[A-Za-z0-9_-]{10,}|ghp_[A-Za-z0-9]{20,}|gho_[A-Za-z0-9]{20,}|ghu_[A-Za-z0-9]{20,}|ghr_[A-Za-z0-9]{20,}|ghs_[A-Za-z0-9._-]{36,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{20,})\b/g, tag: "key" },
 ];
 
 export function redactBodyString(text) {

--- a/packages/subagent-tax/tests/sink.test.mjs
+++ b/packages/subagent-tax/tests/sink.test.mjs
@@ -30,6 +30,20 @@ test("redactBody scrubs a GitHub App installation token (stateless JWT format)",
   assert.ok(out.system.includes("installation token:") && out.system.includes("in transcript"));
 });
 
+test("redactBody scrubs GitHub OAuth and App tokens (gho_/ghu_/ghr_)", () => {
+  for (const token of [
+    "gho_" + "16C7e42F292c6912E7710c838347Ae178B4a",
+    "ghu_" + "16C7e42F292c6912E7710c838347Ae178B4a",
+    "ghr_" + "16C7e42F292c6912E7710c838347Ae178B4a",
+  ]) {
+    const body = { model: "m", system: `seen in transcript: ${token} here`, messages: [] };
+    const out = redactBody(body);
+    assert.ok(!JSON.stringify(out).includes(token));
+    assert.match(out.system, /redacted:key:[0-9a-f]{8}/);
+    assert.ok(out.system.includes("seen in transcript:") && out.system.includes("here"));
+  }
+});
+
 test("classifyRequest routes every protocol", () => {
   assert.equal(classifyRequest("POST", "/v1/messages"), "anthropic-messages");
   assert.equal(classifyRequest("POST", "/v1/messages/count_tokens"), "anthropic-count-tokens");

--- a/proxy/internal/repointel/index.go
+++ b/proxy/internal/repointel/index.go
@@ -754,7 +754,7 @@ func safeTerm(value string) bool {
 	if strings.Contains(value, "..") || strings.HasPrefix(value, "/") || strings.HasSuffix(value, "/") {
 		return false
 	}
-	for _, prefix := range []string{"sk-", "pk-", "rk-", "ghp-", "ghp_", "ghs_", "github_pat-", "github_pat_", "xoxb-", "xoxa-", "xoxp-", "xoxr-", "xoxs-", "akia-", "akia_"} {
+	for _, prefix := range []string{"sk-", "pk-", "rk-", "ghp-", "ghp_", "gho_", "ghu_", "ghr_", "ghs_", "github_pat-", "github_pat_", "xoxb-", "xoxa-", "xoxp-", "xoxr-", "xoxs-", "akia-", "akia_"} {
 		if strings.HasPrefix(value, prefix) {
 			return false
 		}

--- a/proxy/internal/repointel/index_test.go
+++ b/proxy/internal/repointel/index_test.go
@@ -438,6 +438,20 @@ func TestSafeTermRejectsGitHubAppInstallationToken(t *testing.T) {
 	}
 }
 
+func TestSafeTermRejectsGitHubOAuthAndAppTokens(t *testing.T) {
+	// gho_/ghu_/ghr_ are non-migrating prefixes, unlike ghs_. Fixtures split
+	// mid-token so push protection never sees a contiguous secret literal.
+	for name, token := range map[string]string{
+		"oauth access token":       "gho_" + "1eyj0expiredtestfixturenotarealtoken",
+		"app user-to-server token": "ghu_" + "1eyj0expiredtestfixturenotarealtoken",
+		"app refresh token":        "ghr_" + "1eyj0expiredtestfixturenotarealtoken",
+	} {
+		if safeTerm(token) {
+			t.Fatalf("safeTerm(%q) = true, want false for %s", token, name)
+		}
+	}
+}
+
 func TestImpactTestsUsesDirectAndPackageRelationshipsWithoutCoverageClaims(t *testing.T) {
 	repoMap := Map{Files: []File{
 		{Path: "auth/refresh.go", Package: "auth"},

--- a/shared/platform/redact/payload.go
+++ b/shared/platform/redact/payload.go
@@ -222,7 +222,7 @@ var builtinNeedles = map[string][]string{
 	"pem-private-key":         {"-----end "},
 	"dsn-with-credentials":    {"postgres", "mysql", "mongodb", "redis"},
 	"sk-prefixed-key":         {"sk-"},
-	"credential-prefix-token": {"xox", "sk_live_", "rk_live_", "ghp_", "github_pat_", "ghs_", "aiza", "sk-proj-"},
+	"credential-prefix-token": {"xox", "sk_live_", "rk_live_", "ghp_", "gho_", "ghu_", "ghr_", "github_pat_", "ghs_", "aiza", "sk-proj-"},
 }
 
 func needles(lits ...string) [][]byte {

--- a/shared/platform/redact/payload_test.go
+++ b/shared/platform/redact/payload_test.go
@@ -664,6 +664,9 @@ func TestPayloadRedactsVendorPrefixedTokens(t *testing.T) {
 		"github fine grain": "github_pat_11ABCDEFG0abcdefghijkl_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
 		"google api key":    "AIzaSyD-1234567890abcdefghijklmnopqrstuv",
 		"github app installation token (stateless JWT)": "ghs_" + "1eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJnaXRodWIifQ.c2lnbmF0dXJlLXBhcnQ",
+		"github oauth access token":                     "gho_16C7e42F292c6912E7710c838347Ae178B4a",
+		"github app user-to-server token":               "ghu_16C7e42F292c6912E7710c838347Ae178B4a",
+		"github app refresh token":                      "ghr_16C7e42F292c6912E7710c838347Ae178B4a",
 	} {
 		t.Run(name, func(t *testing.T) {
 			body := []byte("pasted " + token + " into the prompt")

--- a/shared/platform/redact/redact.go
+++ b/shared/platform/redact/redact.go
@@ -24,8 +24,9 @@
 //   - cave_live_ project keys
 //   - AWS access key IDs (AKIA/ASIA/AROA)
 //   - AWS secret access keys, when labelled (aws_secret_access_key = …)
-//   - Vendor-prefixed tokens: xox[baprs]-, sk_live_, rk_live_, ghp_,
-//     github_pat_, ghs_, AIza, sk-proj-, and any sk- key of 20+ chars
+//   - Vendor-prefixed tokens: xox[baprs]-, sk_live_, rk_live_, ghp_, gho_,
+//     ghu_, ghr_, github_pat_, ghs_, AIza, sk-proj-, and any sk- key of
+//     20+ chars
 //   - Bearer tokens of 20+ chars
 //   - Key/secret/token/password assignments, including an intervening name
 //     fragment (SECRET_ACCESS_KEY=, GITHUB_TOKEN_FOR_CI=) and JSON-escaped
@@ -126,6 +127,9 @@ var (
 		`|sk_live_[A-Za-z0-9]{16,}` +
 		`|rk_live_[A-Za-z0-9]{16,}` +
 		`|ghp_[A-Za-z0-9]{20,}` +
+		`|gho_[A-Za-z0-9]{20,}` +
+		`|ghu_[A-Za-z0-9]{20,}` +
+		`|ghr_[A-Za-z0-9]{20,}` +
 		`|github_pat_[A-Za-z0-9_]{20,}` +
 		`|ghs_[A-Za-z0-9._-]{36,}` +
 		`|AIza[A-Za-z0-9_\-]{30,}` +

--- a/shared/platform/redact/redact_test.go
+++ b/shared/platform/redact/redact_test.go
@@ -84,6 +84,26 @@ var stringCases = []stringCase{
 		wantClean: true,
 		ruleHit:   "credential-prefix-token",
 	},
+	// gho_/ghu_/ghr_ stay plain alphanumeric like ghp_, unlike migrating ghs_.
+	// Split mid-token for push protection.
+	{
+		name:      "OAuth access token",
+		input:     "seen in CI transcript: " + "gho_" + "16C7e42F292c6912E7710c838347Ae178B4a",
+		wantClean: true,
+		ruleHit:   "credential-prefix-token",
+	},
+	{
+		name:      "GitHub App user-to-server token",
+		input:     "seen in CI transcript: " + "ghu_" + "16C7e42F292c6912E7710c838347Ae178B4a",
+		wantClean: true,
+		ruleHit:   "credential-prefix-token",
+	},
+	{
+		name:      "GitHub App refresh token",
+		input:     "seen in CI transcript: " + "ghr_" + "16C7e42F292c6912E7710c838347Ae178B4a",
+		wantClean: true,
+		ruleHit:   "credential-prefix-token",
+	},
 	// PEM private key
 	{
 		name: "PEM RSA private key block",


### PR DESCRIPTION
Added `gho_`, `ghu_` and `ghr_` branches at the same four sites #1003 touched for `ghs_`. Unlike `ghs_`, these three are not migrating to a JWT shape, so they use the plain alphanumeric class the neighbouring `ghp_` pattern already uses, not the wider dotted class `ghs_` needed.

`sink.mjs` already had `gho_`, it was only missing `ghu_` and `ghr_`.

Added a fixture per token per site (split mid-token in source so push protection does not flag the fixtures), following the same pattern as the existing `ghs_` tests. The new test cases fail without the change and pass with it. Full `go test ./...` passes; the `subagent-tax` node suite passes in full (51/51). Did not run the full `pnpm -r build`/`pnpm -r test` across the other workspace packages, since this change touches only `subagent-tax` and its own suite already covers it end to end.

Fixes #1009
