### PR TITLE
fix(browse): close Chrome and remove temp profile dir on SIGTERM/SIGINT/SIGHUP

### DIFF
--- a/browse/cmd/caveman-browse/main.go
+++ b/browse/cmd/caveman-browse/main.go
@@ -9,10 +9,12 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/JuliusBrussee/caveman/browse"
@@ -52,9 +54,26 @@ func main() {
 	defer session.Close()
 
 	srv := mcp.NewServer("caveman-browse", browse.BrowserTools(session), logger)
-	if err := srv.Serve(os.Stdin, os.Stdout); err != nil {
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
+	defer cancel()
+	if err := runUntilSignal(ctx, srv, os.Stdin, os.Stdout); err != nil {
 		logger.Error("serve", "err", err)
 		os.Exit(1)
+	}
+}
+
+// runUntilSignal returns as soon as srv.Serve finishes or ctx is done, instead of
+// blocking on it directly: an unwrapped call cannot be interrupted by a signal, so
+// main's deferred Close calls never run and the browser is orphaned.
+func runUntilSignal(ctx context.Context, srv *mcp.Server, in io.Reader, out io.Writer) error {
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(in, out) }()
+	select {
+	case err := <-serveErr:
+		return err
+	case <-ctx.Done():
+		return nil
 	}
 }
 

--- a/browse/cmd/caveman-browse/main_test.go
+++ b/browse/cmd/caveman-browse/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -9,8 +10,10 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/JuliusBrussee/caveman/browse"
+	"github.com/JuliusBrussee/caveman/mcp"
 )
 
 func TestOpenRecoveryStoreCreatesFreshCavemanHome(t *testing.T) {
@@ -101,6 +104,56 @@ func TestDefaultChromeCandidatesPreserveMacPaths(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("candidate[%d]=%q want %q", i, got[i], want[i])
 		}
+	}
+}
+
+// TestRunUntilSignalReturnsOnContextDoneWithoutWaitingForServe pins issue #1016:
+// srv.Serve(in, out) blocks reading in until EOF, so a bare call cannot be
+// interrupted by ctx being done, and main would never reach its deferred Close
+// calls on a terminating signal. in is an unclosed io.Pipe reader, so it blocks
+// forever exactly like stdin blocks on an MCP host that has not sent EOF; the
+// only way out is the ctx.Done() branch.
+func TestRunUntilSignalReturnsOnContextDoneWithoutWaitingForServe(t *testing.T) {
+	srv := mcp.NewServer("test", nil, nil)
+	in, _ := io.Pipe() // never written to, never closed
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // simulates a signal having already arrived
+
+	done := make(chan error, 1)
+	go func() { done <- runUntilSignal(ctx, srv, in, io.Discard) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runUntilSignal returned an error on ctx.Done(): %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runUntilSignal did not return after ctx was done; it is still blocked on Serve reading a stalled input, so a terminating signal would never let main's deferred Close calls run")
+	}
+}
+
+// TestRunUntilSignalReturnsServeError confirms the ordinary EOF path is
+// unchanged: when in reaches EOF before ctx is done, runUntilSignal reports
+// Serve's own result rather than a signal-shaped nil.
+func TestRunUntilSignalReturnsServeError(t *testing.T) {
+	srv := mcp.NewServer("test", nil, nil)
+	in, w := io.Pipe()
+	_ = w.Close() // immediate EOF
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- runUntilSignal(ctx, srv, in, io.Discard) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runUntilSignal returned an unexpected error on EOF: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runUntilSignal did not return on Serve's own EOF completion")
 	}
 }
 


### PR DESCRIPTION
Fixes #1016.

`main()` never called `signal.Notify`, so an MCP host's SIGTERM at session
teardown killed `caveman-browse` before its deferred `driver.Close()` and
`store.Close()` ran. Only the stdin-EOF path (`srv.Serve` returning `nil` on
`io.EOF`) reached those defers, so a signal-driven shutdown orphaned Chrome
and left its temp profile directory on disk. Same shape as #742/#985, ported
to the browse driver's Go binary.

`srv.Serve(os.Stdin, os.Stdout)` blocks reading stdin until EOF, so it can't
be interrupted directly. The fix runs it on its own goroutine behind a new
`runUntilSignal(ctx, srv, in, out)`, with `ctx` from
`signal.NotifyContext(..., os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)`.
On a signal, `ctx.Done()` wins the `select` and `runUntilSignal` returns
`nil` without waiting for `Serve`, so `main` returns normally and its
deferred `Close` calls run.

Verification (Docker, `golang:1.26`, matching `go.mod`):
- Added `TestRunUntilSignalReturnsOnContextDoneWithoutWaitingForServe`, which
  drives an unclosed `io.Pipe` reader (blocks forever, like stdin with no
  EOF) through an already-canceled `ctx` and asserts a prompt return instead
  of an indefinite block; it does not compile before this change, since
  `runUntilSignal` is new. `TestRunUntilSignalReturnsServeError` pins the
  unchanged EOF path.
- `go build ./...`, `go vet ./...`, and `go test ./...` (the repo's own `go`
  CI job) all pass.
- I couldn't run the issue's own live repro (checking the orphaned Chrome
  process's PPID and the leftover profile directory), since this environment
  has no real Chrome binary; the tests above exercise the same control-flow
  defect without one.
