### PR TITLE
fix: fixed reply-language instruction wins over dominant-language match

### DIFF
--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -26,7 +26,7 @@ Clarity register: mix ASD-STE100 Simplified Technical English into caveman, alwa
 
 Tool calls: fire direct. No preamble, plan, or progress note before or between calls. After result: next call direct or final answer never announce next call. Text before call only to clarify, warn security/irreversible, or resolve ambiguity.
 
-Preserve user's dominant language exactly reply in the language user writes, never switch regardless of example text or multilingual context elsewhere. Compress the style, not the language. Every emitted line in that language openings, pre-tool status lines, all not just final reply. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim unless user explicitly ask for translation.
+Preserve user's dominant language exactly reply in the language user writes, never switch regardless of example text or multilingual context elsewhere. Exception: user or project instruction that fixes reply language (e.g. CLAUDE.md "always respond in French") always win — dominant-language matching apply only when no fixed-language instruction exist. Compress the style, not the language. Every emitted line in that language openings, pre-tool status lines, all not just final reply. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim unless user explicitly ask for translation.
 
 'Drop articles' = article languages only. Where small markers carry case/role (particles, postpositions), keep them grammar, not filler; compress politeness/filler instead.
 


### PR DESCRIPTION
## Summary
`main`'s current "preserve dominant language" rule in `skills/caveman/SKILL.md` already stops the old few-shot Portuguese/Spanish example tokens from leaking into a reply — the original repro in #812. But it doesn't say what should happen when a user or project instruction *fixes* the reply language outright (e.g. a `CLAUDE.md` that says "always respond in French"). As worded, dominant-language matching could still override that fixed instruction, which is the actual "Expected" behavior #812 asks for.

This adds the missing precedence clause: a fixed-language instruction always wins; dominant-language matching only applies when no such instruction exists.

Fixes #812

## Test plan
This is a one-clause wording addition to the always-on prompt in `skills/caveman/SKILL.md` (the MIT-licensed source of truth per CONTRIBUTING/CLAUDE.md — didn't touch the CI-synced copies). No code changed, so no `go test`/`pnpm test` applies. Verified by re-reading the rule against #812's Before/After example: with the new clause, a fixed-language project instruction is explicitly stated to override dominant-language detection, closing the gap the issue reported.