### PR TITLE
fix(proxy): preserve provider-defined headers

### DIFF
--- a/proxy/providers/adapter.go
+++ b/proxy/providers/adapter.go
@@ -431,19 +431,25 @@ func (b Base) ResolveUpstreamURL(ctx context.Context, req *http.Request, route R
 }
 
 func (b Base) SanitizeAndMapHeaders(ctx context.Context, req *http.Request, credential Credential, _ *url.URL) (http.Header, error) {
-	out := http.Header{}
-	copyIfPresent(out, req.Header, "content-type")
-	copyIfPresent(out, req.Header, "accept")
-	copyIfPresent(out, req.Header, "accept-encoding")
-	copyIfPresent(out, req.Header, "idempotency-key")
-	copyIfPresent(out, req.Header, "openai-organization")
-	copyIfPresent(out, req.Header, "openai-project")
-	copyIfPresent(out, req.Header, "anthropic-version")
-	copyIfPresent(out, req.Header, "anthropic-beta")
-	copyIfPresent(out, req.Header, "api-version")
-	if env.Bool("CAVE_PROPAGATE_TRACE_HEADERS_UPSTREAM", false) {
-		copyIfPresent(out, req.Header, "traceparent")
-		copyIfPresent(out, req.Header, "tracestate")
+	out := req.Header.Clone()
+	for _, name := range []string{
+		"authorization", "proxy-authorization", "proxy-authenticate",
+		"connection", "proxy-connection", "keep-alive", "te", "trailer",
+		"transfer-encoding", "upgrade",
+	} {
+		out.Del(name)
+	}
+	for _, name := range strings.Split(req.Header.Get("connection"), ",") {
+		out.Del(strings.TrimSpace(name))
+	}
+	for name := range out {
+		if strings.HasPrefix(strings.ToLower(name), "x-cave-") {
+			out.Del(name)
+		}
+	}
+	if !env.Bool("CAVE_PROPAGATE_TRACE_HEADERS_UPSTREAM", false) {
+		out.Del("traceparent")
+		out.Del("tracestate")
 	}
 	out.Set("user-agent", appendUserAgent(req.UserAgent()))
 	switch b.Provider {
@@ -482,6 +488,7 @@ func (b Base) SanitizeAndMapHeaders(ctx context.Context, req *http.Request, cred
 				out.Set("authorization", "Bearer "+credential.Key)
 				out.Set("x-goog-user-project", quotaProject)
 			} else {
+				out.Del("x-goog-user-project")
 				out.Set("x-goog-api-key", credential.Key)
 			}
 		}

--- a/proxy/providers/adapter_contract_test.go
+++ b/proxy/providers/adapter_contract_test.go
@@ -147,12 +147,15 @@ func TestSanitizeAndMapHeaders_NoKeyLeakAndCorrectMapping(t *testing.T) {
 		t.Run(c.provider, func(t *testing.T) {
 			b := Base{Provider: c.provider}
 			req, _ := http.NewRequest(http.MethodPost, "/x", nil)
-			// Inbound client headers that MUST NOT leak upstream:
+			// Inbound proxy credentials and hop-by-hop headers must not leak upstream.
 			req.Header.Set("authorization", "Bearer CLIENT-CAVE-KEY")
 			req.Header.Set("x-cave-api-key", "cave_live_clientclient_secret")
 			req.Header.Set("x-cave-upstream-key", "should-not-be-copied-verbatim")
 			req.Header.Set("content-type", "application/json")
-			req.Header.Set("x-internal-secret", "nope")
+			req.Header.Set("x-opencode-session", "session-123")
+			req.Header.Set("x-provider-feature", "enabled")
+			req.Header.Set("connection", "x-hop-private")
+			req.Header.Set("x-hop-private", "nope")
 
 			out, err := b.SanitizeAndMapHeaders(req.Context(), req, Credential{Key: "UPSTREAM-PROVIDER-KEY"}, nil)
 			if err != nil {
@@ -180,19 +183,22 @@ func TestSanitizeAndMapHeaders_NoKeyLeakAndCorrectMapping(t *testing.T) {
 					}
 				}
 			}
-			// x-cave-* and arbitrary inbound secrets are not forwarded.
+			// Caveman-private and hop-by-hop headers are not forwarded.
 			if out.Get("x-cave-api-key") != "" {
 				t.Error("x-cave-api-key forwarded upstream")
 			}
 			if out.Get("x-cave-upstream-key") != "" {
 				t.Error("x-cave-upstream-key forwarded upstream")
 			}
-			if out.Get("x-internal-secret") != "" {
-				t.Error("non-allowlisted x-internal-secret forwarded upstream")
+			if out.Get("connection") != "" || out.Get("x-hop-private") != "" {
+				t.Error("hop-by-hop header forwarded upstream")
 			}
-			// Allowlisted passthrough still works.
+			// Provider-defined end-to-end headers pass through without an allowlist.
 			if out.Get("content-type") != "application/json" {
 				t.Error("content-type should pass through")
+			}
+			if out.Get("x-opencode-session") != "session-123" || out.Get("x-provider-feature") != "enabled" {
+				t.Error("provider-defined header was dropped")
 			}
 		})
 	}

--- a/proxy/providers/openaicompat/openaicompat.go
+++ b/proxy/providers/openaicompat/openaicompat.go
@@ -180,9 +180,7 @@ func (a namedAdapter) InspectRequest(ctx context.Context, body providers.BodyRea
 // inbound Bearer token keeps its scheme on every path, as the repository
 // preserves the auth scheme of an inbound credential. The placeholder token is
 // not a real credential. The gateway replaces it from the environment after
-// this mapping, so it must land in the header of the wire protocol. The method
-// also forwards the OpenCode session headers on every path of the opencode-go
-// mount. See openCodeSessionHeaders.
+// this mapping, so it must land in the header of the wire protocol.
 func (a namedAdapter) SanitizeAndMapHeaders(ctx context.Context, req *http.Request, credential providers.Credential, upstream *url.URL) (http.Header, error) {
 	out, err := a.Base.SanitizeAndMapHeaders(ctx, req, credential, upstream)
 	if err != nil {
@@ -191,7 +189,6 @@ func (a namedAdapter) SanitizeAndMapHeaders(ctx context.Context, req *http.Reque
 	if req == nil || req.URL == nil {
 		return out, nil
 	}
-	a.forwardOpenCodeHeaders(out, req.Header)
 	if !a.anthropicMessagesPath(req.URL.Path) {
 		return out, nil
 	}
@@ -203,37 +200,6 @@ func (a namedAdapter) SanitizeAndMapHeaders(ctx context.Context, req *http.Reque
 		out.Set("anthropic-version", "2023-06-01")
 	}
 	return out, nil
-}
-
-// openCodeGoPrefix is the mount of the built-in OpenCode Go upstream. The
-// session headers below are forwarded on this mount only.
-const openCodeGoPrefix = "/compat/opencode-go"
-
-// openCodeSessionHeaders are the headers that OpenCode reads for session
-// attribution. Pi sends x-opencode-session and x-opencode-client. The OpenCode
-// CLI sends all four. OpenCode announced that from 2026-09-06 a request without
-// x-opencode-session can get an error. The shared allowlist of the base adapter
-// drops every x-opencode-* header, thus this mount puts them back.
-var openCodeSessionHeaders = []string{
-	"x-opencode-session",
-	"x-opencode-client",
-	"x-opencode-project",
-	"x-opencode-request",
-}
-
-// forwardOpenCodeHeaders copies the OpenCode session headers from the inbound
-// request to the upstream headers. The copy is gated on the opencode-go mount.
-// Another named mount has no use for these headers. It must not learn the
-// session identity of the caller.
-func (a namedAdapter) forwardOpenCodeHeaders(out, inbound http.Header) {
-	if a.prefix != openCodeGoPrefix {
-		return
-	}
-	for _, name := range openCodeSessionHeaders {
-		for _, value := range inbound.Values(name) {
-			out.Add(name, value)
-		}
-	}
 }
 
 // realBearer reports whether the credential is a Bearer token from the inbound

--- a/proxy/providers/openaicompat/openaicompat_test.go
+++ b/proxy/providers/openaicompat/openaicompat_test.go
@@ -346,7 +346,7 @@ func TestNewNamed_ForwardsOpenCodeSessionHeaders(t *testing.T) {
 		t.Errorf("anthropic-version = %q, want %q", got, "2023-06-01")
 	}
 
-	// Another named mount gets none of the headers.
+	// Another named mount preserves provider-defined end-to-end headers too.
 	other := mustNamed(t, "other", "https://api.example.test")
 	otherReq := httptest.NewRequest(http.MethodPost, "/compat/other/v1/chat/completions", nil)
 	for name, value := range inbound {
@@ -357,8 +357,8 @@ func TestNewNamed_ForwardsOpenCodeSessionHeaders(t *testing.T) {
 		t.Fatalf("SanitizeAndMapHeaders on the other mount: %v", err)
 	}
 	for name := range inbound {
-		if got := otherOut.Get(name); got != "" {
-			t.Errorf("other mount %s = %q, want no header", name, got)
+		if got := otherOut.Get(name); got != inbound[name] {
+			t.Errorf("other mount %s = %q, want %q", name, got, inbound[name])
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- replace the shared provider-header allowlist with transparent end-to-end forwarding
- strip proxy credentials, Caveman-private headers, and RFC hop-by-hop headers
- preserve the existing trace opt-in and provider-specific authentication/billing rules
- remove the now-redundant OpenCode-only forwarding path

## Why

Provider APIs can introduce required headers independently of Caveman releases. The fixed shared allowlist silently dropped `x-opencode-session`, causing OpenCode Go requests to fail with `MissingSessionID`. Fixing each provider header after an outage repeats the same bug class.

## Validation

- `go test ./proxy/providers/... ./proxy/internal/gateway/...`
- `go test ./proxy/...`
- live Hermes → Caveman → OpenCode Go request with an isolated config containing `fallback_providers: []`
