### PR TITLE
test(agent): gate SIGKILL escalation on readiness

### DIFF
--- a/packages/agent/src/runtime.ts
+++ b/packages/agent/src/runtime.ts
@@ -4719,6 +4719,52 @@ function releaseLedgerHolds(reservations: readonly SpendReservation[]): void {
   }
 }
 
+/**
+ * Lifecycle events of one sandboxed tool child process.
+ *
+ * `stderr` gives the parent a live channel. A test fixture can write a
+ * readiness marker on it. `signal` reports each signal that the runtime sends.
+ * `close` reports the child close event before the tool result settles.
+ */
+export type SandboxLifecycleEvent =
+  | { kind: "stderr"; chunk: Buffer }
+  | { kind: "signal"; signal: "SIGTERM" | "SIGKILL" }
+  | { kind: "close"; code: number | null; signal: NodeJS.Signals | null };
+
+export type SandboxLifecycleObserver = (event: SandboxLifecycleEvent) => void;
+
+let sandboxLifecycleObserver: SandboxLifecycleObserver | undefined;
+
+/**
+ * Install one observer of sandbox child lifecycle events, or clear it with
+ * `undefined`.
+ *
+ * This seam is package-internal and made for tests. `src/index.ts` does not
+ * re-export it, so it is not part of the public API. The setter is the only
+ * gate: with no observer installed, the runtime does no extra work.
+ */
+export function setSandboxLifecycleObserver(
+  observer: SandboxLifecycleObserver | undefined,
+): void {
+  sandboxLifecycleObserver = observer;
+}
+
+/**
+ * Send one lifecycle event to the observer.
+ *
+ * An observer error must not change the outcome of a tool. Thus this function
+ * discards every exception that the observer throws.
+ */
+function notifySandboxLifecycle(event: SandboxLifecycleEvent): void {
+  const observer = sandboxLifecycleObserver;
+  if (observer === undefined) return;
+  try {
+    observer(event);
+  } catch {
+    // Observation is diagnostic only. Never fail a tool because of it.
+  }
+}
+
 async function executeSandboxedTool(
   entryPath: string,
   sourceFiles: readonly string[],
@@ -4790,10 +4836,13 @@ async function executeSandboxedTool(
       let killTimer: NodeJS.Timeout | undefined;
       const terminate = (error: Error, immediate = false) => {
         terminalError ??= error;
-        killSandboxProcess(child, immediate ? "SIGKILL" : "SIGTERM");
+        const first = immediate ? "SIGKILL" : "SIGTERM";
+        killSandboxProcess(child, first);
+        notifySandboxLifecycle({ kind: "signal", signal: first });
         if (!immediate && killTimer === undefined) {
           killTimer = setTimeout(() => {
             killSandboxProcess(child, "SIGKILL");
+            notifySandboxLifecycle({ kind: "signal", signal: "SIGKILL" });
           }, 250);
           killTimer.unref();
         }
@@ -4816,6 +4865,7 @@ async function executeSandboxedTool(
       child.stderr.on("data", (chunk: Buffer) => {
         stderrBytes += chunk.byteLength;
         if (stderrBytes <= 1_048_576) stderr.push(chunk);
+        notifySandboxLifecycle({ kind: "stderr", chunk });
       });
       const resultStream = child.stdio[3] as NodeJS.ReadableStream | null | undefined;
       resultStream?.on("data", (chunk: Buffer) => {
@@ -4830,7 +4880,10 @@ async function executeSandboxedTool(
       child.once("error", (error) => {
         terminalError ??= error;
       });
-      child.once("close", (code) => {
+      child.once("close", (code, closeSignal: NodeJS.Signals | null) => {
+        // Report close BEFORE accept or reject. A test can then prove that the
+        // result settles only after the child closes.
+        notifySandboxLifecycle({ kind: "close", code, signal: closeSignal });
         liveSandboxChildren.delete(child);
         combined.removeEventListener("abort", onAbort);
         if (killTimer !== undefined) clearTimeout(killTimer);

--- a/packages/agent/tests/fixtures/sandbox-agent.mjs
+++ b/packages/agent/tests/fixtures/sandbox-agent.mjs
@@ -159,12 +159,29 @@ export default agent({
       description: "Ignore SIGTERM and tool timeout.",
       input: schema.object({}),
       effect: "read",
-      // Leave worker startup outside timing race so SIGTERM handler is active
-      // before timeout proves SIGKILL escalation and close-wait behavior.
-      timeoutMs: 1_000,
+      // The timeout is long on purpose. A fixed allowance cannot guarantee
+      // that worker startup completes first. The test aborts the run when the
+      // readiness marker below arrives, thus the SIGTERM handler is always
+      // installed before the escalation starts.
+      timeoutMs: 10_000,
       async execute() {
         process.on("SIGTERM", () => undefined);
+        // One marker line on stderr. The runtime sends each stderr chunk to
+        // its lifecycle observer as the data arrives.
+        process.stderr.write("cave-sandbox-ready\n");
         setInterval(() => undefined, 1_000);
+        await new Promise(() => undefined);
+      },
+    }),
+    tool({
+      name: "startup_timeout",
+      description: "Hang with a deadline shorter than worker startup.",
+      input: schema.object({}),
+      effect: "read",
+      // The deadline expires during worker startup. No SIGTERM handler exists
+      // at that time, thus a prompt exit on SIGTERM is correct here.
+      timeoutMs: 1,
+      async execute() {
         await new Promise(() => undefined);
       },
     }),

--- a/packages/agent/tests/framework.runtime.mjs
+++ b/packages/agent/tests/framework.runtime.mjs
@@ -5900,16 +5900,41 @@ test("sandbox timeout during worker startup settles the run", { timeout: 15_000 
       return fauxAssistantMessage("terminated");
     },
   ]);
-  // The deadline expires during startup. A prompt exit on SIGTERM is correct
-  // here, thus this test asserts no SIGKILL escalation.
-  const result = await run(sandboxAgent, "timeout", {
-    ensureRuntime: false,
-    entryPath: "tests/fixtures/sandbox-agent.mjs",
-    model: faux.getModel(),
-    streamFn: faux.provider.streamSimple.bind(faux.provider),
+  // The deadline expires during startup. No SIGTERM handler exists, thus the
+  // worker must die on SIGTERM. The exit signal proves that. This test does
+  // not assert the absence of a SIGKILL event: the SIGKILL timer runs on time,
+  // not on child state, and under load it can fire after the child is already
+  // dead of SIGTERM but before the parent processes the close event.
+  let step = 0;
+  const events = [];
+  setSandboxLifecycleObserver((event) => {
+    if (event.kind !== "stderr") events.push({ at: ++step, ...event });
   });
+  let settledAt = 0;
+  let result;
+  try {
+    result = await run(sandboxAgent, "timeout", {
+      ensureRuntime: false,
+      entryPath: "tests/fixtures/sandbox-agent.mjs",
+      model: faux.getModel(),
+      streamFn: faux.provider.streamSimple.bind(faux.provider),
+    });
+  } finally {
+    settledAt = ++step;
+    setSandboxLifecycleObserver(undefined);
+  }
   assert.equal(result.text, "terminated");
   assert.match(observed, /cave_sandbox_timeout/);
+  const sigterm = events.find((event) => event.kind === "signal" && event.signal === "SIGTERM");
+  const close = events.find((event) => event.kind === "close");
+  assert.notEqual(sigterm, undefined);
+  assert.notEqual(close, undefined);
+  assert.equal(sigterm.at < close.at, true);
+  // The worker exited on SIGTERM: no handler was installed, thus no escalation
+  // was needed to end it.
+  assert.equal(close.signal, "SIGTERM");
+  // The run must not settle before the child closes.
+  assert.equal(close.at < settledAt, true);
 });
 
 test("sandbox rejects parent and worker definition drift before tool execution", async () => {

--- a/packages/agent/tests/framework.runtime.mjs
+++ b/packages/agent/tests/framework.runtime.mjs
@@ -50,6 +50,7 @@ import {
   resolveCaveRoute,
   runAgentInternal,
   sandboxSourceReadFlags,
+  setSandboxLifecycleObserver,
 } from "../dist/runtime.js";
 import { memoryFilePath, mutateMemories, readMemories } from "../dist/memory-store.js";
 import { sourceGraphSHA256 } from "../dist/source-graph.js";
@@ -5827,27 +5828,88 @@ test("sandbox fails closed on child-process permission without OS tree containme
   }
 });
 
-test("sandbox timeout waits for stubborn worker close after SIGKILL escalation", async () => {
+test("sandbox abort waits for stubborn worker close after SIGKILL escalation", { timeout: 15_000 }, async () => {
+  const faux = fauxProvider();
+  faux.setResponses([
+    fauxAssistantMessage(fauxToolCall("ignore_timeout", {}, { id: "ignore-timeout" })),
+    () => fauxAssistantMessage("terminated"),
+  ]);
+  const controller = new AbortController();
+  // A sequence counter proves event ORDER. Wall-clock windows cannot: a loaded
+  // runner changes every duration but never the order of these events.
+  let step = 0;
+  const events = [];
+  let readyText = "";
+  let aborted = false;
+  setSandboxLifecycleObserver((event) => {
+    if (event.kind === "stderr") {
+      readyText += event.chunk.toString("utf8");
+      // Abort only after the worker reports that its SIGTERM handler is live.
+      // This removes the startup race from the escalation scenario.
+      if (!aborted && readyText.includes("cave-sandbox-ready")) {
+        aborted = true;
+        events.push({ at: ++step, kind: "ready" });
+        controller.abort(new Error("cave_test_abort"));
+      }
+      return;
+    }
+    events.push({ at: ++step, ...event });
+  });
+  let settledAt = 0;
+  let failure;
+  try {
+    await run(sandboxAgent, "timeout", {
+      ensureRuntime: false,
+      entryPath: "tests/fixtures/sandbox-agent.mjs",
+      model: faux.getModel(),
+      streamFn: faux.provider.streamSimple.bind(faux.provider),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    failure = error;
+  } finally {
+    settledAt = ++step;
+    setSandboxLifecycleObserver(undefined);
+  }
+  // The abort reaches the tool, thus the run rejects instead of returning text.
+  assert.notEqual(failure, undefined);
+  const ready = events.find((event) => event.kind === "ready");
+  const sigterm = events.find((event) => event.kind === "signal" && event.signal === "SIGTERM");
+  const sigkill = events.find((event) => event.kind === "signal" && event.signal === "SIGKILL");
+  const close = events.find((event) => event.kind === "close");
+  assert.notEqual(ready, undefined);
+  assert.notEqual(sigterm, undefined);
+  assert.notEqual(sigkill, undefined);
+  assert.notEqual(close, undefined);
+  // The worker ignored SIGTERM, thus the runtime escalated to SIGKILL.
+  assert.equal(ready.at < sigterm.at, true);
+  assert.equal(sigterm.at < sigkill.at, true);
+  assert.equal(sigkill.at < close.at, true);
+  assert.equal(close.signal, "SIGKILL");
+  // The run must not settle before the child closes.
+  assert.equal(close.at < settledAt, true);
+});
+
+test("sandbox timeout during worker startup settles the run", { timeout: 15_000 }, async () => {
   const faux = fauxProvider();
   let observed = "";
   faux.setResponses([
-    fauxAssistantMessage(fauxToolCall("ignore_timeout", {}, { id: "ignore-timeout" })),
+    fauxAssistantMessage(fauxToolCall("startup_timeout", {}, { id: "startup-timeout" })),
     (context) => {
       observed = JSON.stringify(context.messages);
       return fauxAssistantMessage("terminated");
     },
   ]);
-  const started = Date.now();
+  // The deadline expires during startup. A prompt exit on SIGTERM is correct
+  // here, thus this test asserts no SIGKILL escalation.
   const result = await run(sandboxAgent, "timeout", {
     ensureRuntime: false,
     entryPath: "tests/fixtures/sandbox-agent.mjs",
     model: faux.getModel(),
     streamFn: faux.provider.streamSimple.bind(faux.provider),
   });
-  const elapsed = Date.now() - started;
   assert.equal(result.text, "terminated");
   assert.match(observed, /cave_sandbox_timeout/);
-  assert.equal(elapsed >= 1_200 && elapsed < 3_000, true);
 });
 
 test("sandbox rejects parent and worker definition drift before tool execution", async () => {


### PR DESCRIPTION
Fixes #1030.

The test `sandbox timeout waits for stubborn worker close after SIGKILL escalation` fails on loaded CI runners. It failed on #1015 and #974, which changed no file under `packages/agent/`. This PR removes the startup race from the test and replaces its wall-clock assertion with an event-order proof.

## Fixes

| Issue(s) | Root cause | Hosts/OS affected | Test added | Supersedes |
| --- | --- | --- | --- | --- |
| #1030 (seen on #1015, #974) | The fixture installed its SIGTERM handler inside `execute()`. The runtime starts the deadline before `spawn`. When startup consumed the deadline, SIGTERM arrived before the handler existed. The worker exited at once, the SIGKILL timer never fired, and `elapsed` fell below the 1200 ms floor. | `packages/agent` test suite, engine-ci job `typescript`, all OS | `sandbox abort waits for stubborn worker close after SIGKILL escalation` and `sandbox timeout during worker startup settles the run` in `tests/framework.runtime.mjs` | — |

## Change

- `src/runtime.ts`: adds a package-internal sandbox lifecycle observer. `executeSandboxedTool` reports each stderr chunk as it arrives, each signal it sends, and the child close event before the result settles. `src/index.ts` does not re-export the setter, so the public API does not change. An observer exception cannot change the tool outcome. The deadline, `terminate`, and `terminalError` semantics do not change.
- `tests/fixtures/sandbox-agent.mjs`: `ignore_timeout` writes one stderr marker after it installs the handler and uses a 10 s timeout. A new `startup_timeout` tool has a 1 ms deadline and no handler.
- `tests/framework.runtime.mjs`: the escalation test waits for the marker, aborts the run through `RunOptions.signal`, and asserts the order SIGTERM → SIGKILL → close(SIGKILL) → run rejection with a sequence counter. The startup-timeout test proves that a deadline during startup reaches the model context and settles the run.

The old floor of 1200 ms cannot be lowered without losing SIGKILL coverage. A longer `timeoutMs` alone only moves the race threshold.

## Verification

- `pnpm test` in `packages/agent`, in a privileged `node:22` container where user namespaces work: `tests 319 / pass 319 / fail 0`.
- The two new tests, 10 runs in a loop: `pass 2 / fail 0` on each run.
- Race proof: with `await new Promise((r) => setTimeout(r, 1_500))` inserted before the handler install, the escalation test still passes. The old test could not pass with that delay. The delay is not in the commit.
- `python3 tests/verify_repo.py`: all checks pass.
- Hosts with `kernel.apparmor_restrict_unprivileged_userns=1` cannot run the `unshare`-based sandbox tests. Those tests fail there before and after this change with `Operation not permitted`.

## Ownership

`CLAUDE.md` routes Agent SDK work to `caveman-agent-sdk`. engine-ci runs the copy in this repository, so the fix lands here. The change is small so that the SDK repository can mirror it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
