### PR TITLE
fix: preserve recovery-store locks and verify elisions

### DIFF
--- a/engine/ccr/sqlite_file_security_linux.go
+++ b/engine/ccr/sqlite_file_security_linux.go
@@ -1,0 +1,39 @@
+//go:build linux && !js
+
+package ccr
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+func chmodSQLiteFile(path string, info os.FileInfo) error {
+	// Closing an ordinary descriptor for the database or -shm drops ALL POSIX
+	// locks held by SQLite in this process. O_PATH pins the inode without opening
+	// it for I/O; closing this metadata-only descriptor does not release locks.
+	fd, err := unix.Open(path, unix.O_PATH|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	file := os.NewFile(uintptr(fd), path)
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if !opened.Mode().IsRegular() || !os.SameFile(info, opened) {
+		return fmt.Errorf("file changed while opening")
+	}
+	if err := unix.Fchmodat(fd, "", 0o600, unix.AT_EMPTY_PATH); !errors.Is(err, unix.EOPNOTSUPP) && !errors.Is(err, unix.EINVAL) {
+		return err
+	}
+	// Kernels before fchmodat2/AT_EMPTY_PATH require procfs. This is the pinned
+	// descriptor's kernel-controlled link, NOT the swappable database pathname.
+	// chmod performs no open/close, so SQLite's locks remain intact. Fail closed
+	// if procfs is unavailable; never fall back to opening the database for I/O.
+	return unix.Chmod("/proc/self/fd/"+strconv.Itoa(fd), 0o600)
+}

--- a/engine/ccr/sqlite_file_security_unix.go
+++ b/engine/ccr/sqlite_file_security_unix.go
@@ -1,0 +1,25 @@
+//go:build !linux && !windows && !js
+
+package ccr
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func chmodSQLiteFile(path string, info os.FileInfo) error {
+	current, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !current.Mode().IsRegular() || !os.SameFile(info, current) {
+		return fmt.Errorf("file changed while securing")
+	}
+	// Do not open/close the inode: close would discard SQLite's process-wide
+	// POSIX locks. Native nofollow chmod cannot follow a swapped symlink; the
+	// caller also checks inode identity afterwards. Unsupported systems fail
+	// closed rather than using a path-following chmod or an ordinary descriptor.
+	return unix.Fchmodat(unix.AT_FDCWD, path, 0o600, unix.AT_SYMLINK_NOFOLLOW)
+}

--- a/engine/ccr/sqlite_parent_security_posix.go
+++ b/engine/ccr/sqlite_parent_security_posix.go
@@ -5,6 +5,7 @@ package ccr
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 func validateSQLiteParentSecurity(path string, info os.FileInfo) error {
@@ -14,4 +15,20 @@ func validateSQLiteParentSecurity(path string, info os.FileInfo) error {
 		return fmt.Errorf("sqlite parent %q is group/world writable", path)
 	}
 	return nil
+}
+
+func createSQLiteFile(path string) error {
+	// Close before publishing: another Store in this process may open the
+	// database as soon as its name exists. Closing even a creation descriptor
+	// after that point would discard SQLite's process-wide POSIX locks.
+	file, err := os.CreateTemp(filepath.Dir(path), ".caveman-sqlite-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(file.Name())
+	if err := file.Close(); err != nil {
+		return err
+	}
+	// Link is atomic and refuses to replace an existing file or symlink.
+	return os.Link(file.Name(), path)
 }

--- a/engine/ccr/sqlite_parent_security_windows.go
+++ b/engine/ccr/sqlite_parent_security_windows.go
@@ -80,3 +80,29 @@ func windowsACLGrantsBroadWrite(dacl *windows.ACL) (bool, error) {
 	}
 	return false, nil
 }
+
+func createSQLiteFile(path string) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+func chmodSQLiteFile(path string, info os.FileInfo) error {
+	// Windows locks are handle-based, so closing this separate descriptor does
+	// not release the locks held by SQLite.
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if !os.SameFile(info, opened) {
+		return fmt.Errorf("file changed while opening")
+	}
+	return file.Chmod(0o600)
+}

--- a/engine/ccr/store_locking_test.go
+++ b/engine/ccr/store_locking_test.go
@@ -1,0 +1,118 @@
+//go:build !js
+
+package ccr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+type lockingRecovery struct {
+	Handle string
+	Object string
+	Data   []byte
+}
+
+type lockingConsumerRequest struct {
+	Path       string
+	Recoveries []lockingRecovery
+}
+
+// The writer must stay open while independent consumers come and go. Closing
+// the writer before checking would checkpoint its WAL and hide lost locks.
+func TestOpenClosePeerPreservesLiveWriter(t *testing.T) {
+	t.Setenv("CAVEMAN_CCR_MAX_BYTES", "")
+	for _, scenario := range []string{"post-open", "prepare-live-store", "in-process-opens"} {
+		t.Run(scenario, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "ccr.db")
+			writer, err := Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer writer.Close()
+			request := lockingConsumerRequest{Path: path}
+			for round := range 3 {
+				data := []byte(fmt.Sprintf("%s round %d: exact bytes\x00\xff\r\n", scenario, round))
+				handle, err := writer.Put(Recovery{ContentType: "text", Compressor: "text", Original: data})
+				if err != nil {
+					t.Fatalf("write after consumer closed: %v", err)
+				}
+				object, err := writer.PutObject(Object{Type: ObjectCommandResult, SessionID: "lock-regression", Data: data})
+				if err != nil {
+					t.Fatalf("write object after consumer closed: %v", err)
+				}
+				request.Recoveries = append(request.Recoveries, lockingRecovery{Handle: handle, Object: object, Data: data})
+				switch scenario {
+				case "prepare-live-store":
+					if err := PrepareSQLitePath(path); err != nil {
+						t.Fatal(err)
+					}
+				case "in-process-opens":
+					peer, err := Open(path)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if err := peer.Close(); err != nil {
+						t.Fatal(err)
+					}
+				}
+				runLockingConsumer(t, request)
+			}
+		})
+	}
+}
+
+func runLockingConsumer(t *testing.T, request lockingConsumerRequest) {
+	t.Helper()
+	input, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, executable, "-test.run=^TestSQLiteLockingConsumerProcess$")
+	cmd.Env = append(os.Environ(), "CAVEMAN_CCR_LOCKING_CONSUMER=1")
+	cmd.Stdin = bytes.NewReader(input)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("fresh consumer: %v\n%s", err, output)
+	}
+}
+
+func TestSQLiteLockingConsumerProcess(t *testing.T) {
+	if os.Getenv("CAVEMAN_CCR_LOCKING_CONSUMER") != "1" {
+		return
+	}
+	var request lockingConsumerRequest
+	if err := json.NewDecoder(os.Stdin).Decode(&request); err != nil {
+		t.Fatal(err)
+	}
+	consumer, err := Open(request.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer consumer.Close()
+	for _, recovery := range request.Recoveries {
+		got, err := consumer.Get(recovery.Handle)
+		if err != nil || !bytes.Equal(got, recovery.Data) {
+			t.Fatalf("recovery %s: bytes=%q, error=%v; want %q", recovery.Handle, got, err, recovery.Data)
+		}
+		object, err := consumer.GetObject(recovery.Object)
+		if err != nil || !bytes.Equal(object.Data, recovery.Data) {
+			t.Fatalf("object %s: bytes=%q, error=%v; want %q", recovery.Object, object.Data, err, recovery.Data)
+		}
+	}
+	if err := consumer.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/engine/ccr/store_permissions_test.go
+++ b/engine/ccr/store_permissions_test.go
@@ -147,3 +147,122 @@ func TestOpenUsesCanonicalParentAfterSymlinkSwap(t *testing.T) {
 		t.Fatalf("redirected database created: %v", err)
 	}
 }
+
+func TestPrepareSQLitePathSecuresExistingSidecars(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not meaningful on Windows")
+	}
+	path := filepath.Join(t.TempDir(), "ccr.db")
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		if err := os.WriteFile(path+suffix, nil, 0o666); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path+suffix, 0o666); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := PrepareSQLitePath(path); err != nil {
+		t.Fatal(err)
+	}
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		info, err := os.Stat(path + suffix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("%s permissions = %04o, want 0600", path+suffix, got)
+		}
+	}
+}
+
+func TestPrepareSQLitePathRejectsSidecarSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		t.Run(suffix, func(t *testing.T) {
+			dir := t.TempDir()
+			path, target := filepath.Join(dir, "ccr.db"), filepath.Join(dir, "target")
+			if err := os.WriteFile(target, []byte("untouched"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(target, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, path+suffix); err != nil {
+				t.Fatal(err)
+			}
+			if err := PrepareSQLitePath(path); err == nil {
+				t.Fatal("symlink sidecar accepted")
+			}
+			info, err := os.Stat(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Mode().Perm() != 0o644 {
+				t.Fatal("symlink target permissions changed")
+			}
+		})
+	}
+}
+
+func TestPrepareSQLitePathRejectsNonRegularFiles(t *testing.T) {
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		t.Run("database"+suffix, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "ccr.db")
+			if err := os.Mkdir(path+suffix, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := PrepareSQLitePath(path); err == nil {
+				t.Fatal("directory accepted as a SQLite file")
+			}
+		})
+	}
+}
+
+func TestChmodSQLiteFileRejectsReplacedInode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX modes and symlink replacement require Unix")
+	}
+	for _, replacement := range []string{"regular", "symlink"} {
+		t.Run(replacement, func(t *testing.T) {
+			dir := t.TempDir()
+			path, target := filepath.Join(dir, "ccr.db"), filepath.Join(dir, "target")
+			if err := os.WriteFile(path, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			info, err := os.Lstat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Keep the original inode alive so the replacement cannot reuse it.
+			if err := os.Rename(path, path+".original"); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(target, nil, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(target, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if replacement == "symlink" {
+				err = os.Symlink(target, path)
+			} else {
+				err = os.Link(target, path)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := chmodSQLiteFile(path, info); err == nil {
+				t.Fatal("replaced SQLite inode accepted")
+			}
+			current, err := os.Stat(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if current.Mode().Perm() != 0o644 {
+				t.Fatal("replacement target permissions changed")
+			}
+		})
+	}
+}

--- a/engine/ccr/store_sqlite.go
+++ b/engine/ccr/store_sqlite.go
@@ -249,9 +249,9 @@ func secureSQLiteFiles(path string) error {
 func secureSQLiteFile(path string, create bool) error {
 	info, err := os.Lstat(path)
 	if errors.Is(err, os.ErrNotExist) && create {
-		file, createErr := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+		createErr := createSQLiteFile(path)
 		if createErr == nil {
-			return file.Close()
+			return nil
 		}
 		if !errors.Is(createErr, os.ErrExist) {
 			return createErr
@@ -267,24 +267,26 @@ func secureSQLiteFile(path string, create bool) error {
 	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
 		return fmt.Errorf("refusing non-regular file")
 	}
-	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	err = chmodSQLiteFile(path, info)
 	if errors.Is(err, os.ErrNotExist) && !create {
-		// The sidecar vanished between Lstat and open — a concurrent process
+		// The sidecar vanished while securing it — a concurrent process
 		// checkpointed the WAL and removed it. Nothing left to secure.
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	defer file.Close()
-	opened, err := file.Stat()
+	secured, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) && !create {
+		return nil
+	}
 	if err != nil {
 		return err
 	}
-	if !os.SameFile(info, opened) {
-		return fmt.Errorf("file changed while opening")
+	if !os.SameFile(info, secured) {
+		return fmt.Errorf("file changed while securing")
 	}
-	return file.Chmod(0o600)
+	return nil
 }
 
 func configureStorageBudget(db *sql.DB, maxBytes int64) error {

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -42,3 +42,16 @@ in `BINARY_LICENSE.md`.
 Compression is lossy (S4) but **reversible**: every drop is recoverable via
 `caveman_retrieve`. Incompressible or malformed input passes through unchanged
 with `ratio:0` — never an error.
+
+Hosts that publish compressed output can first call `caveman_retrieve` with
+`{"recovery_handle":"ccr://ccr_…","verify_only":true}`. Check for the
+`recovery_verification` capability in `caveman-mcp version --json` before using
+this optional mode: older servers may ignore unknown arguments.
+
+Verification returns a JSON text block containing the normalized bare
+`recovery_handle`, UTF-8 `byte_length`, and lowercase hexadecimal `sha256` of
+the complete stored original. It ignores `query`, errors on unknown handles,
+and does not count as a delivery or alter the session's repeated-retrieval
+ledger. Compare all three fields with the proposed handle and original bytes;
+retain the original output when verification fails. This checks availability
+at publication time, not indefinite retention or immunity to later deletion.

--- a/mcp/cmd/caveman-mcp/main.go
+++ b/mcp/cmd/caveman-mcp/main.go
@@ -53,7 +53,7 @@ func handleArgs(args []string, stdout, stderr io.Writer) (bool, int) {
 		err := json.NewEncoder(stdout).Encode(map[string]any{
 			"version":      version,
 			"schema":       "caveman.mcp.version.v1",
-			"capabilities": []string{"mcp_recovery", "build_stamped_version"},
+			"capabilities": []string{"mcp_recovery", "build_stamped_version", "recovery_verification"},
 		})
 		if err != nil {
 			return true, 1

--- a/mcp/cmd/caveman-mcp/main_test.go
+++ b/mcp/cmd/caveman-mcp/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"slices"
 	"testing"
 )
 
@@ -27,8 +28,10 @@ func TestVersionJSON(t *testing.T) {
 	if got.Schema != "caveman.mcp.version.v1" {
 		t.Fatalf("schema=%q", got.Schema)
 	}
-	if len(got.Capabilities) != 2 || got.Capabilities[0] != "mcp_recovery" {
-		t.Fatalf("capabilities=%v", got.Capabilities)
+	for _, capability := range []string{"mcp_recovery", "build_stamped_version", "recovery_verification"} {
+		if !slices.Contains(got.Capabilities, capability) {
+			t.Fatalf("missing %q: capabilities=%v", capability, got.Capabilities)
+		}
 	}
 }
 

--- a/mcp/engine_tools.go
+++ b/mcp/engine_tools.go
@@ -1,7 +1,9 @@
 package mcp
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -58,6 +60,7 @@ func EngineTools(eng Engine, log *slog.Logger) []Tool {
 			InputSchema: ObjectSchema(map[string]any{
 				"recovery_handle": StringProp("Exact ccr_ handle returned by Caveman or copied from a <<ccr:HANDLE>> marker."),
 				"query":           StringProp("Optional but strongly preferred: one broad description covering every detail you need from this handle, so a single call answers the whole question instead of many narrow ones."),
+				"verify_only":     map[string]any{"type": "boolean", "description": "Check exact-original availability and return its byte length and SHA-256 without consuming a recovery delivery. Ignores query."},
 			}, "recovery_handle"),
 			// Recovery returns the exact original bytes: exempt from the
 			// result-size cap so a >cap original (the shared gateway store has no
@@ -169,6 +172,7 @@ func retrieveTool(eng Engine, session *retrieveSession, args json.RawMessage) To
 	var a struct {
 		RecoveryHandle string `json:"recovery_handle"`
 		Query          string `json:"query"`
+		VerifyOnly     bool   `json:"verify_only"`
 	}
 	if err := json.Unmarshal(args, &a); err != nil || a.RecoveryHandle == "" {
 		return ToolError("cave_invalid_arguments", "retrieve: missing recovery_handle")
@@ -176,6 +180,17 @@ func retrieveTool(eng Engine, session *retrieveSession, args json.RawMessage) To
 	a.RecoveryHandle = normalizeRecoveryHandle(a.RecoveryHandle)
 	if a.RecoveryHandle == "" {
 		return ToolError("cave_invalid_arguments", "retrieve: missing recovery_handle")
+	}
+	if a.VerifyOnly {
+		original, err := eng.Retrieve(a.RecoveryHandle)
+		if err != nil {
+			return ToolError("cave_unknown_handle", "no original found for handle")
+		}
+		return ToolText(map[string]any{
+			"recovery_handle": a.RecoveryHandle,
+			"byte_length":     len(original),
+			"sha256":          fmt.Sprintf("%x", sha256.Sum256(original)),
+		})
 	}
 	// Already answered verbatim in this session: the bytes are above in the
 	// transcript, so re-sending them buys nothing and costs a turn. Only ever said

--- a/mcp/retrieve_verification_test.go
+++ b/mcp/retrieve_verification_test.go
@@ -1,0 +1,48 @@
+package mcp
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestVerificationDoesNotConsumeRecovery(t *testing.T) {
+	const original = "exact café bytes\n\t \n"
+	eng := &storeEngine{originals: map[string]string{"ccr_fixture": original}}
+	session := newRetrieveSession()
+	args := json.RawMessage(`{"recovery_handle":"ccr://ccr_fixture","query":"ignored","verify_only":true}`)
+	verify := func() {
+		t.Helper()
+		result := retrieveTool(eng, session, args)
+		if result.IsError || len(result.Content) != 1 {
+			t.Fatalf("verification failed: %+v", result)
+		}
+		var got struct {
+			Handle string `json:"recovery_handle"`
+			Bytes  int    `json:"byte_length"`
+			SHA256 string `json:"sha256"`
+		}
+		if err := json.Unmarshal([]byte(result.Content[0].Text), &got); err != nil {
+			t.Fatal(err)
+		}
+		if got.Handle != "ccr_fixture" || got.Bytes != len(original) || got.SHA256 != fmt.Sprintf("%x", sha256.Sum256([]byte(original))) {
+			t.Fatalf("wrong recovery metadata: %+v", got)
+		}
+	}
+	for range retrieveStormThreshold + 2 {
+		verify()
+	}
+	full := retrieveTool(eng, session, retrieveArgs("ccr_fixture", ""))
+	if full.IsError || len(full.Content) != 1 || full.Content[0].Text != original {
+		t.Fatalf("verification consumed or decorated first recovery: %+v", full)
+	}
+	verify()
+}
+
+func TestVerificationRejectsUnknownHandle(t *testing.T) {
+	result := retrieveTool(newStoreEngine(), newRetrieveSession(), json.RawMessage(`{"recovery_handle":"ccr_missing","verify_only":true}`))
+	if !result.IsError {
+		t.Fatalf("unknown handle verified: %+v", result)
+	}
+}

--- a/packages/pi-extension/README.md
+++ b/packages/pi-extension/README.md
@@ -15,8 +15,11 @@ One extension, four jobs:
   must match. A provider that points at any other endpoint stays direct, with
   one notice saying why.
 - **Exact recovery** — registers a single model-visible tool, `caveman_retrieve`,
-  backed by the local `caveman-mcp` binary and the shared CCR store. Compressed
-  bytes are always recoverable, byte-exact.
+  backed by the local `caveman-mcp` binary and the shared CCR store. Before
+  shortening a tool result, the extension checks that its advertised handle
+  resolves to the original bytes without consuming the model's later recovery.
+  Missing, mismatched, or unverifiable handles leave the original output intact.
+  Older companions without verification support keep tool results unchanged.
 - **Native lifecycle** — bridges Pi session/turn/tool events into the Caveman
   native runtime (Core injection, per-turn context, tool-output shrinking).
 - **Honest fallback** — routing activates only after the recovery gate holds

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -269,7 +269,7 @@ export default function (pi: ExtensionAPI) {
   // instead of terminating — and registering this tool disabled the proxy's
   // server-side retrieve loop, so nothing else would strip it.
   pi.on("tool_result", GUARD_tool_result((event: Parameters<typeof shrinkToolResult>[2]) =>
-    event.toolName === RECOVERY_TOOL ? undefined : shrinkToolResult(bridge, sessionId, event)));
+    event.toolName === RECOVERY_TOOL ? undefined : shrinkToolResult(bridge, sessionId, event, recovery)));
 
   pi.on("session_before_compact", GUARD_session_before_compact(() => { void bridge.call("PreCompact", { session_id: sessionId }); }));
 

--- a/packages/pi-extension/src/protocol.ts
+++ b/packages/pi-extension/src/protocol.ts
@@ -76,6 +76,17 @@ export function outputReplacementOf(response: HookResponse | undefined): string 
   return replacement ? replacement : undefined;
 }
 
+// Match mcp.normalizeRecoveryHandle's historical wrappers, then require one
+// complete CCR id. Never salvage a valid prefix from a malformed reference.
+export function normalizeRecoveryHandle(value: unknown): string | undefined {
+  if (!fits(value, MAX_RECOVERY_REF_BYTES)) return undefined;
+  let handle = value.trim();
+  if (handle.startsWith("<<") && handle.endsWith(">>")) handle = handle.slice(2, -2).trim();
+  if (handle.startsWith("ccr://")) handle = handle.slice(6).trim().replace(/^\/+|\/+$/g, "");
+  else if (handle.startsWith("ccr:")) handle = handle.slice(4).trim();
+  return /^ccr_[A-Za-z0-9_-]+$/.test(handle) ? handle : undefined;
+}
+
 // This route table maps each Pi model API to a path under the local gateway.
 // An API that is not in this table is unsupported, for example azure, bedrock,
 // vertex, mistral, and codex-responses. The extension never routes such an API,

--- a/packages/pi-extension/src/recovery.ts
+++ b/packages/pi-extension/src/recovery.ts
@@ -5,10 +5,12 @@
 // resolve the same handles.
 
 import { type ChildProcess, execFile, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, join } from "node:path";
 import { type PortableInvocation, portableInvocation } from "./portable-command.ts";
+import { MAX_MESSAGE_BYTES, MAX_TOOL_OUTPUT_BYTES, normalizeRecoveryHandle } from "./protocol.ts";
 
 const PROBE_TIMEOUT_MS = 2000;
 const CALL_TIMEOUT_MS = 30_000;
@@ -18,6 +20,7 @@ const CALL_TIMEOUT_MS = 30_000;
 // in this package is 750ms–6s; a timed-out handshake degrades the session to
 // "no recovery available" instead.
 const INIT_TIMEOUT_MS = 2000;
+const VERIFY_TIMEOUT_MS = 2000;
 
 export type RetrieveResult = { text: string; isError: boolean };
 
@@ -39,6 +42,7 @@ export class RecoveryClient {
   private child: ChildProcess | undefined;
   private initialized = false;
   private probed: boolean | undefined;
+  private verificationSupported = false;
   private ensuring: Promise<boolean> | undefined;
   private nextId = 1;
   private pending = new Map<number, Pending>();
@@ -91,6 +95,30 @@ export class RecoveryClient {
     }
   }
 
+  // A silent pre-publication proof must not count as delivery to the model.
+  // Old companions ignore unknown arguments, so capability proof is mandatory
+  // before sending verify_only through the same long-lived recovery child.
+  async verify(handle: string, originalText: string): Promise<boolean> {
+    const normalized = normalizeRecoveryHandle(handle);
+    const bytes = Buffer.byteLength(originalText, "utf8");
+    if (!normalized || bytes > MAX_TOOL_OUTPUT_BYTES) return false;
+    try {
+      if (!(await this.ensure()) || !this.verificationSupported) return false;
+      const result = await this.call("tools/call", {
+        name: "caveman_retrieve",
+        arguments: { recovery_handle: normalized, verify_only: true },
+      }, undefined, VERIFY_TIMEOUT_MS) as { content?: Array<{ type?: string; text?: string }>; isError?: boolean };
+      if (result.isError || !Array.isArray(result.content) || result.content.length !== 1) return false;
+      const block = result.content[0];
+      if (block?.type !== "text" || typeof block.text !== "string" || Buffer.byteLength(block.text, "utf8") > MAX_MESSAGE_BYTES) return false;
+      const proof = JSON.parse(block.text);
+      return proof?.recovery_handle === normalized && proof.byte_length === bytes &&
+        proof.sha256 === createHash("sha256").update(originalText, "utf8").digest("hex");
+    } catch {
+      return false;
+    }
+  }
+
   dispose(): void {
     this.disposed = true;
     const child = this.child;
@@ -129,6 +157,7 @@ export class RecoveryClient {
         if (error) return resolve(false);
         try {
           const parsed = JSON.parse(stdout);
+          this.verificationSupported = Array.isArray(parsed?.capabilities) && parsed.capabilities.includes("recovery_verification");
           resolve(Array.isArray(parsed?.capabilities) && parsed.capabilities.includes("mcp_recovery"));
         } catch {
           resolve(false);

--- a/packages/pi-extension/src/testable.ts
+++ b/packages/pi-extension/src/testable.ts
@@ -4,3 +4,4 @@ export * from "./protocol.ts";
 export { HookBridge, promptDigest, resolveHookInvocations, taskContinuation, taskTerms, taskType } from "./lifecycle.ts";
 export { RecoveryClient, resolveMcpBinary } from "./recovery.ts";
 export { ProviderRouter } from "./provider.ts";
+export { shrinkToolResult } from "./tool-output.ts";

--- a/packages/pi-extension/src/tool-output.ts
+++ b/packages/pi-extension/src/tool-output.ts
@@ -1,10 +1,11 @@
 // Post-tool output shrinking via the native runtime's PostToolUse decision.
-// The runtime decides; this side only applies a valid replacement and carries
-// the recovery handle embedded in it. Anything abnormal keeps the original.
+// A replacement is published only after the session's recovery client proves
+// its advertised handle still resolves to these exact original bytes.
 
 import type { ToolResultEvent } from "@earendil-works/pi-coding-agent";
 import type { HookBridge } from "./lifecycle.ts";
-import { MAX_TOOL_OUTPUT_BYTES, outputReplacementOf } from "./protocol.ts";
+import { MAX_OUTPUT_REPLACEMENT_BYTES, MAX_TOOL_OUTPUT_BYTES, normalizeRecoveryHandle, outputReplacementOf } from "./protocol.ts";
+import type { RecoveryClient } from "./recovery.ts";
 
 // Partial-patch result shape for tool_result handlers (ToolResultEventResult is
 // not re-exported from the package root; omitted fields keep current values).
@@ -14,6 +15,7 @@ export async function shrinkToolResult(
   bridge: HookBridge,
   sessionId: string,
   event: ToolResultEvent,
+  recovery: Pick<RecoveryClient, "verify">,
 ): Promise<ToolResultPatch | undefined> {
   const text = event.content
     .map((block) => (block.type === "text" && typeof block.text === "string" ? block.text : ""))
@@ -22,14 +24,33 @@ export async function shrinkToolResult(
   // Over-cap output is skipped, not truncated: a partial payload could produce
   // a replacement whose recovery handle does not cover the elided bytes.
   if (Buffer.byteLength(text, "utf8") > MAX_TOOL_OUTPUT_BYTES) return undefined;
-  const response = await bridge.call(event.isError ? "PostToolUseFailure" : "PostToolUse", {
-    session_id: sessionId,
-    tool_name: event.toolName,
-    tool_input: event.input,
-    tool_output: text,
-  });
-  const replacement = outputReplacementOf(response);
-  if (!replacement) return undefined;
+  let replacement: string;
+  try {
+    const response = await bridge.call(event.isError ? "PostToolUseFailure" : "PostToolUse", {
+      session_id: sessionId,
+      tool_name: event.toolName,
+      tool_input: event.input,
+      tool_output: text,
+    });
+    const proposed = outputReplacementOf(response);
+    if (!proposed || Buffer.byteLength(proposed, "utf8") > MAX_OUTPUT_REPLACEMENT_BYTES) return undefined;
+    let handle = normalizeRecoveryHandle(response?.recovery_ref);
+    if (response?.recovery_ref !== undefined && !handle) return undefined;
+    let advertised = false;
+    // Consume the whole reference token, including bad suffixes/delimiters.
+    // Repeated mentions are fine; a different or malformed handle is not.
+    for (const match of proposed.matchAll(/(?:<<)?ccr(?::|_)[^\s"'`]*/g)) {
+      if (match.index > 0 && /[A-Za-z0-9_<:/]/.test(proposed[match.index - 1]!)) return undefined;
+      const candidate = normalizeRecoveryHandle(match[0]);
+      if (!candidate || (handle && candidate !== handle)) return undefined;
+      handle = candidate;
+      advertised = true;
+    }
+    if (!advertised || !handle || !(await recovery.verify(handle, text))) return undefined;
+    replacement = proposed;
+  } catch {
+    return undefined;
+  }
   // Replace only the model-facing text; non-text blocks (images) were never
   // sent to the runtime, are not covered by the recovery handle, and must
   // survive the replacement byte-for-byte. Details keep the renderer's shape.

--- a/packages/pi-extension/tests/fixtures/stub-caveman-mcp.mjs
+++ b/packages/pi-extension/tests/fixtures/stub-caveman-mcp.mjs
@@ -13,13 +13,20 @@
 // test can count how many children ensure() actually created and whether
 // dispose() reaped them.
 
-import { appendFileSync, existsSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 
 const KNOWN_HANDLE = "ccr_0123456789abcdef0123456789abcdef";
 const KNOWN_BYTES = "exact original bytes\nline two éø bytes";
+// Read on every retrieve: the hook fixture publishes fresh originals after the
+// MCP child has initialized, just as the separate native producer does.
+function storedText(handle) {
+  if (!process.env.STUB_MCP_STORE) return handle === KNOWN_HANDLE ? KNOWN_BYTES : undefined;
+  try { return JSON.parse(readFileSync(process.env.STUB_MCP_STORE, "utf8"))[handle]; } catch { return undefined; }
+}
 
 if (process.argv[2] === "version") {
-  const capabilities = process.env.STUB_MCP_DROP_CAPABILITY === "1" ? ["build_stamped_version"] : ["mcp_recovery", "build_stamped_version"];
+  const capabilities = process.env.STUB_MCP_DROP_CAPABILITY === "1" ? ["build_stamped_version"] : ["mcp_recovery", "build_stamped_version", ...(process.env.STUB_MCP_DROP_VERIFICATION === "1" ? [] : ["recovery_verification"])];
   process.stdout.write(JSON.stringify({ version: "1.0.0", schema: "caveman.mcp.version.v1", capabilities }) + "\n");
   process.exit(0);
 }
@@ -27,6 +34,7 @@ if (process.argv[2] === "version") {
 const spawnLog = process.env.STUB_MCP_SPAWN_LOG;
 if (spawnLog) appendFileSync(spawnLog, `${process.pid}\n`);
 
+const served = new Set();
 let buffer = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk) => {
@@ -49,10 +57,24 @@ process.stdin.on("data", (chunk) => {
       }
     } else if (message.method === "tools/call") {
       const args = message.params?.arguments ?? {};
+      const handle = args.recovery_handle?.replace(/^ccr:\/\//, "");
+      const text = storedText(handle);
       if (message.params?.name !== "caveman_retrieve") {
         reply(message.id, { content: [{ type: "text", text: JSON.stringify({ error: "cave_unknown_tool" }) }], isError: true });
-      } else if (args.recovery_handle === KNOWN_HANDLE) {
-        reply(message.id, { content: [{ type: "text", text: KNOWN_BYTES }], isError: false });
+      } else if (typeof text === "string") {
+        const key = `${handle}\0${args.query ?? ""}`;
+        if (args.verify_only && process.env.STUB_MCP_DROP_VERIFICATION !== "1") {
+          const proof = { recovery_handle: handle, byte_length: Buffer.byteLength(text), sha256: createHash("sha256").update(text).digest("hex") };
+          const fault = process.env.STUB_MCP_VERIFICATION_FAULT;
+          if (fault === "reference") proof.recovery_handle = "ccr_ffffffffffffffffffffffffffffffff";
+          if (fault === "length") proof.byte_length++;
+          if (fault === "digest") proof.sha256 = "0".repeat(64);
+          if (fault === "hang") continue;
+          reply(message.id, { content: [{ type: "text", text: fault === "malformed" ? "not JSON" : JSON.stringify(proof) }], isError: fault === "error" });
+        } else {
+          reply(message.id, { content: [{ type: "text", text: served.has(key) ? "already recovered" : text }], isError: false });
+          served.add(key);
+        }
       } else {
         reply(message.id, { content: [{ type: "text", text: JSON.stringify({ error: "cave_unknown_handle", message: "no original found for handle" }) }], isError: true });
       }

--- a/packages/pi-extension/tests/integration.runtime.mjs
+++ b/packages/pi-extension/tests/integration.runtime.mjs
@@ -141,40 +141,54 @@ function runPi(env, args) {
 // ~448 bytes, so the recovered original came back to the model as a fresh ccr://
 // mask and recovery looped instead of terminating — and registering the tool
 // disables the proxy's server-side retrieve loop, so nothing else strips it.
-test("caveman_retrieve output is never shrunk; other tools still are", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cave-pi-shrink-"));
-  const hookLog = join(root, "hooks.log");
-  const hook = join(root, "hook.mjs");
+test("fresh tool-output handles recover exactly; caveman_retrieve output is never shrunk", async () => {
+  const fx = fixture(0, { runState: false });
+  const hook = join(fx.root, "publish.mjs");
+  const store = join(fx.root, "originals.json");
+  const original = "exact original bytes\r\nline two éø bytes\0\n";
   writeFileSync(hook, `
-import { appendFileSync } from "node:fs";
-const event = process.argv[process.argv.length - 1];
+import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
 let input = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk) => { input += chunk; });
 process.stdin.on("end", () => {
-  let toolName = "";
-  try { toolName = JSON.parse(input).tool_name ?? ""; } catch { /* logged as empty */ }
-  appendFileSync(${JSON.stringify(hookLog)}, event + " " + toolName + "\\n");
-  process.stdout.write('{"output_replacement":"SHRUNK <<ccr:handle>>"}');
+  const text = JSON.parse(input).tool_output;
+  if (typeof text !== "string") { process.stdout.write("{}"); return; }
+  const handle = "ccr_obj_" + createHash("sha256").update(text).digest("hex").slice(0, 32);
+  writeFileSync(${JSON.stringify(store)}, JSON.stringify({ [handle]: text }));
+  const recovery_ref = "ccr://" + handle;
+  process.stdout.write(JSON.stringify({ recovery_ref, output_replacement: "SHRUNK full: " + recovery_ref }));
 });
 `);
-  const prior = process.env.CAVEMAN_PI_HOOK_CMD;
-  process.env.CAVEMAN_PI_HOOK_CMD = JSON.stringify([process.execPath, hook, "placeholder"]);
+  const vars = {
+    CAVEMAN_PI_HOOK_CMD: JSON.stringify([process.execPath, hook, "placeholder"]),
+    CAVEMAN_MCP_BIN: fx.env.CAVEMAN_MCP_BIN,
+    STUB_MCP_STORE: store,
+  };
+  const prior = Object.fromEntries(Object.keys(vars).map((key) => [key, process.env[key]]));
+  Object.assign(process.env, vars);
+  const handlers = new Map();
+  let retrieveTool;
   try {
     const { default: factory } = await import(pathToFileURL(extension).href);
-    const handlers = new Map();
-    factory({ registerTool: () => {}, on: (name, fn) => handlers.set(name, fn) });
-    const result = (toolName) => handlers.get("tool_result")({ toolName, input: {}, isError: false, content: [{ type: "text", text: "exact original bytes" }] });
+    factory({ registerTool: (tool) => { retrieveTool = tool; }, on: (name, fn) => handlers.set(name, fn) });
+    const image = { type: "image", data: "cGl4ZWxz", mimeType: "image/png" };
+    const content = [{ type: "text", text: original.slice(0, 8) }, image, { type: "text", text: original.slice(8) }];
+    const shrunk = await handlers.get("tool_result")({ toolName: "read_file", input: {}, isError: false, content });
+    const handle = Object.keys(JSON.parse(readFileSync(store, "utf8")))[0];
+    assert.deepEqual(shrunk?.content, [{ type: "text", text: `SHRUNK full: ccr://${handle}` }, image]);
+    assert.equal(shrunk.content[1], image, "nontext content must survive unchanged");
 
-    const shrunk = await result("read_file");
-    assert.equal(shrunk?.content?.[0]?.text, "SHRUNK <<ccr:handle>>", "ordinary tool output must still shrink");
-    assert.equal(await result("caveman_retrieve"), undefined, "recovered originals must reach the model unmasked");
-    // Not merely unchanged output: the runtime is never even asked, so no
-    // handle can be minted for bytes that were already recovered.
-    assert.deepEqual(readFileSync(hookLog, "utf8").trim().split("\n"), ["PostToolUse read_file"]);
+    const recovered = await retrieveTool.execute("recover", { recovery_handle: `ccr://${handle}` }, undefined);
+    assert.deepEqual(recovered.content, [{ type: "text", text: original }], "verification must not consume model recovery");
+    assert.equal(await handlers.get("tool_result")({ toolName: "caveman_retrieve", input: {}, isError: false, content: recovered.content }), undefined);
   } finally {
-    if (prior === undefined) delete process.env.CAVEMAN_PI_HOOK_CMD; else process.env.CAVEMAN_PI_HOOK_CMD = prior;
-    rmSync(root, { recursive: true, force: true });
+    await handlers.get("session_shutdown")?.();
+    for (const [key, value] of Object.entries(prior)) {
+      if (value === undefined) delete process.env[key]; else process.env[key] = value;
+    }
+    fx.cleanup();
   }
 });
 

--- a/packages/pi-extension/tests/recovery.runtime.mjs
+++ b/packages/pi-extension/tests/recovery.runtime.mjs
@@ -8,7 +8,7 @@ const stub = join(here, "fixtures", "stub-caveman-mcp.mjs");
 // pathToFileURL, not a bare path: dynamic import() of an absolute Windows
 // path throws ERR_UNSUPPORTED_ESM_URL_SCHEME (the drive letter reads as a URL
 // scheme).
-const { RecoveryClient } = await import(pathToFileURL(join(here, "..", "dist", "testable.mjs")).href);
+const { RecoveryClient, shrinkToolResult, MAX_TOOL_OUTPUT_BYTES, MAX_OUTPUT_REPLACEMENT_BYTES } = await import(pathToFileURL(join(here, "..", "dist", "testable.mjs")).href);
 
 const KNOWN_HANDLE = "ccr_0123456789abcdef0123456789abcdef";
 const KNOWN_BYTES = "exact original bytes\nline two éø bytes";
@@ -204,4 +204,103 @@ test("a broken stdin pipe degrades the retrieve instead of crashing the host", a
     }
     recovery.dispose();
   }).finally(() => { cleanup(); rmSync(dirname(log), { recursive: true, force: true }); });
+});
+
+const outputEvent = (text = KNOWN_BYTES) => ({
+  toolName: "read_file", input: {}, isError: false,
+  content: [{ type: "text", text }, { type: "image", data: "cGl4ZWxz", mimeType: "image/png" }],
+});
+const shrink = (recovery, response, event = outputEvent()) =>
+  shrinkToolResult({ call: async () => response }, "publication-test", event, recovery);
+
+test("publication accepts only one exact recoverable identity across every advertised reference", async () => {
+  const { path, cleanup } = shim();
+  const recovery = new RecoveryClient(path);
+  const replacement = `full: ccr://${KNOWN_HANDLE}\nrecover: <<ccr:${KNOWN_HANDLE}>>`;
+  try {
+    const event = outputEvent();
+    assert.deepEqual(await shrink(recovery, { recovery_ref: `ccr:${KNOWN_HANDLE}`, output_replacement: replacement }, event),
+      { content: [{ type: "text", text: replacement }, event.content[1]] });
+    const nested = `compressed <<ccr:${KNOWN_HANDLE}>>`;
+    assert.deepEqual(await shrink(recovery, { hookSpecificOutput: { updatedToolOutput: nested } }, event),
+      { content: [{ type: "text", text: nested }, event.content[1]] });
+    assert.equal((await recovery.retrieve(KNOWN_HANDLE, undefined, undefined)).text, KNOWN_BYTES,
+      "silent verification must not mark originals as already delivered");
+  } finally { recovery.dispose(); cleanup(); }
+});
+
+test("unknown, mismatched and malformed publications keep original content", async () => {
+  const { path, cleanup } = shim();
+  const recovery = new RecoveryClient(path);
+  const other = "ccr_ffffffffffffffffffffffffffffffff";
+  const valid = `ccr://${KNOWN_HANDLE}`;
+  try {
+    const cases = [
+      ["unknown", { recovery_ref: other, output_replacement: `full: ccr://${other}` }],
+      ["reference mismatch", { recovery_ref: other, output_replacement: `full: ${valid}` }],
+      ["missing reference", { output_replacement: "summary with no recovery handle" }],
+      ["reference without replacement", { recovery_ref: valid }],
+      ["malformed response reference", { recovery_ref: `${valid}/bad`, output_replacement: `full: ${valid}` }],
+      ["multiple different handles", { output_replacement: `full: ${valid}\nrecover: ccr://${other}` }],
+      ["URI suffix", { output_replacement: `full: ${valid}/different` }],
+      ["URI query", { output_replacement: `full: ${valid}?handle=${other}` }],
+      ["marker suffix", { output_replacement: `<<ccr:${KNOWN_HANDLE}>>different` }],
+      ["unclosed marker", { output_replacement: `<<ccr:${KNOWN_HANDLE}` }],
+      ["extra marker delimiter", { output_replacement: `<<ccr:${KNOWN_HANDLE}>>>` }],
+      ["embedded reference", { output_replacement: `not${valid}` }],
+      ["oversized replacement", { output_replacement: `full: ${valid}\n${"x".repeat(MAX_OUTPUT_REPLACEMENT_BYTES)}` }],
+    ];
+    const event = outputEvent();
+    const original = structuredClone(event);
+    for (const [name, response] of cases) {
+      assert.equal(await shrink(recovery, response, event), undefined, name);
+      assert.deepEqual(event, original, `${name} changed original content`);
+    }
+    for (const text of [KNOWN_BYTES + "\n", KNOWN_BYTES.replace("é", "e\u0301"), "x".repeat(MAX_TOOL_OUTPUT_BYTES + 1)]) {
+      assert.equal(await shrink(recovery, { output_replacement: `full: ${valid}` }, outputEvent(text)), undefined,
+        "nonidentical or over-cap originals must not be replaced");
+    }
+  } finally { recovery.dispose(); cleanup(); }
+});
+
+test("missing verification capability keeps original and does not consume recovery on old companions", async () => {
+  const { path, cleanup } = shim();
+  await withEnv({ STUB_MCP_DROP_VERIFICATION: "1" }, async () => {
+    const recovery = new RecoveryClient(path);
+    try {
+      assert.equal(await shrink(recovery, { output_replacement: `<<ccr:${KNOWN_HANDLE}>>` }), undefined);
+      assert.equal((await recovery.retrieve(KNOWN_HANDLE, undefined, undefined)).text, KNOWN_BYTES);
+    } finally { recovery.dispose(); }
+  }).finally(cleanup);
+});
+
+test("invalid or failed verification proofs keep original output", async () => {
+  const { path, cleanup } = shim();
+  try {
+    for (const fault of ["reference", "length", "digest", "malformed", "error", "hang"]) {
+      await withEnv({ STUB_MCP_VERIFICATION_FAULT: fault }, async () => {
+        const recovery = new RecoveryClient(path);
+        try {
+          const started = Date.now();
+          assert.equal(await shrink(recovery, { output_replacement: `full: ccr://${KNOWN_HANDLE}` }), undefined, fault);
+          if (fault === "hang") assert.ok(Date.now() - started < 5000, "publication must not wait the model's 30s retrieval budget");
+        } finally { recovery.dispose(); }
+      });
+    }
+  } finally { cleanup(); }
+});
+
+test("unavailable recovery and thrown failures leave tool results untouched", async () => {
+  const { path, cleanup } = shim();
+  const recovery = new RecoveryClient(path);
+  recovery.dispose();
+  const response = { output_replacement: `full: ccr://${KNOWN_HANDLE}` };
+  const event = outputEvent();
+  const original = structuredClone(event);
+  try {
+    assert.equal(await shrink(recovery, response, event), undefined);
+    assert.equal(await shrink({ verify: async () => { throw new Error("transport broke"); } }, response, event), undefined);
+    assert.equal(await shrinkToolResult({ call: async () => { throw new Error("hook broke"); } }, "test", event, recovery), undefined);
+    assert.deepEqual(event, original);
+  } finally { cleanup(); }
 });


### PR DESCRIPTION
## Problem

Native tool output could advertise a newly stored `ccr://` handle that a separate MCP reader immediately rejected as unknown. A long-lived producer still held an unlinked WAL/SHM pair while readers used newly created sidecars for the same database.

The cause is `secureSQLiteFile`: opening and closing an ordinary descriptor for the database or SHM file drops **all POSIX record locks held by that process on the inode**, including SQLite's locks. Both post-open permission checks and preparing a path already open elsewhere in the same process could therefore let a short-lived reader unlink a live writer's sidecars.

## Changes

Two separately reviewable, DCO-signed commits:

1. **Preserve SQLite locks while securing files.** Linux uses an inode-validated `O_PATH` descriptor and `fchmodat`, with a pinned procfs fallback for older kernels. Other Unix platforms use native no-follow chmod; Windows retains handle-based validation. Newly created files are closed before atomic, no-overwrite publication. Existing permission, symlink and inode checks remain in place. The shared helper also covers memory-store callers.
2. **Verify recovery before publishing Pi elisions.** The existing session recovery client verifies the advertised handle, exact byte length and SHA-256. A capability-gated `verify_only` mode on `caveman_retrieve` returns metadata without consuming the recovery delivery ledger. Missing, malformed, mismatched, old or unavailable recovery retains the original output, including non-text blocks.

No provider/OAuth routing changes, dependency additions, live-database migration code, or generated bundles are included.

## Reproduction and regression coverage

The storage regression keeps a writer open, opens and closes subprocess readers, then writes new objects and verifies both old and new originals from fresh readers. It also covers repeated same-process opens and direct path preparation. An independent reproduction failed with an unknown handle before this fix and recovered byte-identical content afterward.

Publication regressions cover missing/conflicting/malformed references, wrong proof hashes and lengths, older companions, failed/timed-out verification, preserved non-text output, and verification followed by the model's first full retrieval.

## Verification

On this PR branch, rebased onto current upstream `main`:

- `go build ./...` — passed
- `go vet ./...` — passed
- `go test ./...` — 68 packages passed; 4 have no tests
- `pnpm --filter @caveman-ai/pi test` — build/typecheck and all 38 tests passed

Additional verification of the same fixes before rebasing:

- Race-detector run of the cross-process locking regression passed.
- Forced `fchmodat2` failures using `strace -f -e inject=fchmodat2:error=ENOSYS`; the real older-Linux fallback passed both the independent reproduction and focused CCR permission/locking tests.
- CCR tests cross-compiled for Darwin/arm64 and Windows/amd64 (not runtime-tested locally).
- Deployed and exercised through installed OMP tools against a shared live producer: exact recovery at startup, after session replacement, and after consumer restart. An unavailable recovery store retained the original output. The formerly stranded handle became recoverable, and live SQLite integrity checks passed.

## Compatibility notes

Older MCP companions do not support non-consuming verification, so the updated Pi extension conservatively retains original output until the companion is upgraded. Availability verification is a publication-time check, not a promise against later deletion. This prevents new lock loss; it does not automatically repair already-diverged or corrupted databases.