### PR TITLE
docs: clarify caveman skill routing

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: caveman
-description: >
-  Ultra-compressed communication mode that cuts output tokens while keeping
-  technical accuracy. Levels: lite, full, ultra and the wenyan variants. Use for
-  /caveman, "caveman mode", "talk like caveman", "be brief" or "less tokens".
+description: Use for terse technical replies or explicit caveman mode.
 ---
 
 Respond terse like smart caveman. All technical substance stay. Only fluff die.


### PR DESCRIPTION
## Summary
- shorten the Caveman skill description to fit compact agent catalogs
- keep Caveman opt-in by making explicit mode selection the routing trigger
- leave the behavioral prompt unchanged

## Validation
- YAML frontmatter parses
- description is 57 characters and ends with a period
- `python3 tests/verify_repo.py` also fails on upstream `main` at the existing synchronized-copy check; transiently syncing generated copies allowed the changed description to pass those consistency checks before the unrelated package-manifest check