### PR TITLE
fix(init): honor force when refreshing rules

### DIFF
--- a/src/tools/caveman-init.js
+++ b/src/tools/caveman-init.js
@@ -187,7 +187,7 @@ function processAgent(agent, targetDir, ruleBody, opts) {
   // "our older ruleset" from "a user file that happens to quote the rule".
   // Refreshing on a guess would clobber their content, so skip and let the
   // existing --force flag be the deliberate refresh path.
-  if (existing.includes(SENTINEL)) {
+  if (!opts.force && existing.includes(SENTINEL)) {
     return { status: 'skipped-already-installed', label: '=' };
   }
 

--- a/tests/test_caveman_init.js
+++ b/tests/test_caveman_init.js
@@ -93,6 +93,30 @@ test('--force overwrites existing rule files', (tmp) => {
   assert.match(after, /Respond terse/);
 });
 
+for (const [agent, file] of [
+  ['cursor', '.cursor/rules/caveman.mdc'],
+  ['windsurf', '.windsurf/rules/caveman.md'],
+  ['cline', '.clinerules/caveman.md'],
+]) {
+  test(`--force refreshes an installed ${agent} rule; default and dry-run preserve it`, (tmp) => {
+    runInit(tmp, '--only', agent);
+    const target = path.join(tmp, file);
+    const current = fs.readFileSync(target, 'utf8');
+    const stale = current + '\nOld rule removed upstream.\n';
+    fs.writeFileSync(target, stale);
+
+    assert.match(runInit(tmp, '--only', agent), /skipped-already-installed/);
+    assert.strictEqual(fs.readFileSync(target, 'utf8'), stale);
+
+    const preview = runInit(tmp, '--only', agent, '--force', '--dry-run');
+    assert.match(preview, /1 overwritten/);
+    assert.strictEqual(fs.readFileSync(target, 'utf8'), stale);
+
+    assert.match(runInit(tmp, '--only', agent, '--force'), /1 overwritten/);
+    assert.strictEqual(fs.readFileSync(target, 'utf8'), current);
+  });
+}
+
 test('--dry-run: announces but writes nothing', (tmp) => {
   const out = runInit(tmp, '--dry-run');
   assert.match(out, /\(dry run\)/);


### PR DESCRIPTION
Running `caveman-init --force` on an already initialized Cursor, Windsurf, or Cline repository reports `skipped-already-installed` and leaves stale rules in place. The sentinel check returns before the force-overwrite branch, despite the documented refresh behavior.

Honor `--force` when checking the sentinel. Regression tests exercise all three targets through the CLI, verifying that default runs preserve existing content, `--force --dry-run` reports an overwrite without writing, and `--force` restores the current rule and frontmatter.

Validation on macOS (Node v24.18.0):
- `node tests/test_caveman_init.js`: 15 passed. The three new cases failed before the fix.
- `npm test`: 279 passed.
- `node --check src/tools/caveman-init.js` and `git diff --check`: passed.

Changes are limited to the MIT initializer and its tests.
