### PR TITLE
fix(ccr): dedupe RepositoryMap payloads across sessions

### DIFF
--- a/engine/ccr/store_repositorymap_dedup_test.go
+++ b/engine/ccr/store_repositorymap_dedup_test.go
@@ -1,0 +1,123 @@
+package ccr_test
+
+import (
+	"testing"
+
+	"github.com/JuliusBrussee/caveman/engine/ccr"
+)
+
+func TestRepositoryMapDedupedAcrossSessions(t *testing.T) {
+	s, err := ccr.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	payload := make([]byte, 200000)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	before, err := s.Summary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id1, err := s.PutObject(ccr.Object{
+		Type: ccr.ObjectRepositoryMap, Source: "native:repository-map",
+		SessionID: "session-a", RepositoryState: "git:abc123",
+		TransformVersion: "repository-map-v1", Currentness: ccr.Current,
+		Lifecycle: ccr.Warm, Data: payload,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id2, err := s.PutObject(ccr.Object{
+		Type: ccr.ObjectRepositoryMap, Source: "native:repository-map",
+		SessionID: "session-b", RepositoryState: "git:abc123",
+		TransformVersion: "repository-map-v1", Currentness: ccr.Current,
+		Lifecycle: ccr.Warm, Data: payload,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id1 == id2 {
+		t.Fatal("expected distinct object ids per session (ListSessionObjects must still find each session's own row)")
+	}
+
+	after, err := s.Summary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	grown := after.StorageBytes - before.StorageBytes
+	if grown >= 2*int64(len(payload)) {
+		t.Fatalf("second identical RepositoryMap put duplicated the payload: storage grew by %d bytes for a %d-byte payload (want roughly one copy, not two)", grown, len(payload))
+	}
+
+	got1, err := s.GetObject(id1)
+	if err != nil || string(got1.Data) != string(payload) {
+		t.Fatalf("session-a object did not round-trip byte-exact: err=%v len=%d", err, len(got1.Data))
+	}
+	got2, err := s.GetObject(id2)
+	if err != nil || string(got2.Data) != string(payload) {
+		t.Fatalf("session-b object did not round-trip byte-exact: err=%v len=%d", err, len(got2.Data))
+	}
+
+	// A third, later session with the SAME content must still dedup against
+	// the same underlying bytes, not chain through session-b's row.
+	id3, err := s.PutObject(ccr.Object{
+		Type: ccr.ObjectRepositoryMap, Source: "native:repository-map",
+		SessionID: "session-c", RepositoryState: "git:abc123",
+		TransformVersion: "repository-map-v1", Currentness: ccr.Current,
+		Lifecycle: ccr.Warm, Data: payload,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got3, err := s.GetObject(id3)
+	if err != nil || string(got3.Data) != string(payload) {
+		t.Fatalf("session-c object did not round-trip byte-exact: err=%v len=%d", err, len(got3.Data))
+	}
+	afterThird, err := s.Summary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterThird.StorageBytes-after.StorageBytes >= int64(len(payload)) {
+		t.Fatalf("third identical RepositoryMap put stored another full copy: storage grew by %d bytes", afterThird.StorageBytes-after.StorageBytes)
+	}
+}
+
+func TestNonRepositoryMapTypesStillStoreFullCopyPerSession(t *testing.T) {
+	s, err := ccr.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	payload := []byte(`{"decision_id":"d1","choice":"same-text-different-sessions"}`)
+
+	before, err := s.Summary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.PutObject(ccr.Object{
+		Type: ccr.ObjectTaskDecision, Source: "native:test", SessionID: "session-a",
+		RepositoryState: "git:abc123", Currentness: ccr.Current, Data: payload,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.PutObject(ccr.Object{
+		Type: ccr.ObjectTaskDecision, Source: "native:test", SessionID: "session-b",
+		RepositoryState: "git:abc123", Currentness: ccr.Current, Data: payload,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := s.Summary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	grown := after.StorageBytes - before.StorageBytes
+	if grown < 2*int64(len(payload)) {
+		t.Fatalf("non-RepositoryMap types must keep storing their own full copy per session: storage only grew by %d bytes for two %d-byte puts", grown, len(payload))
+	}
+}

--- a/engine/ccr/store_sqlite.go
+++ b/engine/ccr/store_sqlite.go
@@ -173,6 +173,10 @@ func openWithBudget(path string, maxBytes int64, afterPrepare func()) (*Store, e
 		_ = db.Close()
 		return nil, fmt.Errorf("migrate sqlite metadata %q: %w", canonicalPath, err)
 	}
+	if err := RetryOnBusy(func() error { return ensureDataRefColumn(db) }); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("migrate sqlite data_ref %q: %w", canonicalPath, err)
+	}
 	if err := configureStorageBudget(db, maxBytes); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("configure sqlite storage budget %q: %w", canonicalPath, err)
@@ -342,6 +346,39 @@ func ensureMetadataColumn(db *sql.DB) error {
 	return err
 }
 
+func ensureDataRefColumn(db *sql.DB) error {
+	rows, err := db.Query(`PRAGMA table_info(typed_objects)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dflt, &pk); err != nil {
+			return err
+		}
+		if name == "data_ref" {
+			return rows.Err()
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	_, err = db.Exec(`ALTER TABLE typed_objects ADD COLUMN data_ref TEXT NOT NULL DEFAULT ''`)
+	if err != nil && isDuplicateColumn(err) {
+		// A concurrent process's Open() already added it.
+		return nil
+	}
+	return err
+}
+
+func isDuplicateColumn(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "duplicate column name")
+}
+
 // OpenMemory opens an ephemeral in-memory store.
 func OpenMemory() (*Store, error) { return OpenWithBudget(":memory:", DefaultMaxStorageBytes) }
 
@@ -488,7 +525,8 @@ func (s *Store) GetMetadata(handle string) ([]byte, error) {
 
 // PutObject stores one immutable typed working-memory object. Repeated puts of
 // the same content-derived ID are idempotent; currentness changes use
-// SetObjectCurrentness so invalidation stays explicit.
+// SetObjectCurrentness so invalidation stays explicit. A RepositoryMap put
+// matching an earlier session's content is stored as a reference to it instead.
 func (s *Store) PutObject(input Object) (string, error) {
 	obj, err := prepareObject(input)
 	if err != nil {
@@ -497,6 +535,26 @@ func (s *Store) PutObject(input Object) (string, error) {
 	deps, err := json.Marshal(obj.Dependencies)
 	if err != nil {
 		return "", fmt.Errorf("ccr typed object dependencies: %w", err)
+	}
+	storedData := obj.Data
+	var dataRef string
+	if obj.Type == ObjectRepositoryMap {
+		err = s.db.QueryRow(
+			`SELECT object_id FROM typed_objects
+			 WHERE object_type = ? AND source = ? AND repository_state = ? AND content_hash = ?
+			   AND data_ref = '' AND object_id != ?
+			 ORDER BY created_at ASC LIMIT 1`,
+			obj.Type, obj.Source, obj.RepositoryState, obj.ContentHash, obj.ID,
+		).Scan(&dataRef)
+		if errors.Is(err, sql.ErrNoRows) {
+			dataRef, err = "", nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("ccr typed object dedup lookup: %w", err)
+		}
+		if dataRef != "" {
+			storedData = []byte{}
+		}
 	}
 	used, err := s.storageBytes()
 	if err != nil {
@@ -509,19 +567,19 @@ func (s *Store) PutObject(input Object) (string, error) {
 	} else if err != nil {
 		return "", fmt.Errorf("ccr typed object budget: %w", err)
 	}
-	if used-existingBytes+int64(len(obj.Data)+len(deps)) > s.maxBytes {
+	if used-existingBytes+int64(len(storedData)+len(deps)) > s.maxBytes {
 		return "", fmt.Errorf("ccr typed object put: %w", ErrBudgetExceeded)
 	}
 	result, err := s.db.Exec(
 		`INSERT INTO typed_objects (
 		 object_id, object_type, content_hash, source, created_at, repository_state,
 		 session_id, transform_version, currentness, lifecycle, dependencies_json,
-		 original_byte_length, stored_byte_length, data
-		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		 original_byte_length, stored_byte_length, data, data_ref
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 		ON CONFLICT(object_id) DO NOTHING`,
 		obj.ID, obj.Type, obj.ContentHash, obj.Source, obj.CreatedAt.Format(time.RFC3339Nano),
 		obj.RepositoryState, obj.SessionID, obj.TransformVersion, obj.Currentness,
-		obj.Lifecycle, string(deps), obj.OriginalByteLength, obj.StoredByteLength, obj.Data,
+		obj.Lifecycle, string(deps), obj.OriginalByteLength, obj.StoredByteLength, storedData, dataRef,
 	)
 	if err != nil {
 		if isFull(err) {
@@ -545,40 +603,55 @@ func (s *Store) PutObject(input Object) (string, error) {
 	return obj.ID, nil
 }
 
-func scanObject(scanner interface{ Scan(...any) error }) (Object, error) {
+func scanObject(scanner interface{ Scan(...any) error }) (Object, string, error) {
 	var obj Object
-	var created, deps string
+	var created, deps, dataRef string
 	if err := scanner.Scan(
 		&obj.ID, &obj.Type, &obj.ContentHash, &obj.Source, &created, &obj.RepositoryState,
 		&obj.SessionID, &obj.TransformVersion, &obj.Currentness, &obj.Lifecycle, &deps,
-		&obj.OriginalByteLength, &obj.StoredByteLength, &obj.Data,
+		&obj.OriginalByteLength, &obj.StoredByteLength, &obj.Data, &dataRef,
 	); err != nil {
-		return Object{}, err
+		return Object{}, "", err
 	}
 	parsed, err := time.Parse(time.RFC3339Nano, created)
 	if err != nil {
-		return Object{}, fmt.Errorf("ccr typed object created_at: %w", err)
+		return Object{}, "", fmt.Errorf("ccr typed object created_at: %w", err)
 	}
 	obj.CreatedAt = parsed
 	if err := json.Unmarshal([]byte(deps), &obj.Dependencies); err != nil {
-		return Object{}, fmt.Errorf("ccr typed object dependencies decode: %w", err)
+		return Object{}, "", fmt.Errorf("ccr typed object dependencies decode: %w", err)
 	}
-	return obj, nil
+	return obj, dataRef, nil
 }
 
 const objectColumns = `object_id, object_type, content_hash, source, created_at,
  repository_state, session_id, transform_version, currentness, lifecycle,
- dependencies_json, original_byte_length, stored_byte_length, data`
+ dependencies_json, original_byte_length, stored_byte_length, data, data_ref`
+
+// resolveObjectData fills obj.Data from the row it references when obj was
+// stored as a dedup pointer (see PutObject); dataRef == "" means obj already
+// carries its own data and is returned unchanged.
+func (s *Store) resolveObjectData(obj Object, dataRef string) (Object, error) {
+	if dataRef == "" {
+		return obj, nil
+	}
+	var data []byte
+	if err := s.db.QueryRow(`SELECT data FROM typed_objects WHERE object_id = ?`, dataRef).Scan(&data); err != nil {
+		return Object{}, fmt.Errorf("ccr typed object dedup resolve: %w", err)
+	}
+	obj.Data = data
+	return obj, nil
+}
 
 func (s *Store) GetObject(id string) (Object, error) {
-	obj, err := scanObject(s.db.QueryRow(`SELECT `+objectColumns+` FROM typed_objects WHERE object_id = ?`, id))
+	obj, dataRef, err := scanObject(s.db.QueryRow(`SELECT `+objectColumns+` FROM typed_objects WHERE object_id = ?`, id))
 	if errors.Is(err, sql.ErrNoRows) {
 		return Object{}, ErrNotFound
 	}
 	if err != nil {
 		return Object{}, fmt.Errorf("ccr typed object get: %w", err)
 	}
-	return obj, nil
+	return s.resolveObjectData(obj, dataRef)
 }
 
 func (s *Store) SetObjectCurrentness(id string, currentness Currentness) error {
@@ -631,9 +704,13 @@ func (s *Store) ListSessionObjects(sessionID string, limit int) ([]Object, error
 	defer rows.Close()
 	objects := make([]Object, 0)
 	for rows.Next() {
-		obj, err := scanObject(rows)
+		obj, dataRef, err := scanObject(rows)
 		if err != nil {
 			return nil, fmt.Errorf("ccr typed object list scan: %w", err)
+		}
+		obj, err = s.resolveObjectData(obj, dataRef)
+		if err != nil {
+			return nil, err
 		}
 		objects = append(objects, obj)
 	}
@@ -646,7 +723,7 @@ func (s *Store) ListSessionObjects(sessionID string, limit int) ([]Object, error
 // FindTaskDecision returns one Decision Ledger object by its stable decision
 // ID. Callers still validate the versioned decision schema before rendering it.
 func (s *Store) FindTaskDecision(decisionID string) (Object, error) {
-	obj, err := scanObject(s.db.QueryRow(
+	obj, dataRef, err := scanObject(s.db.QueryRow(
 		`SELECT `+objectColumns+` FROM typed_objects
 		 WHERE object_type = ? AND json_extract(CAST(data AS TEXT), '$.decision_id') = ?
 		 ORDER BY created_at DESC, object_id DESC LIMIT 1`,
@@ -658,7 +735,7 @@ func (s *Store) FindTaskDecision(decisionID string) (Object, error) {
 	if err != nil {
 		return Object{}, fmt.Errorf("ccr task decision find: %w", err)
 	}
-	return obj, nil
+	return s.resolveObjectData(obj, dataRef)
 }
 
 // Summary aggregates stored recoveries into totals + per-content-type buckets.


### PR DESCRIPTION
`PutObject` computes a typed object's ID from `Type + SessionID + Source + RepositoryState + ContentHash`, so `ON CONFLICT(object_id) DO NOTHING` only dedups within one session. A `RepositoryMap` object gets a fresh `SessionID` every session (it's rebuilt from scratch each time), but its `ContentHash` repeats whenever the underlying repository state hasn't changed since the last session. The result: an unchanged repo stores a full copy of the same ~MB-scale map on every session, growing `ccr.db` without bound.

I confirmed this is specific to `RepositoryMap`, not a missing lookup that every type shares: forcing `TaskDecision` through the same two-session scenario with matching content shows the same non-dedup, because there is no per-type content lookup at all, only the ID-collision check above. Other types legitimately produce different content per session even when it happens to match, so applying the same shortcut to all of them would be wrong (the second test below pins that boundary).

Fix: when a `RepositoryMap` put finds an existing row with the same `(source, repository_state, content_hash)` from any session, store a small row that references that row's data (`data_ref`) instead of writing another full copy. `GetObject`/`ListSessionObjects`/`FindTaskDecision` resolve the reference transparently, so every caller still sees the exact original bytes and each session still gets its own `object_id` (session-scoped listing is unaffected). Nothing in the table is ever deleted or the `data`/`data_ref` columns ever updated after insert, so a referenced row can't later be pointed at a row that becomes a pointer itself.

The new schema column needed a migration (`ALTER TABLE typed_objects ADD COLUMN data_ref ...`), and adding it exposed a real bug in that pattern under concurrent processes: `mem/cmd/cavemem`'s own `TestConcurrentRememberSubprocesses` (24 subprocesses opening the same fresh db) failed with `duplicate column name: data_ref` two out of five runs, because the PRAGMA-check-then-ALTER sequence isn't atomic across processes sharing one file. Fixed by treating that specific error as "another process already added it" rather than a real failure.

Verification:
- New regression test: two sessions putting the same repository map grow storage by roughly 2x the payload size before this change and roughly 0x after, and both sessions still read back the exact bytes.
- A second new test locks the scope: two sessions putting the same `TaskDecision` content still store two full copies, so that type must keep its own per-session data.
- `go build ./... && go vet ./... && go test ./...` (whole module, matches the `go` CI job) is green, including `mem/cmd/cavemem`'s concurrent-subprocess test run 5 times in a row after the migration fix.
- Opened a database written by the previous schema directly and confirmed it opens cleanly under the new code with its existing rows read back unchanged.

I only ran this in Linux containers, so I can't speak to the `macos` and `windows` CI legs specifically, though nothing here is filesystem- or OS-dependent.
