### PR TITLE
fix(codex): stop rewriting shell commands for Codex, breaks saved approval rules

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13186,15 +13186,18 @@ async function shrinkHook() {
   const isGemini = tool === "run_shell_command"; // Gemini CLI's shell tool
   const isBash = tool === "Bash";                // Claude Code + the opencode plugin
   const isCodex = tool === "shell" || tool === "shell_command" || tool === "exec_command";
-  if (!isGemini && !isBash && !isCodex) process.exit(0);
+  // Codex's saved prefix_rule rules match on exact command text; rewriting it here
+  // breaks that match for an already-approved command (#1037), and nothing confirms
+  // permissionDecision:"allow" makes Codex skip re-checking it. Pass through as-is.
+  if (isCodex) process.exit(0);
+  if (!isGemini && !isBash) process.exit(0);
   const command = evt.tool_input?.command;
   if (typeof command !== "string" || !shouldShrink(command)) process.exit(0);
   // updatedInput.command executes in host shell (Git Bash on Claude Windows),
   // not hook's explicit PowerShell shell. Never leak PowerShell `&` into it.
   const rewritten = `${cavemanBinForHook(false)} shrink -- ${command.trim()}`;
-  // Each harness has a different (silent-on-mismatch) override contract: Gemini merges
-  // hookSpecificOutput.tool_input (snake_case, no event discriminator); Claude replaces
-  // via hookSpecificOutput.updatedInput (camelCase + hookEventName). Emit the right one.
+  // Gemini merges hookSpecificOutput.tool_input (snake_case, no event discriminator);
+  // Claude replaces via hookSpecificOutput.updatedInput (camelCase + hookEventName).
   const out = isGemini
     ? { hookSpecificOutput: { tool_input: { command: rewritten } } }
     : { hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision: "allow", updatedInput: { command: rewritten } } };

--- a/packages/cli/tests/hooks.runtime.mjs
+++ b/packages/cli/tests/hooks.runtime.mjs
@@ -85,13 +85,16 @@ test("shrink-hook rewrites cargo test", async () => {
   assert.match(o.hookSpecificOutput.updatedInput.command, /shrink -- cargo test --all$/);
 });
 
-test("shrink-hook emits Codex allow + updatedInput for exec_command", async () => {
-  const out = await runHook({ tool_name: "exec_command", tool_input: { command: "git status" } });
-  assert.equal(out.code, 0, out.stderr);
-  const parsed = JSON.parse(out.stdout);
-  assert.equal(parsed.hookSpecificOutput.permissionDecision, "allow");
-  assert.match(parsed.hookSpecificOutput.updatedInput.command, /shrink -- git status$/);
-});
+// Codex's saved prefix_rule approval rules match on exact command text, so
+// rewriting the command here breaks an already-approved rule (#1037). Pass every
+// Codex tool-name alias through unrewritten until that's confirmed safe.
+for (const tool_name of ["exec_command", "shell", "shell_command"]) {
+  test(`shrink-hook does not rewrite Codex commands (${tool_name})`, async () => {
+    const out = await runHook({ tool_name, tool_input: { command: "git status" } });
+    assert.equal(out.code, 0, out.stderr);
+    assert.equal(out.stdout, "", "must not rewrite a Codex tool event");
+  });
+}
 
 test("native-hook injects stable Core, stores bounded metadata, and emits no marker when proxy is off", async () => {
   const caveHome = mkdtempSync(join(tmpdir(), "cave-native-"));


### PR DESCRIPTION
Confirmed the mechanism. `shrinkHook()`'s dispatch treats `exec_command`/`shell`/`shell_command` (Codex) as another Bash-shaped tool and emits the same `permissionDecision: "allow"` + `updatedInput` shape. The function's own top comment never actually lists Codex among the harnesses it rewrites for, so this looks like Codex got folded in without the output branch being adjusted for it.

That rewrite is exactly what breaks your `prefix_rule`: it changes the command text Codex sees.

```
git add -A                          # what your rule matches
caveman shrink -- git add -A        # what shrinkHook actually sent Codex
```

This PR just stops rewriting for Codex tool events, same as any command the function already declines to touch, so the original command reaches Codex unmodified and your existing rule applies.

I don't have a live Codex to check the full round trip, so this is verified at the hook boundary only: `exec_command`/`shell`/`shell_command` now get no rewrite at all (empty stdout, same no-op the function already uses for anything it won't touch). Added three tests for that and replaced the one that asserted the old allow+updatedInput shape. Gemini and the bash branch are unchanged.

Fixes #1037
