### PR TITLE
fix(stats): accept the /caveman stats space-arg form

### DIFF
--- a/src/hooks/caveman-mode-tracker.js
+++ b/src/hooks/caveman-mode-tracker.js
@@ -197,7 +197,10 @@ function handle(raw) {
     // as additionalContext (#618), instructing the model to relay it
     // verbatim. The script reads the active session log, so we pass
     // transcript_path through when Claude Code provides it.
-    const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
+    // The space-arg form (/caveman stats) is accepted too: it used to fall
+    // through to parseModeChange, where "stats" is not a VALID_MODE, so the
+    // flag was left untouched and the prompt ran with no stats at all.
+    const statsMatch = /^\/caveman(?::caveman)?(?:-stats|\s+stats)(?:\s+(.*))?$/.exec(prompt);
     if (statsMatch) {
       const tailArgs = (statsMatch[1] || '').trim().split(/\s+/).filter(Boolean);
       let block;

--- a/tests/installer/slash-commands.test.mjs
+++ b/tests/installer/slash-commands.test.mjs
@@ -33,7 +33,7 @@ const STATS_TOML = path.join(COMMANDS_DIR, 'caveman-stats.toml');
 // Mirrors the live regex in src/hooks/caveman-mode-tracker.js (the
 // `statsMatch` line). Anything that fails this here would also fail in
 // production, so the test stays representative if the hook regex shifts.
-const HOOK_STATS_REGEX = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/m;
+const HOOK_STATS_REGEX = /^\/caveman(?::caveman)?(?:-stats|\s+stats)(?:\s+(.*))?$/m;
 
 test('#470 commands/caveman-stats.toml exists so Claude Code registers /caveman-stats', () => {
   assert.ok(

--- a/tests/test_mode_tracker.py
+++ b/tests/test_mode_tracker.py
@@ -182,6 +182,38 @@ class ModeTrackerTests(unittest.TestCase):
         self.send("/caveman off")
         self.assertIsNone(self.flag_value())
 
+    # ── stats: space-arg form ───────────────────────────────────────────
+
+    # The stats branch always emits this preamble, whether the script produced
+    # real numbers or the could-not-run fallback. An isolated CLAUDE_CONFIG_DIR
+    # has no session log, so routing is what these tests can observe — the
+    # numbers themselves are covered by tests/test_caveman_stats.js.
+    STATS_MARKER = "Print this stats block verbatim"
+
+    def test_slash_caveman_stats_space_arg_is_routed_to_stats(self):
+        """/caveman stats is the form users reach for, and it used to fall
+        through to the mode parser, where "stats" is not a VALID_MODE — the
+        flag was left untouched and the turn produced no stats at all."""
+        self.flag.write_text("full", encoding="utf-8")
+        for prompt in ("/caveman stats", "/caveman:caveman stats",
+                       "/caveman stats --share"):
+            with self.subTest(prompt=prompt):
+                r = self.send(prompt)
+                self.assertIn(self.STATS_MARKER, r.stdout)
+                self.assertEqual(
+                    self.flag_value(), "full",
+                    "a stats request must not disturb the active level",
+                )
+
+    def test_hyphen_stats_form_still_routed(self):
+        for prompt in ("/caveman-stats", "/caveman:caveman-stats"):
+            with self.subTest(prompt=prompt):
+                self.assertIn(self.STATS_MARKER, self.send(prompt).stdout)
+
+    def test_stats_arg_does_not_shadow_a_real_level(self):
+        self.send("/caveman ultra")
+        self.assertEqual(self.flag_value(), "ultra")
+
     # ── #599: one-shot independent modes ────────────────────────────────
 
     def test_commit_restores_prior_level_on_next_prompt(self):


### PR DESCRIPTION
**What:** `/caveman stats` and `/caveman:caveman stats` now route to the stats script, same as `/caveman-stats`.

**Why:** The space-arg form is what users reach for, and it was a silent no-op. `statsMatch` only matched the hyphenated command, so `/caveman stats` fell through to `parseModeChange`, where `stats` is not a `VALID_MODE`. Flag untouched, no stats block injected, prompt ran as an ordinary turn — no error, no output, nothing to indicate the command was even seen.

**Change:** one regex in `src/hooks/caveman-mode-tracker.js`:

```js
-const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
+const statsMatch = /^\/caveman(?::caveman)?(?:-stats|\s+stats)(?:\s+(.*))?$/.exec(prompt);
```

Tail flags (`--share`, `--all`, `--since`) work on the space-arg form too — same capture group.

**Tests:** three added to `tests/test_mode_tracker.py` — space-arg routing across all forms plus `--share`, the hyphenated forms still routing, and `/caveman ultra` still switching level (proving the widened alternation doesn't swallow real mode args). The suite uses an isolated `CLAUDE_CONFIG_DIR` with no session log, so they assert on routing (the stats branch's preamble), not on numbers; the numbers stay covered by `tests/test_caveman_stats.js`.

Also updated the mirrored copy of the regex in `tests/installer/slash-commands.test.mjs`, which is there specifically to track the live hook.

**Green:** `npm test` 279/279, `tests/test_mode_tracker.py` 37/37, `test_caveman_stats.js` 55/55, `test_mode_tracker_stdin.js` 18/18, `test_symlink_flag.js` 15/15, `test_caveman_init.js` 12/12. `tests.test_compress_safety` fails on my machine only — Python 3.9.6 can't parse `str | bytes` at def time in `compress.py:342`. Unrelated to this change, fails the same on a clean checkout.

No source-of-truth SKILL.md touched, so no CI resync needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DgWoFStF2HEaW775zhGka
