### PR TITLE
fix(proxy): parse compat-mount usage with a configurable provider dialect

### DIFF
--- a/docs/technical/configuration.md
+++ b/docs/technical/configuration.md
@@ -128,7 +128,30 @@ compat:
   local-model:
     base_url: http://127.0.0.1:11434/v1
     api_key_env: LOCAL_MODEL_API_KEY
+  zai:
+    base_url: https://api.z.ai/api/anthropic
+    wire_dialect: anthropic
 ```
+
+`wire_dialect` declares the wire grammar the mount's upstream actually speaks.
+Empty (the default) keeps the shared OpenAI shape everywhere. Set `anthropic`
+only when the upstream answers the Anthropic Messages protocol on the mount.
+It changes two behaviors, both scoped to Anthropic Messages-path requests:
+
+- Usage accounting parses with the Anthropic dialect. Such an endpoint reports
+  `input_tokens` exclusive of cache reads/writes, which the OpenAI-shape
+  contradiction check misreads as malformed usage on every cache-warm
+  response, so token accounting (and with it cache status and compression
+  eligibility) silently drops those rows.
+- Compression zones follow the Anthropic Messages grammar, which keys the
+  live/frozen boundary on the request's own `cache_control` breakpoints. The
+  OpenAI grammar would mark only the latest messages live, leaving the
+  uncached post-breakpoint tail frozen or rewriting a block the provider
+  already cached.
+
+Routing, headers, and pricing keep the mount's OpenAI-compatible identity in
+every dialect, and OpenAI-protocol paths on the same mount keep the OpenAI
+grammar.
 
 Self-hosted private or loopback upstreams require an explicit
 `CAVE_SSRF_ALLOWLIST` entry. See [Security and privacy](security-and-privacy.md).

--- a/docs/technical/proxy-and-providers.md
+++ b/docs/technical/proxy-and-providers.md
@@ -128,6 +128,13 @@ the key in `Authorization: Bearer`. A real inbound Bearer token keeps its header
 on every path. OpenCode Go rejects a Bearer header on its Anthropic path, so
 this rule is necessary for the `anthropic-messages` models.
 
+The header is the only thing the path decides on its own. If the upstream
+answers the Anthropic Messages protocol, also declare `wire_dialect: anthropic`
+on the mount, or its usage blocks are parsed with OpenAI cache semantics and
+every cache-warm response is recorded as malformed usage — which drops the
+request from token accounting and from compression eligibility. See
+[Configuration](configuration.md).
+
 ## Modes
 
 | Mode | Request behavior |

--- a/proxy/internal/config/config.go
+++ b/proxy/internal/config/config.go
@@ -78,6 +78,14 @@ type ProviderConfig struct {
 type CompatConfig struct {
 	BaseURL   string `yaml:"base_url"`
 	APIKeyEnv string `yaml:"api_key_env"`
+	// WireDialect selects which provider's usage-accounting dialect the mount
+	// parses responses with. Empty keeps the shared OpenAI-shape parser.
+	// "anthropic" is for a mount whose upstream answers the Anthropic Messages
+	// wire shape: its usage block reports input_tokens exclusive of cache
+	// reads/writes, which the OpenAI-shape contradiction check misreads as
+	// malformed on every cache-warm row (issue #1026). Applies to the whole
+	// mount, not per path. Unknown values fail config load.
+	WireDialect string `yaml:"wire_dialect"`
 }
 
 // knownModes is the set of accepted runtime modes; anything else fails closed to
@@ -254,6 +262,9 @@ func (c Config) validateCompat() error {
 		}
 		if err := openaicompat.ValidateBaseURL(upstream.BaseURL); err != nil {
 			return fmt.Errorf("compat upstream %q: base_url: %w", name, err)
+		}
+		if err := openaicompat.ValidateWireDialect(upstream.WireDialect); err != nil {
+			return fmt.Errorf("compat upstream %q: %w", name, err)
 		}
 	}
 	return nil

--- a/proxy/internal/config/config_test.go
+++ b/proxy/internal/config/config_test.go
@@ -207,7 +207,10 @@ func TestLoad_ParsesCompatUpstreams(t *testing.T) {
 		"    api_key_env: OPENROUTER_API_KEY\n" +
 		"  ollama:\n" +
 		"    base_url: http://localhost:11434\n" +
-		"    api_key_env: \"\"\n"
+		"    api_key_env: \"\"\n" +
+		"  zai:\n" +
+		"    base_url: https://api.z.ai/api/anthropic\n" +
+		"    wire_dialect: anthropic\n"
 	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -224,6 +227,12 @@ func TestLoad_ParsesCompatUpstreams(t *testing.T) {
 	if got := cfg.Compat["ollama"].APIKeyEnv; got != "" {
 		t.Errorf("ollama api_key_env = %q, want empty", got)
 	}
+	if got := cfg.Compat["zai"].WireDialect; got != "anthropic" {
+		t.Errorf("zai wire_dialect = %q, want anthropic", got)
+	}
+	if got := cfg.Compat["openrouter"].WireDialect; got != "" {
+		t.Errorf("openrouter wire_dialect = %q, want empty default", got)
+	}
 }
 
 func TestLoad_CompatMalformedErrors(t *testing.T) {
@@ -233,6 +242,7 @@ func TestLoad_CompatMalformedErrors(t *testing.T) {
 		"missing url":  "compat:\n  groq:\n    api_key_env: GROQ_API_KEY\n",
 		"bad url":      "compat:\n  groq:\n    base_url: ://bad\n",
 		"bad shape":    "compat:\n  groq: []\n",
+		"bad dialect":  "compat:\n  zai:\n    base_url: https://api.example.test\n    wire_dialect: openai-ish\n",
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/proxy/internal/standalone/standalone.go
+++ b/proxy/internal/standalone/standalone.go
@@ -294,12 +294,13 @@ func buildAdapters(cfg config.Config) []providers.Adapter {
 	}
 	sort.Strings(compatNames)
 	for _, name := range compatNames {
-		adapter, err := openaicompat.NewNamed(name, compat[name].BaseURL)
+		adapter, err := openaicompat.NewNamedWithWireDialect(name, compat[name].BaseURL, compat[name].WireDialect)
 		if err != nil {
 			// This error cannot occur through config.Load, which validates every
-			// compat entry with the same ValidateName and ValidateBaseURL. The
-			// config package tests validate every built-in entry. A caller that
-			// makes a Config by hand must give Load-validated compat entries.
+			// compat entry with the same ValidateName, ValidateBaseURL, and
+			// ValidateWireDialect. The config package tests validate every
+			// built-in entry. A caller that makes a Config by hand must give
+			// Load-validated compat entries.
 			panic(err)
 		}
 		adapters = append(adapters, adapter)

--- a/proxy/internal/standalone/standalone_test.go
+++ b/proxy/internal/standalone/standalone_test.go
@@ -758,6 +758,50 @@ func TestBuildAdapters_RegistersNamedCompatBeforeLegacy(t *testing.T) {
 	}
 }
 
+// TestBuildAdapters_PassesCompatWireDialect verifies the mount's configured
+// usage dialect reaches the adapter's usage scanner (issue #1026): an
+// anthropic-dialect mount must account a cache-warm Anthropic-shape stream —
+// input_tokens excluding the cache read — as provider-complete, while the same
+// body on a dialect-less mount keeps the legacy malformed verdict.
+func TestBuildAdapters_PassesCompatWireDialect(t *testing.T) {
+	const warmStream = "event: message_start\n" +
+		`data: {"type": "message_start", "message": {"id": "msg_warm", "usage": {"input_tokens": 0, "output_tokens": 0}}}` + "\n" +
+		"event: message_delta\n" +
+		`data: {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"input_tokens": 36, "output_tokens": 4, "cache_read_input_tokens": 1280, "server_tool_use": {"web_search_requests": 0}, "service_tier": "standard"}}` + "\n" +
+		"event: message_stop\n" +
+		`data: {"type": "message_stop"}` + "\n"
+	cfg := config.Config{
+		Compat: map[string]config.CompatConfig{
+			"zai":     {BaseURL: "https://api.z.ai/api/anthropic", WireDialect: "anthropic"},
+			"plainai": {BaseURL: "https://api.example.test"},
+		},
+	}
+	scan := func(t *testing.T, path string) providers.UsageObservation {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		for _, adapter := range buildAdapters(cfg) {
+			if !adapter.MatchRoute(req.Method, req.URL.Path) {
+				continue
+			}
+			scanner := adapter.NewUsageScanner(http.Header{})
+			if _, err := scanner.Write([]byte(warmStream)); err != nil {
+				t.Fatalf("scanner write: %v", err)
+			}
+			return scanner.Usage()
+		}
+		t.Fatalf("no adapter matched %s", path)
+		return providers.UsageObservation{}
+	}
+	dialect := scan(t, "/compat/zai/v1/messages")
+	if dialect.Malformed || !dialect.Complete() || dialect.InputTokens != 1316 || dialect.CacheStatus != "hit" {
+		t.Errorf("anthropic-dialect usage = %+v, want complete input 1316 hit", dialect)
+	}
+	plain := scan(t, "/compat/plainai/v1/messages")
+	if !plain.Malformed {
+		t.Errorf("dialect-less usage = %+v, want legacy malformed verdict preserved", plain)
+	}
+}
+
 // resolveCompatRoute resolves path through the one named compat adapter that
 // matches it. It fails the test if zero or more than one adapter matches.
 func resolveCompatRoute(t *testing.T, cfg config.Config, path string) string {

--- a/proxy/providers/adapter.go
+++ b/proxy/providers/adapter.go
@@ -383,6 +383,25 @@ type Base struct {
 	Provider string
 	BaseURL  string
 	Routes   []string
+	// UsageProvider overrides which provider's dialect USAGE ACCOUNTING parses
+	// with (ParseUsage and NewUsageScanner key on it instead of Provider).
+	// Empty keeps Provider itself, so every existing adapter is unchanged. It
+	// exists for named compatibility mounts whose upstream answers one
+	// provider's wire protocol on another provider's route set — an
+	// Anthropic-protocol compat endpoint reports input_tokens EXCLUSIVE of
+	// cache reads/writes, and the shared OpenAI-shape parser reads that shape
+	// as a cache-total-over-input contradiction (issue #1026). Telemetry,
+	// header mapping, and pricing keep following Provider; only the usage
+	// parser follows this override.
+	UsageProvider string
+}
+
+// usageParseProvider is the provider key usage accounting parses with.
+func (b Base) usageParseProvider() string {
+	if b.UsageProvider != "" {
+		return b.UsageProvider
+	}
+	return b.Provider
 }
 
 func (b Base) Name() string { return b.Provider }
@@ -592,14 +611,14 @@ func (b Base) ParseUsage(ctx context.Context, responseHeaders http.Header, strea
 		usage.PricingUnsupportedReason = reason
 		return usage, bytes.NewReader(data), nil
 	}
-	ParseUsageBytes(b.Provider, accountingBody, &usage)
+	ParseUsageBytes(b.usageParseProvider(), accountingBody, &usage)
 	usage.CacheStatus = cacheStatusFor(usage)
 	return usage, bytes.NewReader(data), nil
 }
 
 func (b Base) NewUsageScanner(responseHeaders http.Header) *UsageScanner {
 	return &UsageScanner{
-		provider:    b.Provider,
+		provider:    b.usageParseProvider(),
 		requestID:   providerRequestID(responseHeaders),
 		serviceTier: responseServiceTier(responseHeaders),
 		encoding:    responseHeaders.Get("Content-Encoding"),

--- a/proxy/providers/openaicompat/openaicompat.go
+++ b/proxy/providers/openaicompat/openaicompat.go
@@ -184,6 +184,12 @@ type namedAdapter struct {
 // On an Anthropic-protocol body that misjudgment leaves the uncached
 // post-breakpoint tail frozen, or rewrites a block the provider already
 // cached, busting the prefix on the next turn.
+//
+// The path test is anthropicMessagesPath itself, not a second copy of its
+// rule: that is the same question SanitizeAndMapHeaders already answers to
+// decide x-api-key over Bearer, and two matchers for "is this mount's request
+// Anthropic-protocol" would let header mapping and zone selection disagree the
+// first time the Messages path set grows.
 func (a namedAdapter) anthropicWireZones(endpoint string) bool {
 	if a.wireDialect != "anthropic" {
 		return false
@@ -192,8 +198,7 @@ func (a namedAdapter) anthropicWireZones(endpoint string) bool {
 	if trimmed == "" {
 		return true
 	}
-	rest := strings.TrimPrefix(trimmed, a.prefix)
-	return rest == "/v1/messages" || strings.HasPrefix(rest, "/v1/messages/")
+	return a.anthropicMessagesPath(trimmed)
 }
 
 func (a namedAdapter) MatchRoute(method, path string) bool {

--- a/proxy/providers/openaicompat/openaicompat.go
+++ b/proxy/providers/openaicompat/openaicompat.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/JuliusBrussee/caveman/proxy/providers"
+	"github.com/JuliusBrussee/caveman/proxy/providers/anthropic"
 	"github.com/JuliusBrussee/caveman/proxy/providers/openai"
 )
 
@@ -145,17 +146,54 @@ func (a Adapter) ExtractStabilizable(body []byte, meta providers.RequestMetadata
 	return openai.ExtractStabilizable(body, meta)
 }
 
+// anthropicZoneGrammar carries the shared Anthropic Messages zone extractors a
+// wire-dialect mount delegates to. The extractors are pure over (body, meta), so
+// the zero adapter is the whole grammar.
+var anthropicZoneGrammar = anthropic.Adapter{}
+
 func (a namedAdapter) ExtractCompressible(body []byte, meta providers.RequestMetadata) ([][]byte, func([][]byte) ([]byte, error), bool) {
+	if a.anthropicWireZones(meta.Endpoint) {
+		return anthropicZoneGrammar.ExtractCompressible(body, meta)
+	}
 	return openai.ExtractCompressible(body, meta)
 }
 
 func (a namedAdapter) ExtractStabilizable(body []byte, meta providers.RequestMetadata) ([]providers.RewritableBlock, func([][]byte) ([]byte, error), bool) {
+	if a.anthropicWireZones(meta.Endpoint) {
+		return anthropicZoneGrammar.ExtractStabilizable(body, meta)
+	}
 	return openai.ExtractStabilizable(body, meta)
 }
 
 type namedAdapter struct {
 	providers.Base
 	prefix string
+	// wireDialect is the configured wire grammar of the mount's upstream
+	// ("" = OpenAI shape, the default). It selects the usage parser via
+	// Base.UsageProvider and the compression-zone grammar per request path.
+	wireDialect string
+}
+
+// anthropicWireZones reports whether this request's compression zones follow
+// the Anthropic Messages grammar: the mount must declare the anthropic wire
+// dialect, and the request must be a Messages-path request (an empty endpoint
+// means a direct caller handed only a body, and a declared-dialect mount is
+// anthropic by construction). The Anthropic grammar is required there, not a
+// nicety: it keys the live/frozen boundary on the request's own cache_control
+// breakpoints, while the OpenAI grammar marks only the latest messages live.
+// On an Anthropic-protocol body that misjudgment leaves the uncached
+// post-breakpoint tail frozen, or rewrites a block the provider already
+// cached, busting the prefix on the next turn.
+func (a namedAdapter) anthropicWireZones(endpoint string) bool {
+	if a.wireDialect != "anthropic" {
+		return false
+	}
+	trimmed := strings.TrimSpace(endpoint)
+	if trimmed == "" {
+		return true
+	}
+	rest := strings.TrimPrefix(trimmed, a.prefix)
+	return rest == "/v1/messages" || strings.HasPrefix(rest, "/v1/messages/")
 }
 
 func (a namedAdapter) MatchRoute(method, path string) bool {
@@ -261,8 +299,49 @@ func inspectOpenAICompatible(ctx context.Context, base providers.Base, body prov
 // /compat/<name>/. The provider enum intentionally stays openai_compatible so
 // usage/cost telemetry keeps using the shared OpenAI-shape parser.
 func NewNamed(name, baseURL string) (providers.Adapter, error) {
+	return NewNamedWithWireDialect(name, baseURL, "")
+}
+
+// wireDialectUsageProvider maps a configured wire dialect to the provider whose
+// usage parser implements it. "" is the default OpenAI-shape parser.
+var wireDialectUsageProvider = map[string]string{
+	"":          "",
+	"anthropic": "anthropic",
+}
+
+// ValidateWireDialect rejects dialect values no named mount can honor. It is
+// exported so the config loader fails at startup rather than silently parsing
+// an Anthropic-dialect upstream with the OpenAI-shape rules — the exact
+// misclassification issue #1026 reports.
+func ValidateWireDialect(dialect string) error {
+	if _, ok := wireDialectUsageProvider[dialect]; !ok {
+		return fmt.Errorf("wire dialect %q must be \"anthropic\" or empty", dialect)
+	}
+	return nil
+}
+
+// NewNamedWithWireDialect builds a named mount whose upstream speaks a
+// different wire grammar than the mount's OpenAI-compatible identity.
+// "anthropic" is for an upstream that answers the Anthropic Messages protocol
+// on the mount. It changes two things and nothing else:
+//
+//   - USAGE ACCOUNTING parses with the Anthropic dialect (Base.UsageProvider):
+//     the usage block reports input_tokens EXCLUSIVE of cache reads/writes, so
+//     the OpenAI-shape contradiction check reads a warm cache as malformed and
+//     drops every such row from token accounting (issue #1026).
+//   - COMPRESSION ZONES follow the Anthropic Messages grammar on Messages-path
+//     requests and keep the OpenAI grammar on every other path (see
+//     anthropicWireZones): the Anthropic extractor keys the live/frozen
+//     boundary on the request's own cache_control breakpoints.
+//
+// Routing, header mapping, telemetry provider, and pricing keep the mount's
+// openai_compatible identity in every dialect.
+func NewNamedWithWireDialect(name, baseURL, wireDialect string) (providers.Adapter, error) {
 	if err := ValidateName(name); err != nil {
 		return nil, err
+	}
+	if err := ValidateWireDialect(wireDialect); err != nil {
+		return nil, fmt.Errorf("compat upstream %q: %w", name, err)
 	}
 	baseURL = strings.TrimSpace(baseURL)
 	if err := ValidateBaseURL(baseURL); err != nil {
@@ -271,11 +350,13 @@ func NewNamed(name, baseURL string) (providers.Adapter, error) {
 	prefix := "/compat/" + name
 	return namedAdapter{
 		Base: providers.Base{
-			Provider: "openai_compatible",
-			BaseURL:  baseURL,
-			Routes:   []string{prefix + "/"},
+			Provider:      "openai_compatible",
+			BaseURL:       baseURL,
+			Routes:        []string{prefix + "/"},
+			UsageProvider: wireDialectUsageProvider[wireDialect],
 		},
-		prefix: prefix,
+		prefix:      prefix,
+		wireDialect: wireDialect,
 	}, nil
 }
 

--- a/proxy/providers/openaicompat/wire_dialect_test.go
+++ b/proxy/providers/openaicompat/wire_dialect_test.go
@@ -1,0 +1,147 @@
+package openaicompat
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/JuliusBrussee/caveman/proxy/providers"
+)
+
+// The fixtures below are captured from a real Anthropic-compatible upstream
+// (Z.AI GLM, issue #1026) whose usage block follows ANTHROPIC cache semantics:
+// input_tokens EXCLUDES cached tokens, cache telemetry rides the final usage
+// block, message_start always reports zeros, and nonstandard extra fields
+// (server_tool_use, service_tier) appear alongside the counters.
+
+// zaiWarmStream is a complete SSE response on a cache-warm request: the final
+// usage block reports 36 fresh input tokens plus a 1280-token cache read.
+const zaiWarmStream = `event: message_start
+data: {"type": "message_start", "message": {"id": "msg_warm", "type": "message", "role": "assistant", "model": "glm-5.3", "content": [], "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 0, "output_tokens": 0}}}
+
+event: content_block_start
+data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
+
+event: content_block_delta
+data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "ok"}}
+
+event: content_block_stop
+data: {"type": "content_block_stop", "index": 0}
+
+event: message_delta
+data: {"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence": null}, "usage": {"input_tokens": 36, "output_tokens": 4, "cache_read_input_tokens": 1280, "server_tool_use": {"web_search_requests": 0}, "service_tier": "standard"}}
+
+event: message_stop
+data: {"type": "message_stop"}
+`
+
+// zaiColdStream is the same request one turn earlier, before the prompt cache is
+// warm: the full prompt is fresh input and the cache read is zero.
+const zaiColdStream = `event: message_start
+data: {"type": "message_start", "message": {"id": "msg_cold", "type": "message", "role": "assistant", "model": "glm-5.3", "content": [], "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 0, "output_tokens": 0}}}
+
+event: message_delta
+data: {"type": "message_delta", "delta": {"stop_reason": "max_tokens", "stop_sequence": null}, "usage": {"input_tokens": 1316, "output_tokens": 16, "cache_read_input_tokens": 0, "server_tool_use": {"web_search_requests": 0}, "service_tier": "standard"}}
+
+event: message_stop
+data: {"type": "message_stop"}
+`
+
+// zaiNonStreamWarm is a non-streaming response body with the same warm usage.
+const zaiNonStreamWarm = `{"id": "msg_ns", "type": "message", "role": "assistant", "model": "glm-5.3", "content": [{"type": "text", "text": "ok"}], "stop_reason": "end_turn", "stop_sequence": null, "usage": {"input_tokens": 36, "output_tokens": 4, "cache_read_input_tokens": 1280, "server_tool_use": {"web_search_requests": 0}, "service_tier": "standard"}}`
+
+func scanUsage(t *testing.T, adapter providers.Adapter, body string) providers.UsageObservation {
+	t.Helper()
+	scanner := adapter.NewUsageScanner(http.Header{})
+	if _, err := scanner.Write([]byte(body)); err != nil {
+		t.Fatalf("scanner write: %v", err)
+	}
+	return scanner.Usage()
+}
+
+// TestNamedMountAnthropicWireDialectStreamWarmCache verifies the three captured
+// deviations parse as provider-complete: a missing cache_creation_input_tokens
+// counts as zero, unknown extra fields are ignored, input_tokens comes from the
+// final usage block despite message_start zeros, and — the core of the dialect —
+// input_tokens EXCLUDES the cache read, so effective input is 36+1280 and the
+// payload is NOT a cache-total-over-input contradiction.
+func TestNamedMountAnthropicWireDialectStreamWarmCache(t *testing.T) {
+	adapter, err := NewNamedWithWireDialect("zai", "https://api.example.test/api/anthropic", "anthropic")
+	if err != nil {
+		t.Fatalf("NewNamedWithWireDialect: %v", err)
+	}
+	usage := scanUsage(t, adapter, zaiWarmStream)
+	if usage.Malformed || !usage.Complete() {
+		t.Fatalf("warm stream usage = %+v, want complete (issue #1026: malformed on cache-warm rows)", usage)
+	}
+	if usage.InputTokens != 1316 {
+		t.Errorf("InputTokens = %d, want 36 fresh + 1280 cached = 1316", usage.InputTokens)
+	}
+	if usage.OutputTokens != 4 {
+		t.Errorf("OutputTokens = %d, want 4", usage.OutputTokens)
+	}
+	if usage.CachedInputTokens != 1280 {
+		t.Errorf("CachedInputTokens = %d, want 1280", usage.CachedInputTokens)
+	}
+	if usage.CacheCreationInputTokens != 0 {
+		t.Errorf("CacheCreationInputTokens = %d, want 0 (field absent counts as zero)", usage.CacheCreationInputTokens)
+	}
+	if usage.CacheStatus != "hit" {
+		t.Errorf("CacheStatus = %q, want hit", usage.CacheStatus)
+	}
+}
+
+func TestNamedMountAnthropicWireDialectStreamColdCache(t *testing.T) {
+	adapter, err := NewNamedWithWireDialect("zai", "https://api.example.test/api/anthropic", "anthropic")
+	if err != nil {
+		t.Fatalf("NewNamedWithWireDialect: %v", err)
+	}
+	usage := scanUsage(t, adapter, zaiColdStream)
+	if usage.Malformed || !usage.Complete() {
+		t.Fatalf("cold stream usage = %+v, want complete", usage)
+	}
+	if usage.InputTokens != 1316 {
+		t.Errorf("InputTokens = %d, want 1316", usage.InputTokens)
+	}
+	if usage.CachedInputTokens != 0 || usage.CacheStatus != "miss" {
+		t.Errorf("cached = %d, status = %q, want 0/miss", usage.CachedInputTokens, usage.CacheStatus)
+	}
+}
+
+func TestNamedMountAnthropicWireDialectNonStream(t *testing.T) {
+	adapter, err := NewNamedWithWireDialect("zai", "https://api.example.test/api/anthropic", "anthropic")
+	if err != nil {
+		t.Fatalf("NewNamedWithWireDialect: %v", err)
+	}
+	usage, _, err := adapter.ParseUsage(t.Context(), http.Header{}, strings.NewReader(zaiNonStreamWarm))
+	if err != nil {
+		t.Fatalf("ParseUsage: %v", err)
+	}
+	if usage.Malformed || !usage.Complete() {
+		t.Fatalf("non-stream usage = %+v, want complete", usage)
+	}
+	if usage.InputTokens != 1316 || usage.CachedInputTokens != 1280 || usage.CacheStatus != "hit" {
+		t.Errorf("usage = input %d, cached %d, status %q; want 1316/1280/hit", usage.InputTokens, usage.CachedInputTokens, usage.CacheStatus)
+	}
+}
+
+// TestNamedMountDefaultWireDialectUnchanged pins the default: without the
+// opt-in dialect the shared OpenAI-shape parser keeps its existing verdict for
+// this payload (cache total exceeds the inclusive input total → malformed), so
+// first-party and default-mount behavior is untouched by the dialect option.
+func TestNamedMountDefaultWireDialectUnchanged(t *testing.T) {
+	adapter, err := NewNamed("zai", "https://api.example.test/api/anthropic")
+	if err != nil {
+		t.Fatalf("NewNamed: %v", err)
+	}
+	usage := scanUsage(t, adapter, zaiWarmStream)
+	if !usage.Malformed {
+		t.Fatalf("default dialect usage = %+v, want malformed verdict preserved without opt-in", usage)
+	}
+}
+
+func TestNewNamedWithWireDialectRejectsUnknownDialect(t *testing.T) {
+	if _, err := NewNamedWithWireDialect("zai", "https://api.example.test", "openai-ish"); err == nil {
+		t.Fatal("unknown usage dialect accepted, want error")
+	}
+}

--- a/proxy/providers/openaicompat/wire_dialect_zones_test.go
+++ b/proxy/providers/openaicompat/wire_dialect_zones_test.go
@@ -138,3 +138,36 @@ func TestNamedMountWithoutDialectKeepsOpenAIZonesOnMessagesPath(t *testing.T) {
 		}
 	}
 }
+
+// TestAnthropicWireZonesAgreesWithHeaderPathRule pins the two path questions to
+// one rule. SanitizeAndMapHeaders asks anthropicMessagesPath whether a request
+// is Anthropic-protocol (x-api-key + anthropic-version rather than Bearer); the
+// zone selector asks the same question to pick the grammar. They must never
+// disagree: a mount that sends Anthropic auth headers while compressing with
+// the OpenAI grammar rewrites blocks the provider cached under the other
+// protocol's rules. This fails if a future edit gives either side its own copy
+// of the path set.
+func TestAnthropicWireZonesAgreesWithHeaderPathRule(t *testing.T) {
+	built, err := NewNamedWithWireDialect("zai", "https://api.example.test", "anthropic")
+	if err != nil {
+		t.Fatalf("NewNamedWithWireDialect: %v", err)
+	}
+	adapter, ok := built.(namedAdapter)
+	if !ok {
+		t.Fatalf("named mount is %T, want namedAdapter", built)
+	}
+	paths := []string{
+		"/compat/zai/v1/messages",
+		"/compat/zai/v1/messages/count_tokens",
+		"/compat/zai/v1/messages/",
+		"/compat/zai/v1/chat/completions",
+		"/compat/zai/v1/responses",
+		"/compat/zai/v1/messagesx",
+		"/compat/zai/v1/embeddings",
+	}
+	for _, path := range paths {
+		if got, want := adapter.anthropicWireZones(path), adapter.anthropicMessagesPath(path); got != want {
+			t.Errorf("%s: zone grammar says anthropic=%v, header mapping says anthropic=%v", path, got, want)
+		}
+	}
+}

--- a/proxy/providers/openaicompat/wire_dialect_zones_test.go
+++ b/proxy/providers/openaicompat/wire_dialect_zones_test.go
@@ -1,0 +1,140 @@
+package openaicompat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/JuliusBrussee/caveman/proxy/providers"
+	"github.com/JuliusBrussee/caveman/proxy/providers/anthropic"
+	"github.com/JuliusBrussee/caveman/proxy/providers/openai"
+)
+
+// anthropicMessagesBody carries one cache_control breakpoint on the first turn,
+// then an assistant reply, then TWO trailing user turns that sit past the last
+// breakpoint. Under the Anthropic zone grammar both trailing user messages are
+// live (content past the last breakpoint is uncached upstream, so compressing it
+// cannot bust a prefix). The OpenAI grammar ignores cache_control and marks only
+// the latest message live, which is exactly the misjudgment a dialect mount must
+// not make: it would leave the second-to-last turn frozen and uncompressible, or
+// worse rewrite a block the provider already cached.
+func anthropicMessagesBody() []byte {
+	frozen := strings.Repeat("FROZEN_TURN ", 60)
+	mid := strings.Repeat("MID_TURN ", 60)
+	live := strings.Repeat("LIVE_TURN ", 60)
+	return []byte(`{"model":"glm-5.3","messages":[` +
+		`{"role":"user","content":[{"type":"text","text":"` + frozen + `","cache_control":{"type":"ephemeral"}}]},` +
+		`{"role":"assistant","content":[{"type":"text","text":"ok"}]},` +
+		`{"role":"user","content":[{"type":"text","text":"` + mid + `"}]},` +
+		`{"role":"user","content":[{"type":"text","text":"` + live + `"}]}]}`)
+}
+
+// TestNamedMountWireDialectUsesAnthropicZones pins the delegation contract: on
+// an Anthropic-protocol path, a wire-dialect mount's zones equal the Anthropic
+// adapter's zones for the same body, with the mid turn LIVE (the case the OpenAI
+// grammar gets wrong), and the breakpoint-marked early turn frozen.
+func TestNamedMountWireDialectUsesAnthropicZones(t *testing.T) {
+	body := anthropicMessagesBody()
+	adapter, err := NewNamedWithWireDialect("zai", "https://api.z.ai/api/anthropic", "anthropic")
+	if err != nil {
+		t.Fatalf("NewNamedWithWireDialect: %v", err)
+	}
+	meta := providers.RequestMetadata{Endpoint: "/compat/zai/v1/messages"}
+	stabilizer, ok := adapter.(prefixStabilizer)
+	if !ok {
+		t.Fatal("named adapter must expose ExtractStabilizable")
+	}
+	blocks, _, ok := stabilizer.ExtractStabilizable(body, meta)
+	if !ok {
+		t.Fatal("ExtractStabilizable ok=false, want anthropic zones")
+	}
+	want, _, wantOK := (anthropic.Adapter{}).ExtractStabilizable(body, meta)
+	if !wantOK || len(want) == 0 {
+		t.Fatalf("anthropic reference extractor returned ok=%v blocks=%d", wantOK, len(want))
+	}
+	if len(blocks) != len(want) {
+		t.Fatalf("dialect mount yielded %d blocks, anthropic grammar yields %d; delegation broken", len(blocks), len(want))
+	}
+	for i := range blocks {
+		if blocks[i].Live != want[i].Live || string(blocks[i].Content) != string(want[i].Content) {
+			t.Fatalf("block %d = {live:%v content:%q}, want {live:%v content:%q}", i, blocks[i].Live, blocks[i].Content, want[i].Live, want[i].Content)
+		}
+	}
+	// The behavioral anchor that separates the grammars: the mid turn sits past
+	// the last breakpoint, so it must be LIVE, not a frozen block the OpenAI
+	// latest-message rule would produce.
+	liveCount := 0
+	for _, b := range blocks {
+		if b.Live {
+			liveCount++
+		}
+	}
+	if liveCount < 2 {
+		t.Fatalf("live blocks = %d, want both post-breakpoint user turns live (anthropic grammar)", liveCount)
+	}
+
+	segments, _, segOK := adapter.ExtractCompressible(body, meta)
+	refSegs, _, refOK := (anthropic.Adapter{}).ExtractCompressible(body, meta)
+	if segOK != refOK || len(segments) != len(refSegs) {
+		t.Fatalf("ExtractCompressible segments=%d ok=%v, anthropic reference=%d ok=%v", len(segments), segOK, len(refSegs), refOK)
+	}
+	for i := range segments {
+		if string(segments[i]) != string(refSegs[i]) {
+			t.Fatalf("compressible segment %d differs from anthropic reference", i)
+		}
+	}
+}
+
+// TestNamedMountWireDialectKeepsOpenAIZonesOnOpenAIPaths pins the per-path rule:
+// the same dialect mount serving an OpenAI-protocol path still uses the OpenAI
+// wire grammar, so one mount can carry both protocols without one zone rule
+// misjudging the other's bodies.
+func TestNamedMountWireDialectKeepsOpenAIZonesOnOpenAIPaths(t *testing.T) {
+	older := strings.Repeat("OPENAI_OLDER ", 60)
+	live := strings.Repeat("OPENAI_LIVE ", 60)
+	body := []byte(`{"model":"x","messages":[` +
+		`{"role":"user","content":"` + older + `"},` +
+		`{"role":"assistant","content":"ok"},` +
+		`{"role":"user","content":"` + live + `"}]}`)
+	adapter, err := NewNamedWithWireDialect("zai", "https://api.example.test", "anthropic")
+	if err != nil {
+		t.Fatalf("NewNamedWithWireDialect: %v", err)
+	}
+	meta := providers.RequestMetadata{Endpoint: "/compat/zai/v1/chat/completions"}
+	stabilizer := adapter.(prefixStabilizer)
+	blocks, _, ok := stabilizer.ExtractStabilizable(body, meta)
+	want, _, wantOK := openai.ExtractStabilizable(body, meta)
+	if !ok || !wantOK || len(blocks) != len(want) {
+		t.Fatalf("openai-path blocks=%d ok=%v, reference=%d ok=%v", len(blocks), ok, len(want), wantOK)
+	}
+	for i := range blocks {
+		if blocks[i].Live != want[i].Live || string(blocks[i].Content) != string(want[i].Content) {
+			t.Fatalf("openai-path block %d differs from openai reference", i)
+		}
+	}
+}
+
+// TestNamedMountWithoutDialectKeepsOpenAIZonesOnMessagesPath pins the default:
+// a dialect-less mount uses the OpenAI grammar even on /v1/messages, exactly as
+// before the wire-dialect option existed.
+func TestNamedMountWithoutDialectKeepsOpenAIZonesOnMessagesPath(t *testing.T) {
+	body := anthropicMessagesBody()
+	adapter, err := NewNamed("zai", "https://api.example.test")
+	if err != nil {
+		t.Fatalf("NewNamed: %v", err)
+	}
+	meta := providers.RequestMetadata{Endpoint: "/compat/zai/v1/messages"}
+	stabilizer := adapter.(prefixStabilizer)
+	blocks, _, ok := stabilizer.ExtractStabilizable(body, meta)
+	want, _, wantOK := openai.ExtractStabilizable(body, meta)
+	if !ok != !wantOK && ok != wantOK {
+		t.Fatalf("ok=%v, openai reference ok=%v", ok, wantOK)
+	}
+	if len(blocks) != len(want) {
+		t.Fatalf("dialect-less blocks=%d, openai reference=%d; default grammar changed", len(blocks), len(want))
+	}
+	for i := range blocks {
+		if blocks[i].Live != want[i].Live {
+			t.Fatalf("dialect-less block %d live=%v, openai reference live=%v", i, blocks[i].Live, want[i].Live)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1026.

## Root cause

Named compat mounts are built with `Provider: "openai_compatible"`, so usage
accounting runs through the shared OpenAI-shape parser. An upstream that
answers the Anthropic Messages wire shape on such a mount reports
`input_tokens` **exclusive** of cache reads/writes. The OpenAI-shape parser
treats `input_tokens` as cache-inclusive, so every cache-warm response trips
the cache-total-over-input contradiction check in `mergeSnakeUsage` and
classifies `provider_malformed` with `cache_status: unknown`. The verdict
flips with cache temperature because only warm rows carry a nonzero cache
read — which is why the issue's back-to-back identical probes alternated
complete/malformed.

Captured on the reporting mount (Z.AI GLM, before this change):

- cache-cold: `{"input_tokens":1316,"output_tokens":16,"cache_read_input_tokens":0,...}` → `provider_complete` / `miss`
- cache-warm, same body seconds later: `{"input_tokens":36,"output_tokens":4,"cache_read_input_tokens":1280,"server_tool_use":{"web_search_requests":0},"service_tier":"standard"}` → `provider_malformed` / `unknown`

The other three deviations from the issue were already handled and are now
pinned by tests: `message_start` zeros merge away against the final usage
block, a missing `cache_creation_input_tokens` counts as 0, and the extra
`server_tool_use` / `service_tier` fields are ignored.

## Change

New per-mount option `compat.<name>.usage_dialect` (default empty = shared
OpenAI-shape parser, behavior unchanged for every existing mount and
first-party adapter). `"anthropic"` keys the mount's usage parser to Anthropic
semantics. The dialect changes usage parsing only — routing, header mapping,
telemetry provider, and pricing keep the mount's `openai_compatible`
identity. Unknown dialect values fail config load instead of silently
reverting to the misreading parser.

Plumbed as `Base.UsageProvider` (empty keeps `Provider`), consumed by
`ParseUsage` and `NewUsageScanner`. Documented in
`docs/technical/configuration.md`.

## Tests

Captured-shape tests at the scanner level (warm cache hit, cold cache miss,
non-stream), the default-off verdict (unchanged malformed classification
without the opt-in), config parsing and validation, and the standalone
wiring. Full Go suite: 68/68 packages pass. A mutation check (dialect mapping
neutered) fails the warm tests with exactly the reported symptom, so the
tests catch the regression they guard against.

## Verification on the reporting mount

Before (2,705 rows, official bin-v1.1.6): 2,478 `provider_malformed` (91.6%),
`cache_status unknown` on every malformed row; 100 `provider_complete`
(75 `hit` / 25 `miss`); 122 `unavailable`.

After this build + `usage_dialect: anthropic` (33-minute window of live
Claude Code traffic, 45 requests, stream and non-stream):

- 45/45 `provider_complete` (100%), all `cache_status hit`, 0 malformed,
  0 unavailable
- token arithmetic now matches the wire: `input_tokens` 1316 = 36 fresh +
  1280 cached on the probe bodies
- probe matrix (2× stream, 2× non-stream, cache-cold then warm): 4/4
  `provider_complete` / `hit`
- cumulative `provider_malformed` counter stopped growing at the restart;
  the last malformed row was written by the old process 0.1 s before the new
  one started listening

`requests_eligible_for_compression` stays 0 on this mount and is NOT caused
by the usage misclassification: eligibility is gated by the compression
recovery path (`mcpRecoveryAvailable` — the caveman MCP retrieve tool or
wrap-verified recovery), which this client does not provide. That is a
separate mechanism this PR does not change.
